### PR TITLE
Generate SPEC §19's Zero-Skip roster from YAML, and delete the prose reader

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -251,6 +251,16 @@ advancing too.
 `scripts/test-doc-constants.rb` (run by `make doc-constants-check`) asserts the
 gate rejects each of these failure modes.
 
+One marked span is not a claim to be checked but a block to be GENERATED: SPEC
+§19's Zero-Skip roster, `<!-- @zero-skip-roster:begin/end -->`, is rendered from
+`spec/zero-skip-roster.yml` and required to match byte for byte, and the writer
+rewrites it. Edit the YAML, never the block. It is writable where the other
+block kinds are not for the reason `spec/doc-constants.json` states: no column
+of it is hand-written, so the writer can author the whole span. It replaced a
+parser that read the roster back out of SPEC's prose — five bypasses in, each
+fix a new selector, which is what "reassess the instrument" looks like when the
+instrument is a reader.
+
 **Pin semantics.** The pin is the conformance baseline as of the last sync — it asserts that all upstream drift up to that revision has been *triaged*, not that every contract in it has been *absorbed*. Upstream contracts shipped past the SDK's modeled surface are tracked in `spec/api-gaps/` (status `addressed-in-bc3-pr-N`) until an absorption PR lands. A repin is valid exactly when every drift item in `pin..HEAD` is either absorbed into the spec or registered in `spec/api-gaps/`; it is not blocked on absorption itself. The pin never moves backward. The `compatibility.*` pins mark the last **verified API-surface state** of their branch, not a last-glanced timestamp — refresh one only when re-verifying that branch's API surface, and record verification dates in the PR that did the checking.
 
 ### Pre-sync

--- a/SPEC.md
+++ b/SPEC.md
@@ -2219,8 +2219,10 @@ absence case, and is what proves it can say no.
 
 The roster below is GENERATED. Its source is `spec/zero-skip-roster.yml`; `make
 doc-constants-check` renders that file and requires the block between the
-markers to match byte for byte, and `make sync-api-version` rewrites it. Editing
-the block by hand is an edit the next `make` reverts. It used to be the other
+markers to match byte for byte, and `make sync-api-version` rewrites it. A hand
+edit to the block is REJECTED rather than repaired: `make` runs `check`, which
+reports the drift and stops; `make sync-api-version` is the only thing that
+rewrites the block, and it rewrites it from the YAML. It used to be the other
 way round — the roster lived here and a parser read it back out — until that
 reader's "a misreading always surfaces as a mismatch" invariant had been
 breached five times, each fix a new selector for a new spelling. Prose is an

--- a/SPEC.md
+++ b/SPEC.md
@@ -2153,7 +2153,8 @@ verbatim from the runners' skip mechanisms. A skip is
 either **waiver-backed** (a `rubric-audit.json` waiver ID), **architectural**
 (runner mechanics, compensated by native tests), or **unwaivered** (a known gap
 with no rubric record — tracked work, not an accepted divergence). A PR that
-closes a gap deletes exactly its own lines.
+closes a gap deletes exactly its own entry from `spec/zero-skip-roster.yml`,
+which is where the roster is written; the block below is rendered from it.
 
 One fixture, "List operation returns first page with Link header"
 (`conformance/tests/pagination.json`, tagged `link-header`), is handled by a
@@ -2216,12 +2217,21 @@ arrival and a live run only proves it can say yes;
 `scripts/test-check-fixture-execution.rb` crafts the all-six state and every
 absence case, and is what proves it can say no.
 
-The roster below is HALF checked, and the split is the point. Its ENUMERATION —
+The roster below is GENERATED. Its source is `spec/zero-skip-roster.yml`; `make
+doc-constants-check` renders that file and requires the block between the
+markers to match byte for byte, and `make sync-api-version` rewrites it. Editing
+the block by hand is an edit the next `make` reverts. It used to be the other
+way round — the roster lived here and a parser read it back out — until that
+reader's "a misreading always surfaces as a mismatch" invariant had been
+breached five times, each fix a new selector for a new spelling. Prose is an
+output now, so there is nothing left to misread.
+
+The roster is still HALF checked, and the split is the point. Its ENUMERATION —
 which runner skips which case — is compared for set equality against the
 execution manifests by `make check-fixture-execution` (#736), so a skip added to
-a runner without a line here, or a line left behind after a gap closes, fails
-the build. Its CLASSIFICATION and reasoning are judgement, and nothing asserts
-them; that is why the section keeps its `[manual]` tag.
+a runner without an entry in the YAML, or an entry left behind after a gap
+closes, fails the build. Its CLASSIFICATION and reasoning are judgement, and
+nothing asserts them; that is why the section keeps its `[manual]` tag.
 
 The check found this roster already wrong on arrival: Kotlin and Swift each
 exclude the `link-header` case wholesale through their tag branch, and the
@@ -2233,15 +2243,12 @@ parsing their source: a source parser cannot see a tag branch, a derived table,
 or a case the loader dropped, which is why the enumeration waited for the
 manifests rather than being checked on its own.
 
-<!-- zero-skip-roster:begin -->
-**Go** (`conformance/runner/go/main.go` `goSDKSkips`) — architectural; same-origin
-logic is covered by `TestIsSameOrigin` unit tests:
+<!-- @zero-skip-roster:begin -->
+**Go** (`conformance/runner/go/main.go` `goSDKSkips`) — architectural; same-origin logic is covered by `TestIsSameOrigin` unit tests:
 - "Mixed-case host and explicit default port stay on the mocked origin" — Go runner dials `configOverrides.baseUrl` directly; its `httptest` mock owns its origin, so origin-interception normalization does not apply.
 - "Bracketed IPv6 loopback origin stays on the mocked origin" — same as above.
 
-**Python** (`conformance/runner/python/runner.py` `SKIPS`) — none. The
-`link-header` fixture above runs; only its `requestCount` assertion is
-suppressed.
+**Python** (`conformance/runner/python/runner.py` `SKIPS`) — none; the `link-header` fixture above runs; only its `requestCount` assertion is suppressed.
 
 **Ruby** (`conformance/runner/ruby/runner.rb` `RUBY_SKIPS`):
 - "PUT operation is naturally idempotent" — GET-only retry (waiver 2B.3).
@@ -2259,15 +2266,13 @@ suppressed.
 **TypeScript** (`conformance/runner/typescript/runner.test.ts` `TS_SDK_SKIPS`):
 - "Large integer IDs preserved without precision loss" — `Number` is 53-bit (waiver 1B.6).
 
-**Kotlin** (`kotlin/conformance/.../Main.kt` — `KOTLIN_SKIPS` is empty; the
-entry below comes from the `link-header` tag branch) — architectural:
+**Kotlin** (`kotlin/conformance/.../Main.kt` — `KOTLIN_SKIPS` is empty; the entry below comes from the `link-header` tag branch) — architectural:
 - "List operation returns first page with Link header" — the SDK auto-paginates, and its status model reports the last consumed response, so a one-response queue yields "no response" (see the tag-branch discussion above).
 
-**Swift** (`conformance/runner/swift/.../Runner.swift` — `temporarySkips` is
-empty; the entry below comes from the `link-header` tag branch) — architectural:
+**Swift** (`conformance/runner/swift/.../Runner.swift` — `temporarySkips` is empty; the entry below comes from the `link-header` tag branch) — architectural:
 - "List operation returns first page with Link header" — same as Kotlin: auto-pagination plus a last-consumed-response status model.
 
-<!-- zero-skip-roster:end -->
+<!-- @zero-skip-roster:end -->
 
 Swift carries no capability skips. It is three-gate on retry (status, network,
 idempotent POST) and, since #563, retries the authenticated download hop, so

--- a/scripts/check-fixture-execution.rb
+++ b/scripts/check-fixture-execution.rb
@@ -78,7 +78,17 @@ Manifest = Struct.new(:runner, :total, :executed, :excluded, keyword_init: true)
 class Failure < StandardError; end
 
 def load_manifest(path)
-  raw = JSON.parse(File.read(path))
+  # Encoding PINNED, for the reason every gate in this repo pins it: CI runs
+  # under LC_ALL=C, where an unpinned read hands JSON a US-ASCII string and any
+  # non-ASCII byte in a case name dies as Encoding::InvalidByteSequenceError
+  # with a Ruby backtrace rather than a verdict. Every case name in the tracked
+  # fixtures is ASCII today, which is the only reason this has never fired.
+  #
+  # It was the file's one unpinned read while the roster reader beside it was
+  # pinned; deleting that reader would have left this as the only read and no
+  # example of the convention. Found by a self-test case that put a separator in
+  # a case name and got a stack trace instead of the refusal it asserted.
+  raw = JSON.parse(File.read(path, encoding: "UTF-8"))
   # Shape-check before reaching for keys. A manifest that is a JSON string or
   # array still parses, and `fetch` on it raises NoMethodError — which exits
   # non-zero, so the gate is fail-closed either way, but reports a Ruby

--- a/scripts/check-fixture-execution.rb
+++ b/scripts/check-fixture-execution.rb
@@ -57,6 +57,8 @@ require "json"
 require "optparse"
 require "set"
 
+require_relative "zero_skip_roster"
+
 # Overridable so the self-test can point the whole gate at a synthetic manifest
 # set and prove each rejection fires. Same mechanism as DOC_CONSTANTS_ROOT: this
 # check is green on the real tree by construction (maximum overlap is 2 of 6),
@@ -185,138 +187,29 @@ end
 # instead of enumerating it -- two of six runners wrong, in a roster nobody
 # re-derives by hand.
 #
-# The manifests make the ENUMERATION derivable, so it is now checked for set
-# equality. The classification and reasoning on each line stay judgement, and
-# nothing asserts them; that half is why the section keeps its `[manual]` tag.
+# The manifests make the ENUMERATION derivable, so it is checked here for set
+# equality. The classification and reasoning stay judgement, and nothing asserts
+# them; that half is why the section keeps its `[manual]` tag.
 #
-# WHY THIS PARSER IS ACCEPTABLE WHERE THE ROSTER-TABLE ONE WAS NOT. #740
-# declined to keep teaching `sync-doc-constants.rb` more GFM -- separator
-# widths, backslash parity -- because a mis-parse there is SILENT: it validates
-# the wrong cell and reports success. This extraction fails LOUD in both
-# directions. A bullet it cannot read is a name missing from the roster set,
-# which is a mismatch; a name it invents is an extra, also a mismatch. There is
-# no reading of a malformed line that produces a passing comparison, so the
-# failure mode is a false alarm the author fixes, never a false green.
+# WHERE THE ROSTER LIVES, and why it moved. It used to live in SPEC.md's prose
+# and be parsed back out of it, on the argument that every misreading surfaces
+# as a set mismatch and never as a passing comparison. That was breached five
+# times, each fix a new selector (see scripts/zero_skip_roster.rb for the list).
+# It now lives in spec/zero-skip-roster.yml and SPEC's block is RENDERED from
+# it, so this gate reads structured data and nothing reads the prose.
 #
-# The delimiters are deliberately NOT `@`-markers. sync-doc-constants owns
-# those, and it runs in spec-gates where no conformance run has happened, so it
-# has no manifests to compare against. Registering a kind there whose real
-# enforcement lives here would split one check across two gates.
-ROSTER_BEGIN = "<!-- zero-skip-roster:begin -->"
-ROSTER_END   = "<!-- zero-skip-roster:end -->"
-
-# Heading label => runner id. Hardcoded for the same reason EXPECTED_RUNNERS is:
-# deriving it from whatever headings appear lets a renamed section silently drop
-# a runner out of the comparison.
-ROSTER_HEADINGS = {
-  "Go" => "go", "Python" => "python", "Ruby" => "ruby",
-  "TypeScript" => "typescript", "Kotlin" => "kotlin", "Swift" => "swift"
-}.freeze
-
-# Returns { runner => [case name] } as the roster states it.
-def parse_roster(spec_path)
-  text = File.read(spec_path, encoding: "UTF-8")
-
-  # EXACTLY one of each delimiter. Taking the first occurrence of each would
-  # silently ignore a second, complete roster block — and a stale line living in
-  # that duplicate would never be compared while the gate reported success. That
-  # is a SILENT pass, which is the one failure mode this extractor is not
-  # allowed to have: the whole argument for parsing prose here is that every
-  # misreading surfaces as a set mismatch. Copilot found it.
-  begins = text.scan(ROSTER_BEGIN).length
-  ends   = text.scan(ROSTER_END).length
-
-  # No roster at all is its own failure, and a distinct one: the roster was
-  # deleted or renamed, not duplicated. Kept separate so the message names what
-  # actually happened.
-  i = text.index(ROSTER_BEGIN)
-  j = text.index(ROSTER_END)
-  raise Failure, "SPEC.md holds no #{ROSTER_BEGIN} / #{ROSTER_END} pair" if i.nil? || j.nil? || j < i
-
-  if begins > 1 || ends > 1
-    raise Failure, "SPEC.md must hold exactly one #{ROSTER_BEGIN} and one #{ROSTER_END}; " \
-                   "found #{begins} and #{ends}. A second block is not compared, so a stale " \
-                   "line inside it would pass unnoticed."
-  end
-
-  body = text[(i + ROSTER_BEGIN.length)...j]
-  roster = Hash.new { |h, k| h[k] = [] }
-  runner = nil
-  seen = []
-
-  body.each_line do |line|
-    if (m = line.match(/\A\*\*([A-Za-z]+)\*\*/))
-      label = m[1]
-      runner = ROSTER_HEADINGS[label]
-      raise Failure, "SPEC roster has a section for unknown runner #{label.inspect}" if runner.nil?
-
-      seen << runner
-      roster[runner]
-      next
-    end
-
-    # FAIL-CLOSED on anything list-shaped, rather than recognising one spelling
-    # and skipping the rest. `next unless line.start_with?("- ")` silently
-    # dropped every other valid Markdown list form — indented, `*`, `+`, `1.` —
-    # and a STALE entry written that way was then absent from the roster set, so
-    # no mismatch arose and the gate passed. A false green, which is the one
-    # outcome this extractor may not produce.
-    #
-    # The answer is not a third selector per spelling. It is to invert the
-    # default: a line that looks like a list item in ANY form must be the
-    # canonical `- "case name"`, or it is an error. One predicate closes the
-    # whole class, including spellings nobody has written yet. Prose
-    # continuation lines (the roster's headings wrap, and Python's section is a
-    # sentence) are untouched because they are not list-shaped.
-    next unless line.match?(/\A\s*([-*+]|\d+[.)])\s/)
-
-    raise Failure, "SPEC roster bullet before any runner heading: #{line.strip[0, 60]}" if runner.nil?
-
-    name = line[/\A-\s+"([^"]+)"/, 1]
-    if name.nil?
-      raise Failure, "SPEC roster line is list-shaped but not a canonical bullet " \
-                     "(`- \"case name\" — reason`): #{line.strip[0, 80]}. Written another way it " \
-                     "would be skipped, and a stale entry that is skipped never contradicts " \
-                     "anything."
-    end
-
-    roster[runner] << name
-  end
-
-  missing = EXPECTED_RUNNERS - seen
-  unless missing.empty?
-    raise Failure, "SPEC roster has no section for: #{missing.join(', ')} - a runner without a " \
-                   "heading contributes nothing and its skips go unrecorded"
-  end
-
-  # A duplicated heading splits one runner's lines across two sections, so
-  # neither reads as the whole set and "one line per runner x test" is already
-  # broken before any comparison.
-  repeated = seen.tally.select { |_, n| n > 1 }.keys
-  unless repeated.empty?
-    raise Failure, "SPEC roster has more than one section for: #{repeated.sort.join(', ')}"
-  end
-
-  # A case listed twice under one runner is invisible to the comparison:
-  # Array#- removes EVERY matching occurrence, so `actual - stated` and
-  # `stated - actual` are both empty and the duplicate passes — with two
-  # possibly conflicting classifications attached to one case. Codex found it,
-  # and it is the same silent-pass shape as the duplicate block above.
-  roster.each do |run_id, names|
-    dupes = names.tally.select { |_, n| n > 1 }.keys
-    next if dupes.empty?
-
-    raise Failure, "SPEC roster lists #{dupes.first.inspect} twice under #{run_id}; the section " \
-                   "promises one line per runner x test, and a repeat is invisible to the " \
-                   "set comparison"
-  end
-
-  roster
-end
+# The delimiters used to be deliberately NOT `@`-markers, because
+# sync-doc-constants owns those and runs in spec-gates where no conformance run
+# has happened -- it had no manifests to compare against, so registering a kind
+# there would have split one check across two gates. The YAML removed that
+# objection: it is present in every checkout, so the half that needs no
+# conformance run (does SPEC's block match the roster?) is now an
+# @zero-skip-roster block kind over there, and the half that does need one (does
+# the roster match what the runners reported?) is this file. Two gates, two
+# claims, neither able to make the other's.
 
 # Compares the roster's enumeration against what the runners reported.
-def check_roster(manifests, spec_path)
-  roster = parse_roster(spec_path)
+def check_roster(manifests, roster)
   errors = []
 
   manifests.each do |m|
@@ -326,27 +219,56 @@ def check_roster(manifests, spec_path)
     # same-named cases from different fixtures. No runner excludes such a pair
     # today; if one ever does, the roster needs file qualifiers and this says so
     # rather than silently comparing an ambiguous set.
+    #
+    # This projection is UNCHANGED by the move to YAML, deliberately. A `file:`
+    # key would be a schema the manifests could be compared against more
+    # precisely — and no runner needs it yet, so adding it now would be a field
+    # nobody fills in correctly and nothing exercises.
     dupes = actual.tally.select { |_, n| n > 1 }.keys
     unless dupes.empty?
-      errors << "#{m.runner} excludes #{dupes.first.inspect} in more than one fixture; the SPEC " \
-                "roster identifies cases by name alone and cannot express that. Add the fixture " \
-                "to those roster lines and teach this check to read it."
+      errors << "#{m.runner} excludes #{dupes.first.inspect} in more than one fixture; " \
+                "#{ZeroSkipRoster::RELATIVE_PATH} identifies cases by name alone and cannot " \
+                "express that. Add the fixture to those entries and teach this check to read it."
       next
     end
 
-    stated = roster[m.runner]
+    stated = roster.fetch(m.runner)
     (actual - stated).each do |name|
-      errors << "#{m.runner} excludes #{name.inspect} and the SPEC roster does not list it"
+      errors << "#{m.runner} excludes #{name.inspect} and #{ZeroSkipRoster::RELATIVE_PATH} does " \
+                "not list it"
     end
     (stated - actual).each do |name|
-      errors << "the SPEC roster lists #{name.inspect} for #{m.runner}, which no longer excludes it"
+      errors << "#{ZeroSkipRoster::RELATIVE_PATH} lists #{name.inspect} for #{m.runner}, which no " \
+                "longer excludes it"
     end
   end
 
   errors
 end
 
+def load_roster
+  ZeroSkipRoster.case_names(ZeroSkipRoster.load(ROOT))
+rescue ZeroSkipRoster::Malformed => e
+  # A roster that cannot be read is not a roster that lists nothing. Loading it
+  # is the first thing `run` does, before any comparison, so there is no path
+  # where an unreadable file is quietly compared against as an empty set.
+  raise Failure, e.message
+end
+
 def run(partial:)
+  # Two hardcoded runner lists, one for manifests and one for the roster, and
+  # nothing but this line stops them diverging. The mechanism is an ordinary
+  # mistake, not an adversary: a seventh runner added to one and not the other
+  # leaves that runner's roster section unchecked (or its manifest compared
+  # against a section that does not exist, which is a KeyError below).
+  unless EXPECTED_RUNNERS.sort == ZeroSkipRoster::RUNNERS.sort
+    raise Failure, "the runners this gate expects (#{EXPECTED_RUNNERS.sort.join(', ')}) and the " \
+                   "ones #{ZeroSkipRoster::RELATIVE_PATH} is defined over " \
+                   "(#{ZeroSkipRoster::RUNNERS.sort.join(', ')}) disagree; one of the two lists " \
+                   "gained a runner the other never heard of"
+  end
+
+  roster = load_roster
   manifests = load_all
   present = manifests.map(&:runner).sort
   missing = EXPECTED_RUNNERS - present
@@ -370,11 +292,12 @@ def run(partial:)
   # because that is the only claim needing every runner. A runner that did not
   # report simply is not compared; its roster section is neither confirmed nor
   # contradicted.
-  roster_errors = check_roster(manifests, File.join(ROOT, "SPEC.md"))
+  roster_errors = check_roster(manifests, roster)
   unless roster_errors.empty?
     roster_errors.each { |e| warn "FAIL: #{e}" }
     warn "      SPEC section 19's Zero-Skip roster claims to enumerate every skip verbatim from " \
-         "the runners' skip mechanisms (#736). It is restated by hand, so it drifts."
+         "the runners' skip mechanisms (#736). Nothing derives it from the runners, so it drifts " \
+         "the moment a skip is added or closed without editing #{ZeroSkipRoster::RELATIVE_PATH}."
     return 1
   end
 

--- a/scripts/sync-doc-constants.rb
+++ b/scripts/sync-doc-constants.rb
@@ -182,7 +182,17 @@ MARKER_RE   = /<!--\s*@([a-z0-9][a-z0-9-]*)(?::(begin|end))?\s*-->/
 # Markdown are already standalone, so this pins existing practice rather than
 # demanding a migration. Line markers are deliberately exempt — a line marker's
 # whole job is to sit at the end of the prose sentence it qualifies.
-STANDALONE_BLOCK_MARKER_RE = /\A<!--\s*@[a-z0-9][a-z0-9-]*:(?:begin|end)\s*-->\z/
+#
+# INDENTATION IS BOUNDED AT THREE SPACES, the same limit and for the same reason
+# FENCE_RE below carries it: at four spaces CommonMark reads the line as
+# INDENTED CODE, so an indented marker is not an HTML comment at all — it is
+# visible literal text in the rendered document. Indent both of a block's
+# markers and the count still matches, the body between them is still compared
+# byte for byte, and SPEC quietly shows the delimiters it promises are
+# invisible. A tab is excluded for the same reason it is there: it counts as
+# four columns. Checked against the raw line rather than a stripped one,
+# because stripping is what threw the indentation away.
+STANDALONE_BLOCK_MARKER_RE = /\A {0,3}<!--\s*@[a-z0-9][a-z0-9-]*:(?:begin|end)\s*-->[ \t]*\z/
 # A fenced-code delimiter: 3+ backticks or 3+ tildes, indented at most three
 # spaces, with whatever follows captured as the info string (a close must have
 # none).
@@ -390,11 +400,12 @@ def scan_file(file)
           next
         end
 
-        unless line.strip.match?(STANDALONE_BLOCK_MARKER_RE)
-          errors << "#{file}:#{line_no}: @#{kind}:#{form} shares its line with other content. A " \
-                    "block marker must be alone on its line: the body is the lines BETWEEN the " \
-                    "markers, so anything on the marker line renders into the document and is " \
-                    "compared against nothing."
+        unless line.match?(STANDALONE_BLOCK_MARKER_RE)
+          errors << "#{file}:#{line_no}: @#{kind}:#{form} must be alone on its line and indented " \
+                    "at most three spaces. The body is the lines BETWEEN the markers, so anything " \
+                    "else on the marker line renders into the document and is compared against " \
+                    "nothing; and at four spaces the marker is indented code rather than an HTML " \
+                    "comment, so it renders as visible text instead of delimiting anything."
           next
         end
 

--- a/scripts/sync-doc-constants.rb
+++ b/scripts/sync-doc-constants.rb
@@ -1123,6 +1123,12 @@ end
 
 # --- writer ------------------------------------------------------------------
 
+# Every argument here is a VALUE, never a thunk, and that is load-bearing rather
+# than stylistic: this runs inside the write loop, so anything that computes
+# lazily here can raise after earlier files are already on disk. Passing
+# resolved values makes "the loop cannot raise for a reason we have not already
+# found" a property of the signature instead of a discipline someone has to
+# remember at the next call site.
 def rewrite_line(kind, line, api_version:, revision:, date:, operation_count_value:)
   case kind
   when "api-version"
@@ -1131,7 +1137,7 @@ def rewrite_line(kind, line, api_version:, revision:, date:, operation_count_val
     # Refuse an ambiguous span instead of rewriting every integer on it. Left
     # untouched, it fails the next --check with a message naming the problem;
     # rewritten, it would be silently corrupt and then pass.
-    sole_ticked_int(line) ? line.sub(TICKED_INT_RE, "`#{operation_count_value.call}`") : line
+    sole_ticked_int(line) ? line.sub(TICKED_INT_RE, "`#{operation_count_value}`") : line
   when "bc3-pin"
     # Preserve the abbreviation length the prose already chose.
     line
@@ -1269,8 +1275,8 @@ def run(mode, openapi)
       return 1
     end
 
-    # ...and every writable block body is RENDERED HERE, before any file is
-    # opened, for exactly the same reason one paragraph up.
+    # ...and EVERY DEFERRED INPUT THE WRITE LOOP CAN DEMAND is resolved here,
+    # before any file is opened, for exactly the same reason one paragraph up.
     #
     # This is the hole the structural preflight above did NOT close, and it is
     # worth naming rather than quietly fixing: the bodies were lambdas called
@@ -1285,11 +1291,22 @@ def run(mode, openapi)
     # write loop cannot raise for a reason it has not already discovered, so
     # "aborted" and "nothing written" mean the same thing again.
     #
-    # Only the kinds actually MARKED are forced. A repo whose SPEC carries no
-    # roster marker must not be made to load the roster file, which is what
-    # keeps this gate's own crafted fixtures minimal.
+    # Only what is actually MARKED is forced. A repo whose SPEC carries no roster
+    # marker must not be made to load the roster file, and one with no
+    # @operation-count span must not be made to count operations in an OpenAPI
+    # document it never makes a claim about — which is what keeps this gate's own
+    # crafted fixtures minimal.
+    #
+    # This is the third report of one defect, which is why it is written as a
+    # place rather than as two fixes. The block bodies were the reported
+    # instance; `op_count` was the next one, raising from inside `rewrite_line`
+    # after an earlier stale file had been written. A fourth deferred input would
+    # have gone the same way, so it now has an obvious home, and `rewrite_line`
+    # takes values rather than thunks so the loop cannot reach a computation at
+    # all.
     marked_writable_blocks = spans.select(&:block).map(&:kind).uniq & WRITABLE_BLOCK_KINDS
     rendered_blocks = marked_writable_blocks.to_h { |kind| [kind, block_bodies.fetch(kind).call] }
+    op_count_value = op_count.call if spans.any? { |s| s.kind == "operation-count" }
 
     written = []
     declined = []
@@ -1308,7 +1325,7 @@ def run(mode, openapi)
         newline = lines[index].end_with?("\n") ? "\n" : ""
         lines[index] = rewrite_line(span.kind, body,
                                     api_version: api_version, revision: revision, date: date,
-                                    operation_count_value: op_count) + newline
+                                    operation_count_value: op_count_value) + newline
       end
 
       # Blocks are spliced LAST and from the bottom up. A rendered block rarely

--- a/scripts/sync-doc-constants.rb
+++ b/scripts/sync-doc-constants.rb
@@ -163,6 +163,26 @@ WRITABLE_BLOCK_KINDS = %w[zero-skip-roster].freeze
 KNOWN_KINDS = (LINE_KINDS + BLOCK_KINDS).freeze
 
 MARKER_RE   = /<!--\s*@([a-z0-9][a-z0-9-]*)(?::(begin|end))?\s*-->/
+
+# A block marker must be ALONE on its line. Everything else on that line is
+# content the checker structurally cannot see: scan_file takes a block's body as
+# the lines strictly BETWEEN the markers, so a table row or a roster bullet
+# written onto the marker line itself is rendered into the document and compared
+# against nothing. `- "stale" — x. <!-- @zero-skip-roster:end -->` reads as an
+# extra roster entry, survives --check, and is preserved by --write.
+#
+# HELD FOR EVERY BLOCK KIND, not for the one it was found in. The hole is in the
+# span arithmetic, not in any kind's checker: every block kind compares only
+# span.lines — the tables by set, the roster by bytes — so a row riding the
+# marker line is equally invisible to all four, and to the fifth. Scoping the
+# rule to @zero-skip-roster would fix one and leave the others, which is the
+# per-spelling selector this whole change is a reaction to.
+#
+# It costs nothing to hold generally: all eight block markers in tracked
+# Markdown are already standalone, so this pins existing practice rather than
+# demanding a migration. Line markers are deliberately exempt — a line marker's
+# whole job is to sit at the end of the prose sentence it qualifies.
+STANDALONE_BLOCK_MARKER_RE = /\A<!--\s*@[a-z0-9][a-z0-9-]*:(?:begin|end)\s*-->\z/
 # A fenced-code delimiter: 3+ backticks or 3+ tildes, indented at most three
 # spaces, with whatever follows captured as the info string (a close must have
 # none).
@@ -367,6 +387,14 @@ def scan_file(file)
       else
         unless BLOCK_KINDS.include?(kind)
           errors << "#{file}:#{line_no}: @#{kind} is a line marker; drop the :#{form} suffix"
+          next
+        end
+
+        unless line.strip.match?(STANDALONE_BLOCK_MARKER_RE)
+          errors << "#{file}:#{line_no}: @#{kind}:#{form} shares its line with other content. A " \
+                    "block marker must be alone on its line: the body is the lines BETWEEN the " \
+                    "markers, so anything on the marker line renders into the document and is " \
+                    "compared against nothing."
           next
         end
 

--- a/scripts/sync-doc-constants.rb
+++ b/scripts/sync-doc-constants.rb
@@ -13,8 +13,9 @@
 #   @operation-count      openapi.json  count of path × HTTP-method pairs
 #   @fixture-categories   git ls-files conformance/tests/*.json
 #   @fixture-section-map  git ls-files conformance/tests/*.json
+#   @zero-skip-roster     spec/zero-skip-roster.yml, RENDERED — see below
 #
-# The last two are the same shape as @assertion-types one level out: a table
+# The fixture rosters are the same shape as @assertion-types one level out: a table
 # that CLAIMS to account for every conformance fixture, with nothing checking
 # it. Both were missed by the last three fixture-adding commits, in three
 # different ways — dee221c85 added documents_write.json and updated neither
@@ -23,6 +24,17 @@
 # half-applications in opposite directions is not carelessness; it is a rule
 # nobody can see (CONTRIBUTING.md tells contributors to add conformance tests
 # and mentions neither table).
+#
+# @zero-skip-roster is the odd one out, and deliberately so: it is the first
+# span this gate RENDERS rather than reads. Every other block kind carries a
+# human-authored column, so --check compares sets and the writer keeps its hands
+# off. SPEC §19's Zero-Skip roster carries no such column — every character of it
+# is derived from spec/zero-skip-roster.yml — so it is rendered into memory and
+# the block is required to be BYTE-IDENTICAL. Nothing parses it, which is the
+# whole point: the parser it replaces had its "a misreading always surfaces as a
+# mismatch" invariant breached five times, each fix a new selector for a new
+# spelling. A byte comparison has no selectors to widen. See
+# scripts/zero_skip_roster.rb for the five and for what this does NOT close.
 #
 # Only spans MARKED with an HTML comment are checked. That is deliberate:
 # spec/api-gaps/ legitimately cites ~20 historical bc3 SHAs in narrative
@@ -86,11 +98,14 @@
 # Modes
 #   --check (default)  Report drift; exit 1 on any error.
 #   --write            Rewrite marked spans in place from the sources.
-#                      Only the scalar constants are writable — every BLOCK
-#                      kind is a table whose rows carry a human-authored
-#                      column (an assertion type's meaning, a fixture's owning
-#                      spec sections, a fixture's case summary), so --write
-#                      never touches them and never fails on them.
+#                      Writable iff the writer can author the whole span. That
+#                      is every scalar constant, and exactly one block kind:
+#                      @zero-skip-roster, which is rendered from
+#                      spec/zero-skip-roster.yml. The other block kinds are
+#                      tables whose rows carry a human-authored column (an
+#                      assertion type's meaning, a fixture's owning spec
+#                      sections, a fixture's case summary), so --write never
+#                      touches them and never fails on them.
 #                      `make doc-constants-check` is what catches those;
 #                      keeping them out of the writer keeps a schema or
 #                      fixture edit from breaking every `make generate`.
@@ -116,6 +131,8 @@
 require "json"
 require "set"
 
+require_relative "zero_skip_roster"
+
 # The repo this gate reads. DOC_CONSTANTS_ROOT exists so
 # scripts/test-doc-constants.rb can point the gate at a crafted tiny repo and
 # assert it rejects each failure mode; nothing in normal operation sets it.
@@ -135,7 +152,14 @@ LINE_KINDS  = %w[api-version bc3-pin operation-count].freeze
 # The OpenAPI verbs an operation can be keyed under. Anything else in a path
 # item (parameters, servers, summary) is not an operation and must not count.
 HTTP_METHODS = %w[get put post delete patch head options trace].freeze
-BLOCK_KINDS = %w[assertion-types fixture-categories fixture-section-map].freeze
+BLOCK_KINDS = %w[assertion-types fixture-categories fixture-section-map
+                 zero-skip-roster].freeze
+
+# The block kinds the writer may author, which is the ones with no
+# human-authored content in them at all. Everything else in BLOCK_KINDS is a
+# table carrying a column only a person can write, and rewriting one would mean
+# inventing that column.
+WRITABLE_BLOCK_KINDS = %w[zero-skip-roster].freeze
 KNOWN_KINDS = (LINE_KINDS + BLOCK_KINDS).freeze
 
 MARKER_RE   = /<!--\s*@([a-z0-9][a-z0-9-]*)(?::(begin|end))?\s*-->/
@@ -1013,6 +1037,51 @@ def check_fixture_section_map(span, fixtures)
   errors
 end
 
+# SPEC §19's Zero-Skip roster: rendered from spec/zero-skip-roster.yml and
+# required to match BYTE FOR BYTE.
+#
+# This is the only check in this file with no parser behind it, and that is the
+# entire design. Its predecessor read the roster back out of SPEC's prose, on the
+# argument that a misreading always surfaces as a set mismatch and never as a
+# passing comparison. That argument failed five times — a list marker it did not
+# recognise, a duplicate block, a duplicate entry, a payload on a blockquote or
+# table row, and an ASCII-only quote test that curly quotes and backticks walk
+# straight through. Each fix was one more selector. String equality has none:
+# every one of those spellings is now just text inside a generated block, and any
+# text the renderer did not produce is a diff.
+#
+# WHAT IT DOES AND DOES NOT BUY. It makes SPEC's block faithful to the YAML,
+# nothing more. Whether the YAML is faithful to the RUNNERS is a different claim,
+# checked by scripts/check-fixture-execution.rb against the execution manifests —
+# which needs a conformance run, which is why that half cannot live here.
+#
+# VACUITY, and why there is no guard for it here. "Both sides empty is agreement"
+# is the hole every set comparison in this file has to plug explicitly. This one
+# cannot reach it: ZeroSkipRoster.load requires all six runner sections and
+# render_lines emits at least a heading for each, so the rendered side is never
+# empty and an emptied block never matches it. An emptied YAML fails in the
+# loader instead, before this is called. Committed as self-test cases rather than
+# asserted here, because a guard that cannot fire is a guard nobody can test.
+def check_zero_skip_roster(span, expected)
+  actual = span.lines
+  return [] if actual == expected
+
+  index = (0...[actual.length, expected.length].max).find { |n| actual[n] != expected[n] }
+  line_no = span.line_no + index
+
+  # Name the first differing line and show both sides whole. Truncating would
+  # hide exactly the cases worth reporting — a trailing space, a straightened
+  # quote, an em dash written as a hyphen — since the visible halves of two such
+  # lines are identical.
+  ["#{span.file}:#{line_no}: the @#{span.kind} block does not match " \
+   "#{ZeroSkipRoster::RELATIVE_PATH} (#{actual.length} line(s) in SPEC, #{expected.length} " \
+   "rendered; first difference on this line).\n" \
+   "      rendered: #{(expected[index] || '(end of block)').inspect}\n" \
+   "      found:    #{(actual[index] || '(end of block)').inspect}\n" \
+   "      This block is generated. Edit #{ZeroSkipRoster::RELATIVE_PATH} and run " \
+   "`make sync-api-version`; editing SPEC by hand is what this replaced."]
+end
+
 # --- writer ------------------------------------------------------------------
 
 def rewrite_line(kind, line, api_version:, revision:, date:, operation_count_value:)
@@ -1049,6 +1118,28 @@ def run(mode, openapi)
   op_count = lambda do
     op_count_memo ||= operation_count(openapi_doc, openapi)
   end
+
+  # Lazy and memoised for the same reason once more, and this one is needed in
+  # BOTH modes: --write renders the roster block, --check compares against it.
+  # A repo whose SPEC never carries the marker never loads the file, which is
+  # what lets the gate's own crafted fixtures stay minimal.
+  #
+  # A malformed roster is a Failure (exit 2), not a drift error (exit 1): the
+  # gate has no source of truth, so it cannot vouch for the block either way.
+  # Reporting "the block does not match" would name the wrong file.
+  roster_memo = nil
+  roster = lambda do
+    roster_memo ||= begin
+      ZeroSkipRoster.load(ROOT)
+    rescue ZeroSkipRoster::Malformed => e
+      raise Failure, e.message
+    end
+  end
+  roster_lines = -> { ZeroSkipRoster.render_lines(roster.call) }
+
+  # kind => the exact lines a writable block must hold. Keyed by kind so adding
+  # a second rendered block is a line here rather than a branch in the writer.
+  block_bodies = { "zero-skip-roster" => roster_lines }
 
   provenance = read_json("spec/api-provenance.json")
   revision = dig!(provenance, "spec/api-provenance.json", "bc3", "revision")
@@ -1123,7 +1214,9 @@ def run(mode, openapi)
     declined = []
     spans.group_by(&:file).each do |file, file_spans|
       writable = file_spans.reject(&:block).select { |s| LINE_KINDS.include?(s.kind) }
-      next if writable.empty?
+      writable_blocks = file_spans.select(&:block)
+                                  .select { |s| WRITABLE_BLOCK_KINDS.include?(s.kind) }
+      next if writable.empty? && writable_blocks.empty?
 
       path = File.join(ROOT, file)
       original = File.read(path, encoding: UTF8)
@@ -1136,6 +1229,21 @@ def run(mode, openapi)
                                     api_version: api_version, revision: revision, date: date,
                                     operation_count_value: op_count) + newline
       end
+
+      # Blocks are spliced LAST and from the bottom up. A rendered block rarely
+      # has the same line count as the one it replaces, so every span below it
+      # in the same file would be off by the difference — including the line
+      # spans just rewritten by index above. Descending order means each splice
+      # only ever moves lines that have already been written.
+      #
+      # "Last" is what the self-test exercises; the ORDER is not, because one
+      # writable block exists and a single splice cannot be out of order. It is
+      # written this way so the second one does not have to notice.
+      writable_blocks.sort_by { |span| -span.line_no }.each do |span|
+        start = span.line_no - 1
+        lines[start, span.lines.length] = block_bodies.fetch(span.kind).call.map { |l| "#{l}\n" }
+      end
+
       updated = lines.join
       next if updated == original
 
@@ -1153,7 +1261,10 @@ def run(mode, openapi)
     end
 
     if written.empty?
-      puts "Doc constants already in sync (#{spans.count { |s| LINE_KINDS.include?(s.kind) }} marked spans)."
+      writable_count = spans.count do |s|
+        s.block ? WRITABLE_BLOCK_KINDS.include?(s.kind) : LINE_KINDS.include?(s.kind)
+      end
+      puts "Doc constants already in sync (#{writable_count} marked spans)."
     else
       written.each { |file| puts "Rewrote marked doc constants in #{file}" }
     end
@@ -1197,6 +1308,7 @@ def run(mode, openapi)
       when "operation-count"     then check_operation_count(span, op_count.call, openapi)
       when "fixture-categories"  then check_fixture_categories(span, fixtures.call)
       when "fixture-section-map" then check_fixture_section_map(span, fixtures.call)
+      when "zero-skip-roster"    then check_zero_skip_roster(span, roster_lines.call)
       else []
       end
     )
@@ -1223,6 +1335,12 @@ def run(mode, openapi)
     if spans.any? { |s| %w[fixture-categories fixture-section-map].include?(s.kind) }
       puts "  fixtures         #{fixtures.call.length} tracked under conformance/tests/"
     end
+    if spans.any? { |s| s.kind == "zero-skip-roster" }
+      skips = roster.call.values.sum { |section| section.skips.length }
+      puts "  zero-skip-roster #{skips} skip(s) across " \
+           "#{ZeroSkipRoster::RUNNERS.length} runners (block rendered from " \
+           "#{ZeroSkipRoster::RELATIVE_PATH})"
+    end
     0
   else
     warn "ERROR: documentation constants have drifted from their sources."
@@ -1243,6 +1361,11 @@ def run(mode, openapi)
     warn "                    table and Appendix D. Neither is auto-written: the owning-section " \
          "and case-summary"
     warn "                    columns are attributions only the fixture's author can make."
+    warn "  Zero-skip roster: SPEC §19's marked block is RENDERED from " \
+         "#{ZeroSkipRoster::RELATIVE_PATH}."
+    warn "                    Edit the YAML, then `make sync-api-version` to rewrite the block. " \
+         "It is the"
+    warn "                    one block the writer authors, because none of it is hand-written."
     warn "  Unmarked pin:     see the A/B rule in AGENTS.md §Provenance is Mandatory."
     1
   end

--- a/scripts/sync-doc-constants.rb
+++ b/scripts/sync-doc-constants.rb
@@ -1238,6 +1238,26 @@ def run(mode, openapi)
   end
 
   if mode == :write
+    # STRUCTURAL PROBLEMS ABORT BEFORE ANYTHING IS WRITTEN, and the ordering is
+    # the whole point: this check used to run after the write loop, so a file
+    # with damaged markers was rewritten and THEN reported as "nothing could be
+    # synced" — a message the code made false by writing first.
+    #
+    # It mattered little while every writable span was a single line rewritten
+    # in place. It matters now: a writable BLOCK is spliced, its length can
+    # change, and the span offsets come from the same scan that recorded the
+    # error. Two roster blocks where the inventory declares one, or a marker
+    # left nested by a merge, would be spliced from indices the errors say not
+    # to trust — inside `make generate`, against a tracked file.
+    #
+    # So the rule is the plain one a generation pass should already obey: a run
+    # that cannot vouch for what it read changes nothing on disk.
+    unless errors.empty?
+      warn "ERROR: doc-constant markers are malformed; nothing was synced:"
+      errors.each { |e| warn "  #{e}" }
+      return 1
+    end
+
     written = []
     declined = []
     spans.group_by(&:file).each do |file, file_spans|
@@ -1306,13 +1326,6 @@ def run(mode, openapi)
       warn "      `make doc-constants-check` stays red until you do."
     end
 
-    # Structural marker problems are still fatal in --write: they mean the
-    # writer could not see a span it was supposed to maintain.
-    unless errors.empty?
-      warn "ERROR: doc-constant markers are malformed; nothing could be synced for these:"
-      errors.each { |e| warn "  #{e}" }
-      return 1
-    end
     return 0
   end
 

--- a/scripts/sync-doc-constants.rb
+++ b/scripts/sync-doc-constants.rb
@@ -1258,6 +1258,28 @@ def run(mode, openapi)
       return 1
     end
 
+    # ...and every writable block body is RENDERED HERE, before any file is
+    # opened, for exactly the same reason one paragraph up.
+    #
+    # This is the hole the structural preflight above did NOT close, and it is
+    # worth naming rather than quietly fixing: the bodies were lambdas called
+    # inside the splice, so a malformed roster raised in the middle of the write
+    # loop. Files are walked in scan order, so COORDINATION.md's stale pin was
+    # already rewritten by the time SPEC.md's block asked for a roster that
+    # would not load — a partially modified checkout from a run that reported
+    # failure. Moving one check earlier answered the errors scan_file records
+    # and left every failure that only appears when the body is demanded.
+    #
+    # Forcing them up front turns that class into nothing: after this line the
+    # write loop cannot raise for a reason it has not already discovered, so
+    # "aborted" and "nothing written" mean the same thing again.
+    #
+    # Only the kinds actually MARKED are forced. A repo whose SPEC carries no
+    # roster marker must not be made to load the roster file, which is what
+    # keeps this gate's own crafted fixtures minimal.
+    marked_writable_blocks = spans.select(&:block).map(&:kind).uniq & WRITABLE_BLOCK_KINDS
+    rendered_blocks = marked_writable_blocks.to_h { |kind| [kind, block_bodies.fetch(kind).call] }
+
     written = []
     declined = []
     spans.group_by(&:file).each do |file, file_spans|
@@ -1289,7 +1311,7 @@ def run(mode, openapi)
       # written this way so the second one does not have to notice.
       writable_blocks.sort_by { |span| -span.line_no }.each do |span|
         start = span.line_no - 1
-        lines[start, span.lines.length] = block_bodies.fetch(span.kind).call.map { |l| "#{l}\n" }
+        lines[start, span.lines.length] = rendered_blocks.fetch(span.kind).map { |l| "#{l}\n" }
       end
 
       updated = lines.join

--- a/scripts/sync-doc-constants.rb
+++ b/scripts/sync-doc-constants.rb
@@ -339,7 +339,8 @@ def scan_file(file)
   spans = []
   errors = []
   prose = []
-  lines = File.readlines(File.join(ROOT, file), chomp: true, encoding: UTF8)
+  raw = File.read(File.join(ROOT, file), encoding: UTF8)
+  lines = raw.lines.map(&:chomp)
   open_block = nil
   open_fence = nil
 
@@ -432,6 +433,31 @@ def scan_file(file)
 
   if open_block
     errors << "#{file}:#{open_block[:line_no]}: @#{open_block[:kind]}:begin never closed"
+  end
+
+  # A marked file must be LF-only, and this is what makes "byte-identical" an
+  # honest description of @zero-skip-roster's comparison rather than an
+  # approximation of it.
+  #
+  # Spans are chomped, and `chomp` eats LF, CRLF and a lone CR alike — so a
+  # block converted to CRLF compares EQUAL to the renderer's LF output and
+  # --check passes over a block that is not byte-for-byte anything, while
+  # --write would rewrite the same lines and produce a diff. Check green,
+  # generate dirty: the drift-gate failure mode, inside the gate.
+  #
+  # Two ways to close it: carry terminators through every span, which changes
+  # what every block checker sees for one file nobody has; or refuse the
+  # terminator that creates the ambiguity. With no CR in the file, "the lines
+  # match" and "the bytes match" are the same sentence, so the cheaper one is
+  # also the one that makes the claim true. Scoped to files that actually carry
+  # a span, since an unmarked file's line endings are nobody's business here,
+  # and free today: no tracked Markdown contains a CR.
+  if !spans.empty? && raw.include?("\r")
+    line_no = raw[0...raw.index("\r")].count("\n") + 1
+    errors << "#{file}:#{line_no}: carries a CR line ending, and the file holds marked span(s). " \
+              "Spans are compared after chomping, which treats CRLF and LF as equal, so a " \
+              "CRLF block would pass --check byte-unequal and then be rewritten by --write. " \
+              "Convert the file to LF."
   end
 
   # Only LINE spans leave the prose pool. A line span IS the marked claim — the

--- a/scripts/test-check-fixture-execution.rb
+++ b/scripts/test-check-fixture-execution.rb
@@ -16,14 +16,14 @@
 # live check).
 
 require "json"
+require "yaml"
 require "tmpdir"
 require "fileutils"
 require "open3"
 
 GATE = File.join(__dir__, "check-fixture-execution.rb")
 RUNNERS = %w[go kotlin python ruby swift typescript].freeze
-ROSTER_LABELS = { "go" => "Go", "kotlin" => "Kotlin", "python" => "Python",
-                  "ruby" => "Ruby", "swift" => "Swift", "typescript" => "TypeScript" }.freeze
+ROSTER_FILE = "spec/zero-skip-roster.yml"
 
 failures = []
 
@@ -36,35 +36,59 @@ def default_manifests
   end
 end
 
-# A SPEC roster that agrees with whatever the manifests say, so roster drift is
-# only ever exercised by a case that asks for it.
-def default_spec(manifests)
-  labels = ROSTER_LABELS
-  body = RUNNERS.map do |runner|
-    lines = ["**#{labels.fetch(runner)}** (`x`):"]
+# A roster that agrees with whatever the manifests say, so roster drift is only
+# ever exercised by a case that asks for it. Built as a Ruby structure and
+# dumped, so a case that wants to break the roster breaks one field rather than
+# hand-editing YAML text — and a case that wants to break the SYNTAX passes a
+# raw string instead (see `roster_text:`).
+def default_roster(manifests)
+  runners = RUNNERS.to_h do |runner|
     # Defensive: some cases replace a manifest with a non-Hash or nil on
     # purpose, and this helper only exists to keep the roster in step with the
     # ones that are real.
     entry = manifests[runner]
     excluded = entry.is_a?(Hash) ? (entry["excluded"] || []) : []
-    excluded.each do |e|
-      lines << %(- "#{e['name']}" — because.)
-    end
-    lines.join("\n")
-  end.join("\n\n")
+    [runner, {
+      "source" => "`runner.x` `SKIPS`",
+      "note" => "a note, which an empty section needs",
+      "skips" => excluded.map { |e| { "case" => e["name"], "reason" => "because." } },
+    }]
+  end
+  { "runners" => runners }
+end
 
-  "# Spec\n\n<!-- zero-skip-roster:begin -->\n#{body}\n<!-- zero-skip-roster:end -->\n"
+# A valid roster in which nobody skips anything — the starting point for every
+# case that wants a specific disagreement. Rebuilt on each call, because the
+# cases mutate what they are handed.
+def roster_without_skips
+  default_roster(default_manifests)
+end
+
+# ...with one runner's skips replaced wholesale.
+def roster_with(**by_runner)
+  doc = roster_without_skips
+  by_runner.each { |runner, skips| doc["runners"].fetch(runner.to_s)["skips"] = skips }
+  doc
 end
 
 # Materialise the manifests (after `mutate` has had a chance to break one) and
 # run the gate against them.
-def gate(mutate = nil, partial: false, spec: nil)
+#
+# `roster:` replaces the roster STRUCTURE (a Hash, dumped to YAML, or nil to
+# write no file at all); `roster_text:` replaces the file's bytes outright, for
+# the cases about YAML the loader cannot parse.
+def gate(mutate = nil, partial: false, roster: :default, roster_text: nil)
   manifests = default_manifests
   mutate&.call(manifests)
 
   Dir.mktmpdir do |dir|
     FileUtils.mkdir_p(File.join(dir, "conformance", "manifests"))
-    File.write(File.join(dir, "SPEC.md"), spec || default_spec(manifests))
+    FileUtils.mkdir_p(File.join(dir, "spec"))
+
+    doc = roster == :default ? default_roster(manifests) : roster
+    body = roster_text || (doc.nil? ? nil : YAML.dump(doc))
+    File.write(File.join(dir, ROSTER_FILE), body) unless body.nil?
+
     manifests.each do |runner, body|
       next if body.nil? # a nil entry means "this runner did not report"
 
@@ -231,117 +255,183 @@ out, status = gate lambda { |m|
 expect_fail(failures, "an exclusion without its fixture file", out, status, "missing required key")
 
 # One case excluded twice by one runner: its own integrity count would still add
-# up while the comparison saw a single entry.
-out, status = gate lambda { |m|
+# up while the comparison saw a single entry. The roster is handed the case ONCE
+# — a roster built from this manifest would carry the duplicate too, and fail in
+# the loader for a different reason than the one this case is about.
+out, status = gate(lambda { |m|
   2.times { m["go"]["excluded"] << { "file" => "alpha.json", "name" => "dup", "reason" => "x" } }
   m["go"]["executed"] -= 2
-}
+}, roster: roster_with(go: [{ "case" => "dup", "reason" => "x." }]))
 expect_fail(failures, "one case excluded twice in one manifest", out, status, "is excluded twice")
 
-# --- SPEC roster set-equality (#736) -----------------------------------------
+# --- roster set-equality (#736) ----------------------------------------------
+#
+# The roster is spec/zero-skip-roster.yml. It used to be SPEC.md's prose, read
+# back out by a parser, and the cases below used to craft Markdown: a bullet with
+# an unrecognised marker, a blockquoted entry, a second roster block, a claim
+# riding a heading. Each of those was a bypass found after the fact, and each fix
+# was one more selector.
+#
+# They are gone because the class is gone, not because it was ruled out of
+# scope. A stale entry now has to be an entry — a `case:` under a runner — and
+# whatever it is spelled with, it is compared to the manifest byte for byte. The
+# spelling cases that remain are here as evidence of exactly that (see "the old
+# bypasses are just strings now", below).
+#
+# What SPEC's block says is checked by `make doc-constants-check`, which renders
+# it from this file and requires byte equality. Nothing here reads SPEC.md at
+# all.
 
 # A runner skip the roster does not list. This is the drift that was ALREADY in
 # SPEC when the check was written: Kotlin and Swift excluded the link-header
 # case via their tag branch while the roster described it in prose.
 out, status = gate(lambda { |m| exclude(m, "unlisted skip", ["ruby"]) },
-                   spec: "<!-- zero-skip-roster:begin -->\n" +
-                         RUNNERS.map { |r| "**#{ ROSTER_LABELS.fetch(r) }** (`x`):" }.join("\n\n") +
-                         "\n<!-- zero-skip-roster:end -->\n")
+                   roster: roster_without_skips)
 expect_fail(failures, "a runner skip missing from the roster", out, status,
-            "the SPEC roster does not list it")
+            "does not list it")
 
-# The opposite drift: a roster line for a skip that has been closed. "A PR that
-# closes a gap deletes exactly its own lines" is the roster's own rule, and it
+# The opposite drift: an entry for a skip that has been closed. "A PR that
+# closes a gap deletes exactly its own entry" is the roster's own rule, and it
 # was enforced by nothing.
-out, status = gate(nil,
-                   spec: "<!-- zero-skip-roster:begin -->\n" +
-                         RUNNERS.map { |r|
-                           head = "**#{ ROSTER_LABELS.fetch(r) }** (`x`):"
-                           r == "go" ? "#{head}\n- \"a closed gap\" — stale." : head
-                         }.join("\n\n") +
-                         "\n<!-- zero-skip-roster:end -->\n")
-expect_fail(failures, "a roster line for a skip that no longer exists", out, status,
+out, status = gate(nil, roster: roster_with(go: [{ "case" => "a closed gap", "reason" => "stale." }]))
+expect_fail(failures, "a roster entry for a skip that no longer exists", out, status,
             "which no longer excludes it")
 
-# A runner with no heading contributes nothing, so its skips would go unchecked.
-out, status = gate(nil, spec: "<!-- zero-skip-roster:begin -->\n**Go** (`x`):\n<!-- zero-skip-roster:end -->\n")
-expect_fail(failures, "a runner with no roster section", out, status, "has no section for")
+# A runner with no section contributes nothing, so its skips would go unchecked.
+# An absent key and an empty list are not the same statement, and only one of
+# them was written on purpose.
+out, status = gate(nil, roster: begin
+  doc = roster_without_skips
+  doc["runners"].delete("go")
+  doc
+end)
+expect_fail(failures, "a runner with no roster section", out, status, "no section for go")
 
-# No roster at all must not read as "the roster agrees".
-out, status = gate(nil, spec: "# Spec\n\nNo roster here.\n")
-expect_fail(failures, "SPEC with no roster block", out, status, "holds no")
+# No roster file at all must not read as "the roster agrees".
+out, status = gate(nil, roster: nil)
+expect_fail(failures, "no roster file", out, status, "is missing")
 
-# A bullet the extractor cannot read is a name missing from the roster set —
-# loud, never a silent pass. This is the property that makes the parser
-# acceptable at all.
-out, status = gate(nil,
-                   spec: "<!-- zero-skip-roster:begin -->\n**Go** (`x`):\n- unquoted case name\n" +
-                         (RUNNERS - ["go"]).map { |r| "**#{ ROSTER_LABELS.fetch(r) }** (`x`):" }.join("\n\n") +
-                         "\n<!-- zero-skip-roster:end -->\n")
-expect_fail(failures, "a roster bullet without a quoted name", out, status,
-            "list-shaped but not a canonical bullet")
+# An EMPTY roster is the vacuity case: both sides empty must not be a pass.
+# Every runner is required, so an empty `runners` map fails as six missing
+# sections rather than as agreement with six empty manifests.
+out, status = gate(nil, roster: { "runners" => {} })
+expect_fail(failures, "an empty roster is not agreement", out, status, "no section for")
+
+# ...including a file that parses to nothing at all.
+out, status = gate(nil, roster_text: "\n")
+expect_fail(failures, "a roster that parses to nothing", out, status, "expected a mapping")
+
+# YAML the loader cannot parse is not a roster that lists nothing. It has to
+# fail, not fall back to an empty set that agrees with clean manifests.
+out, status = gate(nil, roster_text: "runners:\n  go:\n   - [oops\n")
+expect_fail(failures, "a roster that is not valid YAML", out, status, "not valid YAML")
+
+# A section for a runner nothing compares is dead weight that reads as coverage.
+out, status = gate(nil, roster: begin
+  doc = roster_without_skips
+  # A DEEP copy: dumping one object twice emits a YAML alias — and a shallow
+  # `dup` still shares the `skips` array, which is enough to emit one. This case
+  # would then be pinning the alias refusal below instead of the unknown-runner
+  # rule.
+  doc["runners"]["haskell"] = Marshal.load(Marshal.dump(doc["runners"]["go"]))
+  doc
+end)
+expect_fail(failures, "a roster section for an unknown runner", out, status, "unknown runner")
+
+# Anchors and aliases are refused rather than resolved: two sections sharing one
+# anchor edit as one and read as two. Left to Psych they raise a class that is
+# not a syntax error, so an unguarded loader exits with a backtrace naming the
+# loader rather than a message naming the file.
+out, status = gate(nil, roster_text: <<~YAML)
+  runners:
+    go: &section
+      source: "`x`"
+      note: "a note"
+      skips: []
+    kotlin: *section
+YAML
+expect_fail(failures, "a roster using a YAML alias", out, status, "aliases are refused")
+
+# An absent `skips` key reads as "skips nothing" to any comparison, which is a
+# stale roster that passes. Refused, so the empty case has to be written down.
+out, status = gate(nil, roster: begin
+  doc = roster_without_skips
+  doc["runners"]["go"].delete("skips")
+  doc
+end)
+expect_fail(failures, "a section with no skips key", out, status, "has no `skips` key")
+
+# "None" with no reason is indistinguishable from a section somebody forgot to
+# fill in — which is the state Python's section would be in if its note were
+# dropped, and the note is the whole content of that section.
+out, status = gate(nil, roster: begin
+  doc = roster_without_skips
+  doc["runners"]["go"].delete("note")
+  doc
+end)
+expect_fail(failures, "an empty section that says nothing", out, status, "says nothing")
+
+# A misspelled key contributes nothing and looks like a filled-in section.
+out, status = gate(nil, roster: begin
+  doc = roster_without_skips
+  doc["runners"]["go"]["skip"] = doc["runners"]["go"].delete("skips")
+  doc
+end)
+expect_fail(failures, "a section with a misspelled key", out, status, "unknown key(s)")
+
+out, status = gate(nil, roster: begin
+  doc = roster_without_skips
+  doc["runners"]["go"]["skips"] = "not a list"
+  doc
+end)
+expect_fail(failures, "skips that is not a list", out, status, "not a list")
+
+out, status = gate(lambda { |m| exclude(m, "nameless", ["go"]) }, roster: begin
+  roster_with(go: [{ "reason" => "no case key." }])
+end)
+expect_fail(failures, "a skip entry with no case name", out, status, "`case` is required")
+
+# One case listed twice under a runner. Array#- removes every matching
+# occurrence, so both diffs come back empty and the duplicate passes — carrying
+# two possibly conflicting reasons for one case.
+out, status = gate(lambda { |m| exclude(m, "listed twice", ["go"]) },
+                   roster: roster_with(go: [{ "case" => "listed twice", "reason" => "a." },
+                                            { "case" => "listed twice", "reason" => "b." }]))
+expect_fail(failures, "one case listed twice under a runner", out, status, "more than once")
 
 # Roster drift must be caught in PARTIAL mode too. The normal Linux `make
 # check` path always passes --partial (Swift's manifest is macOS-only), so a
 # roster check that ran only in full mode never ran locally at all — a stale Go
-# or Ruby line would reach CI untouched. Partial input relaxes the all-six
+# or Ruby entry would reach CI untouched. Partial input relaxes the all-six
 # overlap verdict and nothing else.
 out, status = gate(lambda { |m|
   exclude(m, "unlisted skip", ["ruby"])
   m["swift"] = nil
-}, partial: true,
-   spec: "<!-- zero-skip-roster:begin -->\n" +
-         RUNNERS.map { |r| "**#{ROSTER_LABELS.fetch(r)}** (`x`):" }.join("\n\n") +
-         "\n<!-- zero-skip-roster:end -->\n")
-expect_fail(failures, "roster drift is caught in partial mode", out, status,
-            "the SPEC roster does not list it")
+}, partial: true, roster: roster_without_skips)
+expect_fail(failures, "roster drift is caught in partial mode", out, status, "does not list it")
 
-# A SECOND complete roster block is not compared, so a stale line inside it
-# would pass unnoticed — a silent pass, the one failure mode this extractor is
-# not allowed to have.
-one_block = RUNNERS.map { |r| "**#{ROSTER_LABELS.fetch(r)}** (`x`):" }.join("\n\n")
-out, status = gate(nil,
-                   spec: "<!-- zero-skip-roster:begin -->\n#{one_block}\n<!-- zero-skip-roster:end -->\n" \
-                         "\n<!-- zero-skip-roster:begin -->\n#{one_block}\n<!-- zero-skip-roster:end -->\n")
-expect_fail(failures, "two roster blocks in SPEC", out, status, "exactly one")
-
-# One case listed twice under a runner. Array#- removes every matching
-# occurrence, so both diffs come back empty and the duplicate passes — carrying
-# two possibly conflicting classifications for one case.
-out, status = gate(lambda { |m| exclude(m, "listed twice", ["go"]) },
-                   spec: "<!-- zero-skip-roster:begin -->\n" +
-                         RUNNERS.map { |r|
-                           head = "**#{ROSTER_LABELS.fetch(r)}** (`x`):"
-                           r == "go" ? "#{head}\n- \"listed twice\" — a.\n- \"listed twice\" — b." : head
-                         }.join("\n\n") +
-                         "\n<!-- zero-skip-roster:end -->\n")
-expect_fail(failures, "one case listed twice under a runner", out, status, "twice under go")
-
-# Two sections for one runner splits its lines, so neither reads as the whole
-# set and the contract is broken before any comparison runs.
-out, status = gate(nil,
-                   spec: "<!-- zero-skip-roster:begin -->\n" +
-                         (RUNNERS.map { |r| "**#{ROSTER_LABELS.fetch(r)}** (`x`):" } +
-                          ["**Go** (`x`):"]).join("\n\n") +
-                         "\n<!-- zero-skip-roster:end -->\n")
-expect_fail(failures, "two roster sections for one runner", out, status, "more than one section")
-
-# A STALE entry written with any non-canonical list marker. `start_with?("- ")`
-# skipped these, so the entry never entered the roster set, never contradicted a
-# manifest, and the gate passed — a false green, the one outcome this extractor
-# may not produce. Fixed by inverting the default: list-shaped means canonical
-# or error, which closes every spelling at once rather than one at a time.
-["  - \"indented stale\" — x.", "* \"asterisk stale\" — x.",
- "+ \"plus stale\" — x.", "1. \"ordered stale\" — x."].each do |bullet|
-  out, status = gate(nil,
-                     spec: "<!-- zero-skip-roster:begin -->\n" +
-                           RUNNERS.map { |r|
-                             head = "**#{ROSTER_LABELS.fetch(r)}** (`x`):"
-                             r == "go" ? "#{head}\n#{bullet}" : head
-                           }.join("\n\n") +
-                           "\n<!-- zero-skip-roster:end -->\n")
-  expect_fail(failures, "stale roster entry as #{bullet.strip[0, 12]}", out, status,
-              "list-shaped but not a canonical bullet")
+# --- the old bypasses are just strings now -----------------------------------
+#
+# Five times, a stale entry hid from the prose reader by being spelled in a way
+# the reader did not recognise: a `*` marker instead of `- `, a blockquote, a
+# table row, an HTML comment, curly quotes or backticks around the name (the
+# quote test was ASCII-only), and a second quoted name riding an otherwise
+# canonical bullet — which the live Kotlin entry actually carries, in its
+# `yields "no response"`. Each was invisible to the comparison, so it never
+# contradicted a manifest and the gate passed.
+#
+# None of those is a shape any more. A roster entry is a `case:` string, and the
+# comparison is byte-exact, so every spelling below is a stale entry the gate
+# reports rather than skips. This case is the evidence for that claim: it is the
+# same five payloads, and they all fail.
+["“curly quoted stale”",
+ "`backticked stale`",
+ "> - \"blockquoted stale\" — x.",
+ "| Go | \"table-row stale\" | x |",
+ "real name\" — also supersedes \"stale ghost"].each do |name|
+  out, status = gate(nil, roster: roster_with(go: [{ "case" => name, "reason" => "stale." }]))
+  expect_fail(failures, "a stale entry spelled #{name[0, 24].inspect}", out, status,
+              "which no longer excludes it")
 end
 
 # --- report ------------------------------------------------------------------

--- a/scripts/test-check-fixture-execution.rb
+++ b/scripts/test-check-fixture-execution.rb
@@ -480,6 +480,37 @@ expect_fail(failures, "a section using a YAML merge key", out, status, "uses a Y
               "Values render verbatim into Markdown")
 end
 
+# ...but NOT `case`, which this file copies rather than composes. It must match
+# the fixture's name byte for byte, so a rule about how a value ought to be
+# WRITTEN cannot apply to it: refusing one would make a legitimately-named skip
+# unrepresentable and this gate permanently red, with no edit to the roster that
+# helps, since rephrasing changes the very key being compared. Asserted as a
+# PASS, because "the roster can state what the runner actually skipped" is the
+# property, and a guard that swallows a valid state fails silently otherwise.
+["a case with a <bracket>", "a case with an &amp", "a trailing space case "].each do |name|
+  out, status = gate(lambda { |m| exclude(m, name, ["go"]) },
+                     roster: roster_with(go: [{ "case" => name, "reason" => "because." }]))
+  expect_pass(failures, "a copied case name spelled #{name.inspect}", out, status)
+end
+
+# The exemption is for COPIED keys only: the same spelling in composed prose is
+# still refused, which is what keeps it an exemption rather than a hole.
+out, status = gate(nil, roster: begin
+  doc = roster_without_skips
+  doc["runners"]["go"]["note"] = "a note with a <bracket> in it"
+  doc
+end)
+expect_fail(failures, "the same spelling in a composed note", out, status,
+            "Values render verbatim into Markdown")
+
+# The rule that is not about authoring still reaches `case`: a control character
+# cannot render onto the one line the roster gives it, whoever wrote it.
+out, status = gate(lambda { |m| exclude(m, "a case", ["go"]) }, roster: roster_with(
+  go: [{ "case" => "a case\u{2028}- \"smuggled\"", "reason" => "because." }]
+))
+expect_fail(failures, "a copied case name carrying a line separator", out, status,
+            "a control character or line separator")
+
 # The same rule reaches every field, not just the qualifiers — a `source` and a
 # `reason` render into the document exactly as verbatim.
 [["source", "`x` <!-- @zero-skip-roster:end -->"],

--- a/scripts/test-check-fixture-execution.rb
+++ b/scripts/test-check-fixture-execution.rb
@@ -506,15 +506,35 @@ expect_fail(failures, "an empty section that says nothing", out, status, "says n
 # neither gate can object afterwards, because both compare SPEC against exactly
 # what the renderer produced. This is the one rule the YAML stated only in a
 # comment; a comment is not a gate.
-{ "note" => "nothing to skip.", "classification" => "architectural." }.each do |key, value|
+#
+# The trailing-space rows are that rule's one bypass, found in review:
+# CLAUSE_TERMINATOR_RE anchors at the end, so a single space after the period
+# hid it and `nothing to skip. ` rendered `nothing to skip. .`. Closed by
+# refusing surrounding whitespace on every value rather than by teaching the
+# terminator regex to look past it — the space is content in its own right, and
+# a trailing one on ANY value lands invisibly at the end of a rendered line.
+[["note", "nothing to skip.", "ends in terminating punctuation"],
+ ["classification", "architectural.", "ends in terminating punctuation"],
+ ["note", "nothing to skip. ", "has leading or trailing whitespace"],
+ ["classification", "architectural. ", "has leading or trailing whitespace"]]
+  .each do |key, value, want|
   out, status = gate(nil, roster: begin
     doc = roster_without_skips
     doc["runners"]["go"][key] = value
     doc
   end)
-  expect_fail(failures, "a #{key} that punctuates itself", out, status,
-              "`go.#{key}` ends in terminating punctuation")
+  expect_fail(failures, "a #{key} of #{value.inspect}", out, status, want)
 end
+
+# ...and the same rule from the other end, where there is no punctuation
+# involved at all: a leading space is content that shifts the render.
+out, status = gate(nil, roster: begin
+  doc = roster_without_skips
+  doc["runners"]["go"]["source"] = " `x`"
+  doc
+end)
+expect_fail(failures, "a source with a leading space", out, status,
+            "which has leading or trailing whitespace")
 
 # A misspelled key contributes nothing and looks like a filled-in section.
 out, status = gate(nil, roster: begin

--- a/scripts/test-check-fixture-execution.rb
+++ b/scripts/test-check-fixture-execution.rb
@@ -71,6 +71,17 @@ def roster_with(**by_runner)
   doc
 end
 
+CLEAN_SECTION = %(    source: "`x`"\n    note: "a note"\n    skips: []\n)
+
+# A valid roster as TEXT, with Go's body substitutable and arbitrary text
+# appendable inside `runners`. The duplicate-key cases have no other way in: a
+# Ruby Hash cannot hold one key twice, so `YAML.dump` can never emit the defect
+# they exist to catch, and `roster:` goes through `YAML.dump`.
+def raw_roster(go: CLEAN_SECTION, tail: "")
+  sections = RUNNERS.map { |runner| "  #{runner}:\n#{runner == 'go' ? go : CLEAN_SECTION}" }
+  "runners:\n#{sections.join}#{tail}"
+end
+
 # Materialise the manifests (after `mutate` has had a chance to break one) and
 # run the gate against them.
 #
@@ -352,6 +363,46 @@ out, status = gate(nil, roster_text: <<~YAML)
 YAML
 expect_fail(failures, "a roster using a YAML alias", out, status, "aliases are refused")
 
+# --- duplicate mapping keys ---------------------------------------------------
+#
+# The alias above is one way YAML lets a roster mean something other than what
+# it looks like. A repeated KEY is the other, and the worse one: it is legal,
+# Psych accepts it, and it keeps only the LAST — so the earlier claim is
+# discarded in silence. That is exactly the duplicate-section false green this
+# whole change exists to retire, reappearing inside the instrument that replaced
+# the parser. The loader therefore reads the parsed AST, where a key is a key,
+# rather than the Hash the duplicate has already been erased from.
+#
+# Each case below is written so it would PASS with the guard removed: what
+# survives the duplicate agrees with the manifests, and only the discarded half
+# is a ghost. A case that failed either way would be pinning some other rule.
+
+# A whole runner section, twice. The first claims a skip nothing excludes.
+out, status = gate(nil, roster_text: raw_roster(
+  go: %(    source: "`x`"\n    note: "a note"\n    skips:\n) +
+      %(      - case: "a discarded ghost"\n        reason: "never compared."\n),
+  tail: %(  go:\n    source: "`x`"\n    note: "the section that wins"\n    skips: []\n)
+))
+expect_fail(failures, "a runner section written twice", out, status,
+            "`runners.go` is written more than once")
+
+# One FIELD of a section, twice, and `skips` is where it costs most: the
+# surviving list is the one compared against the manifests.
+out, status = gate(nil, roster_text: raw_roster(go: %(    source: "`x`"\n    note: "a note"\n) +
+  %(    skips:\n      - case: "a discarded ghost"\n        reason: "never compared."\n) +
+  %(    skips: []\n)))
+expect_fail(failures, "a section field written twice", out, status,
+            "`runners.go.skips` is written more than once")
+
+# One field of a SKIP ENTRY, twice — the deepest level, and the one an
+# enumeration of levels rather than a walk would have missed.
+out, status = gate(lambda { |m| exclude(m, "the case that wins", ["go"]) },
+                   roster_text: raw_roster(go: %(    source: "`x`"\n    note: "a note"\n) +
+                     %(    skips:\n      - case: "a discarded ghost"\n) +
+                     %(        case: "the case that wins"\n        reason: "never compared."\n)))
+expect_fail(failures, "a skip entry field written twice", out, status,
+            "`runners.go.skips[0].case` is written more than once")
+
 # An absent `skips` key reads as "skips nothing" to any comparison, which is a
 # stale roster that passes. Refused, so the empty case has to be written down.
 out, status = gate(nil, roster: begin
@@ -370,6 +421,22 @@ out, status = gate(nil, roster: begin
   doc
 end)
 expect_fail(failures, "an empty section that says nothing", out, status, "says nothing")
+
+# A qualifier that punctuates itself. The renderer supplies every terminator, so
+# `note: "nothing to skip."` renders `— none; nothing to skip..` and
+# `classification: "architectural."` renders `— architectural.; a note` — and
+# neither gate can object afterwards, because both compare SPEC against exactly
+# what the renderer produced. This is the one rule the YAML stated only in a
+# comment; a comment is not a gate.
+{ "note" => "nothing to skip.", "classification" => "architectural." }.each do |key, value|
+  out, status = gate(nil, roster: begin
+    doc = roster_without_skips
+    doc["runners"]["go"][key] = value
+    doc
+  end)
+  expect_fail(failures, "a #{key} that punctuates itself", out, status,
+              "`go.#{key}` ends in terminating punctuation")
+end
 
 # A misspelled key contributes nothing and looks like a filled-in section.
 out, status = gate(nil, roster: begin

--- a/scripts/test-check-fixture-execution.rb
+++ b/scripts/test-check-fixture-execution.rb
@@ -507,16 +507,25 @@ expect_fail(failures, "an empty section that says nothing", out, status, "says n
 # what the renderer produced. This is the one rule the YAML stated only in a
 # comment; a comment is not a gate.
 #
-# The trailing-space rows are that rule's one bypass, found in review:
+# The trailing-space rows are that rule's bypass, found in review:
 # CLAUSE_TERMINATOR_RE anchors at the end, so a single space after the period
 # hid it and `nothing to skip. ` rendered `nothing to skip. .`. Closed by
 # refusing surrounding whitespace on every value rather than by teaching the
 # terminator regex to look past it — the space is content in its own right, and
 # a trailing one on ANY value lands invisibly at the end of a rendered line.
+#
+# The NBSP and ideographic-space rows are the SECOND round of that same lesson,
+# and the reason the rule is a \p{Space} match rather than `value.strip`:
+# String#strip is ASCII-only, so of the eight whitespace code points worth
+# testing it removes two, and U+00A0 walked through the fix for U+0020 and hid
+# the period all over again. They are here so the rule cannot quietly narrow
+# back to ASCII.
 [["note", "nothing to skip.", "ends in terminating punctuation"],
  ["classification", "architectural.", "ends in terminating punctuation"],
- ["note", "nothing to skip. ", "has leading or trailing whitespace"],
- ["classification", "architectural. ", "has leading or trailing whitespace"]]
+ ["note", "nothing to skip. ", "begins or ends with whitespace"],
+ ["classification", "architectural. ", "begins or ends with whitespace"],
+ ["note", "nothing to skip.\u{00A0}", "begins or ends with whitespace"],
+ ["source", "`x`\u{3000}", "begins or ends with whitespace"]]
   .each do |key, value, want|
   out, status = gate(nil, roster: begin
     doc = roster_without_skips
@@ -534,7 +543,7 @@ out, status = gate(nil, roster: begin
   doc
 end)
 expect_fail(failures, "a source with a leading space", out, status,
-            "which has leading or trailing whitespace")
+            "which begins or ends with whitespace")
 
 # A misspelled key contributes nothing and looks like a filled-in section.
 out, status = gate(nil, roster: begin

--- a/scripts/test-check-fixture-execution.rb
+++ b/scripts/test-check-fixture-execution.rb
@@ -88,7 +88,7 @@ end
 # `roster:` replaces the roster STRUCTURE (a Hash, dumped to YAML, or nil to
 # write no file at all); `roster_text:` replaces the file's bytes outright, for
 # the cases about YAML the loader cannot parse.
-def gate(mutate = nil, partial: false, roster: :default, roster_text: nil)
+def gate(mutate = nil, partial: false, roster: :default, roster_text: nil, env: {})
   manifests = default_manifests
   mutate&.call(manifests)
 
@@ -109,7 +109,7 @@ def gate(mutate = nil, partial: false, roster: :default, roster_text: nil)
 
     cmd = ["ruby", GATE]
     cmd << "--partial" if partial
-    out, status = Open3.capture2e({ "FIXTURE_EXECUTION_ROOT" => dir }, *cmd)
+    out, status = Open3.capture2e({ "FIXTURE_EXECUTION_ROOT" => dir }.merge(env), *cmd)
     [utf8(out), status]
   end
 end
@@ -414,6 +414,72 @@ out, status = gate(nil, roster_text: "#{raw_roster}---\n#{raw_roster(
       %(      - case: "an unread second roster"\n        reason: "never compared."\n)
 )}")
 expect_fail(failures, "a second YAML document", out, status, "holds 2 YAML documents")
+
+# An extra TOP-LEVEL key. The loader used to read `doc["runners"]` and ignore
+# whatever else the document held, so a misspelled or duplicated top-level
+# mapping could carry a whole roster that is visible in the file and read by
+# nothing — the discarded claim the nested unknown-key rules already refuse one
+# level down, at the level a reader is likeliest to paste one.
+out, status = gate(nil, roster: begin
+  doc = roster_without_skips
+  doc["runnners"] = { "go" => { "source" => "`x`", "note" => "unread", "skips" => [
+    { "case" => "an unread entry", "reason" => "never compared." }
+  ] } }
+  doc
+end)
+expect_fail(failures, "an unknown top-level key", out, status, "unknown top-level key(s) runnners")
+
+# --- a value that can end a line ----------------------------------------------
+#
+# Every scalar renders onto ONE line. A value carrying a line ending spells a
+# second heading or bullet in SPEC while the block still matches byte for byte,
+# and — for a `case` — while the manifest projection still compares the whole
+# scalar. Same false green, sourced from a character instead of from a parser.
+#
+# The rule is a CLASS (no control character, no line/paragraph separator), not a
+# list, and these cases are evidence for that shape rather than for one
+# character. Review reported `\r`; it is only the first of the five below, and
+# the other four are spellings nobody has written. Narrowing the guard to the
+# reported character leaves all four green, which is the mutation that would
+# otherwise have to be argued about instead of demonstrated.
+#
+# The smuggled payload deliberately ends in a letter, not a period. Ending it in
+# one would make the CLAUSE rule refuse the note first, and these cases would be
+# pinning that guard instead of this one — the substring trap, one field over.
+{ "CR" => "\u{000D}", "U+2028 LINE SEPARATOR" => "\u{2028}",
+  "U+2029 PARAGRAPH SEPARATOR" => "\u{2029}", "U+0085 NEL" => "\u{0085}",
+  "VT" => "\u{000B}" }.each do |label, char|
+  out, status = gate(nil, roster: begin
+    doc = roster_without_skips
+    doc["runners"]["go"]["note"] = %(a note#{char}- "a smuggled stale entry" — see above)
+    doc
+  end)
+  expect_fail(failures, "a note carrying #{label}", out, status,
+              "a control character or line separator")
+end
+
+# NOT tested here: the same separator in a `case`. The guard is one rule in
+# `scalar` and covers every field, but a case name is compared byte-exact
+# against the manifests, so a separator in one is a LOUD mismatch rather than a
+# false green — and a case asserting the refusal would pass off the mismatch
+# instead. Writing it revealed something else, which is below.
+
+# --- the gate reads its manifests as UTF-8 ------------------------------------
+#
+# Fallout from the case above: the manifest read was UNPINNED, so under LC_ALL=C
+# — which is how CI runs — a non-ASCII byte in any case name reached JSON as
+# US-ASCII and died as Encoding::InvalidByteSequenceError with a Ruby backtrace
+# instead of a verdict. Never fired only because every tracked fixture case name
+# is ASCII. It was also the file's one unpinned read, beside a roster reader
+# that pinned its own and that this change deletes.
+#
+# The roster AGREES with the manifest here, so the assertion is a pass: the
+# gate must reach its verdict at all, which is what an unpinned read denies it.
+accented = "Bracketed IPv6 loopback \u{2014} caf\u{00E9} na\u{00EF}ve"
+out, status = gate(lambda { |m| exclude(m, accented, ["go"]) },
+                   roster: roster_with(go: [{ "case" => accented, "reason" => "r." }]),
+                   env: { "LC_ALL" => "C", "LANG" => "C" })
+expect_pass(failures, "a non-ASCII case name under LC_ALL=C", out, status)
 
 # An absent `skips` key reads as "skips nothing" to any comparison, which is a
 # stale roster that passes. Refused, so the empty case has to be written down.

--- a/scripts/test-check-fixture-execution.rb
+++ b/scripts/test-check-fixture-execution.rb
@@ -448,11 +448,29 @@ expect_fail(failures, "a section using a YAML merge key", out, status, "uses a Y
 # injects a doc-constant MARKER, which the writer emits and exits 0 over, leaving
 # a document the next check refuses as structurally malformed.
 #
-# Reported as two findings, closed as one rule: a value that can open or close an
-# HTML comment. There is no third instance — those are the only two delimiters —
-# and marker injection is a strict subset, since every marker is one of these.
-["<!--", "-->", %(a note <!-- @zero-skip-roster:end -->),
- %(<!-- @fixture-categories:begin -->)].each do |markup|
+# Reported as THREE findings across two rounds — a bare `<!--`, an injected
+# marker, and then `<details>`, which needs no comment at all and collapses
+# everything after it on GitHub while both gates stay green. The first two were
+# closed with `/<!--|-->/`; the third is what showed that was a selector rather
+# than a rule.
+#
+# Raw HTML has exactly two openers: `<` begins every tag and every comment, `&`
+# begins every entity. Refusing both closes the class including the spellings
+# nobody has written, and REPLACES the comment rule rather than joining it. The
+# `<details>`, `<script>` and entity rows are here so it cannot narrow back. The
+# entities sit MID-VALUE on purpose: `&lt;` ends in a semicolon, so at the end
+# of a value the clause rule would refuse it first and the case would be pinning
+# that guard instead of this one.
+#
+# A bare `-->` is deliberately NO LONGER refused, and this is a real narrowing
+# rather than an oversight. The old rule took it because it was half of a
+# delimiter pair; with `<` refused, no value can open a comment for it to close,
+# and the renderer emits none either — so it is literal text in a Markdown
+# document, like any other punctuation. Refusing a closer that cannot close
+# anything would be the fortress this PR keeps arguing against.
+["<!--", %(a note <!-- @zero-skip-roster:end -->),
+ %(<!-- @fixture-categories:begin -->), "<details>", "<script>",
+ "an &amp; entity", "an &lt;b&gt; entity"].each do |markup|
   out, status = gate(nil, roster: begin
     doc = roster_without_skips
     doc["runners"]["go"]["note"] = "a note #{markup}".strip

--- a/scripts/test-check-fixture-execution.rb
+++ b/scripts/test-check-fixture-execution.rb
@@ -429,6 +429,56 @@ out, status = gate(nil, roster: begin
 end)
 expect_fail(failures, "an unknown top-level key", out, status, "unknown top-level key(s) runnners")
 
+# A YAML MERGE key, which is the duplicate-key defect wearing a different key.
+# Psych resolves `<<` before the Hash exists and any field the section also
+# states explicitly wins, so the merged entry vanishes — and the duplicate rule
+# cannot see it, because `<<` and `skips` are two distinct keys in the AST. The
+# manifests are clean here, so the surviving `skips: []` agrees with them and
+# this is green without the rule.
+out, status = gate(nil, roster_text: raw_roster(go: %(    source: "`x`"\n    note: "a note"\n) +
+  %(    <<: {skips: [{case: "a merged ghost", reason: "discarded."}]}\n) +
+  %(    skips: []\n)))
+expect_fail(failures, "a section using a YAML merge key", out, status, "uses a YAML merge key")
+
+# --- a value that is markup rather than text ----------------------------------
+#
+# Values render VERBATIM into a Markdown document, so an HTML comment delimiter
+# in one is not text. `<!--` opens a comment that swallows the rest of the block
+# and whatever follows it in SPEC; a complete `<!-- @zero-skip-roster:end -->`
+# injects a doc-constant MARKER, which the writer emits and exits 0 over, leaving
+# a document the next check refuses as structurally malformed.
+#
+# Reported as two findings, closed as one rule: a value that can open or close an
+# HTML comment. There is no third instance — those are the only two delimiters —
+# and marker injection is a strict subset, since every marker is one of these.
+["<!--", "-->", %(a note <!-- @zero-skip-roster:end -->),
+ %(<!-- @fixture-categories:begin -->)].each do |markup|
+  out, status = gate(nil, roster: begin
+    doc = roster_without_skips
+    doc["runners"]["go"]["note"] = "a note #{markup}".strip
+    doc
+  end)
+  expect_fail(failures, "a note carrying #{markup.inspect}", out, status,
+              "Values render verbatim into Markdown")
+end
+
+# The same rule reaches every field, not just the qualifiers — a `source` and a
+# `reason` render into the document exactly as verbatim.
+[["source", "`x` <!-- @zero-skip-roster:end -->"],
+ ["reason", "because. <!-- oops -->"]].each do |key, markup|
+  out, status = gate(lambda { |m| exclude(m, "a real case", ["go"]) }, roster: begin
+    doc = roster_with(go: [{ "case" => "a real case", "reason" => "because." }])
+    if key == "reason"
+      doc["runners"]["go"]["skips"][0]["reason"] = markup
+    else
+      doc["runners"]["go"][key] = markup
+    end
+    doc
+  end)
+  expect_fail(failures, "a #{key} carrying an HTML comment", out, status,
+              "Values render verbatim into Markdown")
+end
+
 # --- a value that can end a line ----------------------------------------------
 #
 # Every scalar renders onto ONE line. A value carrying a line ending spells a

--- a/scripts/test-check-fixture-execution.rb
+++ b/scripts/test-check-fixture-execution.rb
@@ -403,6 +403,18 @@ out, status = gate(lambda { |m| exclude(m, "the case that wins", ["go"]) },
 expect_fail(failures, "a skip entry field written twice", out, status,
             "`runners.go.skips[0].case` is written more than once")
 
+# A second YAML DOCUMENT, which is the duplicate one level out and is breach 2
+# of the old reader — "a second complete roster block silently ignored" —
+# reproduced in the file format. `safe_load` returns the first document and
+# drops the rest without a word. The first document here is the one that agrees
+# with the manifests, so with the guard removed this passes green while a whole
+# second roster sits in the file unread.
+out, status = gate(nil, roster_text: "#{raw_roster}---\n#{raw_roster(
+  go: %(    source: "`x`"\n    note: "a note"\n    skips:\n) +
+      %(      - case: "an unread second roster"\n        reason: "never compared."\n)
+)}")
+expect_fail(failures, "a second YAML document", out, status, "holds 2 YAML documents")
+
 # An absent `skips` key reads as "skips nothing" to any comparison, which is a
 # stale roster that passes. Refused, so the empty case has to be written down.
 out, status = gate(nil, roster: begin

--- a/scripts/test-doc-constants.rb
+++ b/scripts/test-doc-constants.rb
@@ -1228,6 +1228,27 @@ writer lambda { |f|
   end
 end
 
+# A malformed roster discovered while WRITING must leave the checkout alone.
+# This is the hole the structural preflight did not close: the block bodies were
+# lambdas called inside the splice, so the load failed mid-loop — and files are
+# walked in scan order, so COORDINATION.md's stale pin had already been
+# rewritten by the time SPEC.md's block asked for a roster that would not load.
+# The repin is what makes that earlier file stale, and is the whole point of the
+# case: without it there is no earlier write to catch.
+writer lambda { |f|
+  repin_to.call("f" * 40, "2026-11-11").call(f)
+  f["spec/zero-skip-roster.yml"] = "runners:\n  go:\n   - [oops\n"
+} do |out, status, dir|
+  if status.success?
+    failures << "writer: a malformed roster must be fatal, got exit 0:\n#{out}"
+  end
+  coordination = read_in(dir, "COORDINATION.md")
+  unless coordination.include?("`#{SHORT}`")
+    failures << "writer: a file earlier in scan order was rewritten before the roster " \
+                "failed to load:\n#{coordination}"
+  end
+end
+
 # Structural marker damage IS fatal to the writer: it means a span it was
 # supposed to maintain was invisible to it. And it must be fatal BEFORE
 # anything is written — the check used to run after the write loop, so a file

--- a/scripts/test-doc-constants.rb
+++ b/scripts/test-doc-constants.rb
@@ -285,8 +285,9 @@ def gate(mutate = nil, openapi_version: API_VER, openapi_paths: SOURCE_PATHS)
   run_gate(mutate: mutate, openapi_version: openapi_version, openapi_paths: openapi_paths)
 end
 
-def writer(mutate = nil, &inspect_result)
-  run_gate(mode: "--write", mutate: mutate, inspect_result: inspect_result)
+def writer(mutate = nil, openapi_paths: SOURCE_PATHS, &inspect_result)
+  run_gate(mode: "--write", mutate: mutate, inspect_result: inspect_result,
+           openapi_paths: openapi_paths)
 end
 
 def read_in(dir, rel)
@@ -1292,6 +1293,24 @@ writer lambda { |f|
   written = read_in(dir, "SPEC.md")
   if written.scan("<!-- @zero-skip-roster:end -->").length != 1
     failures << "writer: emitted a document with an injected marker:\n#{written}"
+  end
+end
+
+# The same class again, one deferred input over: `op_count` was resolved inside
+# `rewrite_line`, so an OpenAPI document the count cannot be derived from raised
+# in the middle of the write loop — after COORDINATION.md, earlier in scan
+# order, had already been rewritten by the repin. Third report of one defect,
+# which is why the fix is a single place where every deferred input is resolved
+# and a `rewrite_line` that takes values rather than thunks.
+writer(lambda { |f| repin_to.call("a" * 40, "2026-12-12").call(f) },
+       openapi_paths: nil) do |out, status, dir|
+  if status.success?
+    failures << "writer: an underivable operation count must be fatal, got exit 0:\n#{out}"
+  end
+  coordination = read_in(dir, "COORDINATION.md")
+  unless coordination.include?("`#{SHORT}`")
+    failures << "writer: a file earlier in scan order was rewritten before the operation " \
+                "count failed to derive:\n#{coordination}"
   end
 end
 

--- a/scripts/test-doc-constants.rb
+++ b/scripts/test-doc-constants.rb
@@ -23,6 +23,62 @@ require "open3"
 ROOT = File.expand_path("..", __dir__)
 GATE = File.join(__dir__, "sync-doc-constants.rb")
 
+# SPEC §19's Zero-Skip roster: the crafted source, and the block the gate must
+# render from it.
+#
+# The expected block is written out BY HAND rather than produced by requiring
+# ZeroSkipRoster and rendering with it. A positive control that computes what it
+# expects by calling the code under test is not a control — it would agree with
+# any rendering, including a broken one. Written out, a change to the renderer
+# fails here and someone has to decide it was meant.
+ZERO_SKIP_YAML = <<~YAML
+  runners:
+    go:
+      source: "`x`"
+      classification: architectural
+      note: "a note"
+      skips:
+        - case: "a skipped case"
+          reason: "a reason."
+    python:
+      source: "`x`"
+      note: "nothing to skip"
+      skips: []
+    ruby:
+      source: "`x`"
+      note: "nothing to skip"
+      skips: []
+    typescript:
+      source: "`x`"
+      note: "nothing to skip"
+      skips: []
+    kotlin:
+      source: "`x`"
+      note: "nothing to skip"
+      skips: []
+    swift:
+      source: "`x`"
+      note: "nothing to skip"
+      skips: []
+YAML
+
+ZERO_SKIP_LINES = [
+  "**Go** (`x`) — architectural; a note:",
+  %(- "a skipped case" — a reason.),
+  "",
+  "**Python** (`x`) — none; nothing to skip.",
+  "",
+  "**Ruby** (`x`) — none; nothing to skip.",
+  "",
+  "**TypeScript** (`x`) — none; nothing to skip.",
+  "",
+  "**Kotlin** (`x`) — none; nothing to skip.",
+  "",
+  "**Swift** (`x`) — none; nothing to skip.",
+  "",
+].freeze
+ZERO_SKIP_BLOCK = ZERO_SKIP_LINES.map { |line| "#{line}\n" }.join
+
 REVISION = "d0edc1283b231c58b7c88b014df5f8d231b1f7c8"
 SHORT    = REVISION[0, 8]
 PIN_DATE = "2026-07-31"
@@ -112,8 +168,10 @@ def default_files
         "operation-count" => { "SPEC.md" => 1 },
         "fixture-categories" => { "SPEC.md" => 1 },
         "fixture-section-map" => { "SPEC.md" => 1 },
+        "zero-skip-roster" => { "SPEC.md" => 1 },
       }
     ),
+    "spec/zero-skip-roster.yml" => ZERO_SKIP_YAML,
     # Two tracked conformance fixtures, which is the whole source of truth for
     # the two roster checks — their CONTENT is never read, only their tracked
     # filenames. `beta_write` earns its underscore: the category slug rule
@@ -158,6 +216,9 @@ def default_files
       | `alpha.json` | does a thing | §1 |
       | `beta_write.json` | does another thing | §2 |
       <!-- @fixture-section-map:end -->
+
+      <!-- @zero-skip-roster:begin -->
+      #{ZERO_SKIP_BLOCK}<!-- @zero-skip-roster:end -->
     MD
     "spec/api-gaps/entry.md" => <<~MD,
       # An entry
@@ -1139,6 +1200,135 @@ end
 writer ->(f) { f["SPEC.md"] += "\nSomething. <!-- @nope -->\n" } do |out, status, _dir|
   if status.success?
     failures << "writer: malformed markers must be fatal, got exit 0:\n#{out}"
+  end
+end
+
+# --- @zero-skip-roster (SPEC §19's Zero-Skip roster) ---------------------------
+#
+# The first RENDERED block, and the first writable one. Everything below is one
+# claim: the text between the markers must be byte-identical to what
+# spec/zero-skip-roster.yml renders to. There is no parser, so there are no
+# shapes to enumerate — which is the whole reason this replaced a reader whose
+# "every misreading surfaces as a mismatch" invariant was breached five times.
+
+# A single character. Not a plausible edit on its own — it stands in for the
+# class the old reader kept missing by one spelling at a time: a straightened
+# quote, a hyphen for an em dash, a trailing space. All of them are this case.
+out, status = gate ->(f) { f["SPEC.md"] = f["SPEC.md"].sub("a reason.", "a reason!") }
+expect_fail(failures, "SPEC block drifts from the YAML by one character", out, status,
+            "does not match spec/zero-skip-roster.yml")
+
+# The same drift from the other side, which is the one that actually happens: an
+# entry is added to (or deleted from) the YAML and the block is not regenerated.
+added_skip = "    skips:\n      - case: \"a new skip\"\n        reason: \"newly discovered.\"\n"
+out, status = gate lambda { |f|
+  updated = f["spec/zero-skip-roster.yml"].sub("    skips: []\n", added_skip)
+  raise "fixture drift: no `skips: []` to replace" if updated == f["spec/zero-skip-roster.yml"]
+
+  f["spec/zero-skip-roster.yml"] = updated
+}
+expect_fail(failures, "an entry added to the YAML but not rendered into SPEC", out, status,
+            "does not match spec/zero-skip-roster.yml")
+
+# THE STRUCTURAL CLOSURE. Every bypass that beat the prose reader — a curly-quoted
+# name, a backticked one, a blockquoted bullet, a table row, a second quoted name
+# on a canonical bullet — is now text inside a generated block. None of them needs
+# its own rule: the renderer did not produce it, so it is a diff. One is
+# exercised here; the others differ only in which characters they are made of,
+# which is exactly the property being claimed.
+["> - “curly blockquoted stale” — x.",
+ "| Go | `backticked stale` | x |",
+ %(- "a skipped case" — a reason, which also supersedes "a stale ghost".)].each do |smuggled|
+  out, status = gate ->(f) { f["SPEC.md"] = f["SPEC.md"].sub(ZERO_SKIP_BLOCK, "#{smuggled}\n#{ZERO_SKIP_BLOCK}") }
+  expect_fail(failures, "a stale claim smuggled into the block as #{smuggled[0, 18].inspect}",
+              out, status, "does not match spec/zero-skip-roster.yml")
+end
+
+# An emptied block is the vacuity case at the block level. It cannot be read as
+# agreement, because the rendered side is never empty: all six runner sections
+# are required and each renders at least a heading.
+out, status = gate ->(f) { f["SPEC.md"] = f["SPEC.md"].sub(ZERO_SKIP_BLOCK, "") }
+expect_fail(failures, "an emptied block is not agreement", out, status,
+            "does not match spec/zero-skip-roster.yml")
+
+# ...and the same from the source side: an emptied YAML fails in the loader, so
+# empty-against-empty never reaches the comparison at all.
+out, status = gate lambda { |f|
+  f["spec/zero-skip-roster.yml"] = "runners: {}\n"
+  f["SPEC.md"] = f["SPEC.md"].sub(ZERO_SKIP_BLOCK, "")
+}
+expect_fail(failures, "an emptied YAML against an emptied block", out, status, "no section for")
+
+# A missing source is not a block that vouches for itself.
+out, status = gate ->(f) { f.delete("spec/zero-skip-roster.yml") }
+expect_fail(failures, "the roster source is missing", out, status,
+            "spec/zero-skip-roster.yml is missing")
+
+out, status = gate ->(f) { f["spec/zero-skip-roster.yml"] = "runners:\n  go:\n   - [oops\n" }
+expect_fail(failures, "the roster source is not valid YAML", out, status, "not valid YAML")
+
+# A repo that never mentions the roster must not be made to load it. The gate's
+# own crafted fixtures are minimal by design, and an eager load would fail every
+# case over a file the document never claims anything about.
+out, status = gate lambda { |f|
+  f["SPEC.md"] = f["SPEC.md"].sub("<!-- @zero-skip-roster:begin -->\n#{ZERO_SKIP_BLOCK}" \
+                                  "<!-- @zero-skip-roster:end -->\n", "")
+  f.delete("spec/zero-skip-roster.yml")
+  cfg = JSON.parse(f["spec/doc-constants.json"])
+  cfg["markerCounts"].delete("zero-skip-roster")
+  f["spec/doc-constants.json"] = JSON.pretty_generate(cfg)
+}
+expect_pass(failures, "no marker, no roster file, no complaint", out, status)
+
+# The writer authors this block — the one block kind it may, because none of it
+# is hand-written. Repinning gives it work elsewhere in the same file, so
+# "it rewrote the block" is not confused with "it rewrote the file".
+writer lambda { |f|
+  repin_to.call("d" * 40, "2026-09-09").call(f)
+  f["SPEC.md"] = f["SPEC.md"].sub("a reason.", "drifted, by hand, wrongly.")
+} do |out, status, dir|
+  expect_pass(failures, "writer rewrites a drifted zero-skip block", out, status)
+  written = read_in(dir, "SPEC.md")
+  unless written.include?(ZERO_SKIP_BLOCK)
+    failures << "writer: expected the rendered block restored, got:\n#{written}"
+  end
+  if written.include?("drifted, by hand, wrongly.")
+    failures << "writer: the hand edit survived:\n#{written}"
+  end
+end
+
+# The rewritten block must land BETWEEN its markers and leave the rest of the
+# file alone. A splice is line-indexed, so an off-by-one lands the block inside
+# the neighbouring span — where --check would still pass on the block itself.
+writer lambda { |f|
+  f["SPEC.md"] = f["SPEC.md"].sub(ZERO_SKIP_BLOCK, "wiped\n")
+} do |out, status, dir|
+  expect_pass(failures, "writer restores a wiped block", out, status)
+  written = read_in(dir, "SPEC.md")
+  unless written.include?("<!-- @zero-skip-roster:begin -->\n#{ZERO_SKIP_BLOCK}" \
+                          "<!-- @zero-skip-roster:end -->\n")
+    failures << "writer: block not restored between its own markers:\n#{written}"
+  end
+  unless written.include?("| `beta_write.json` | does another thing | §2 |\n" \
+                          "<!-- @fixture-section-map:end -->\n")
+    failures << "writer: the neighbouring block was disturbed:\n#{written}"
+  end
+  unless written.include?("The surface is `#{OP_COUNT}` operations across 2 paths. " \
+                          "<!-- @operation-count -->")
+    failures << "writer: a line span near the splice was disturbed:\n#{written}"
+  end
+end
+
+# ...and a --write pass must leave a correct block exactly as it found it,
+# byte for byte. The rendered block replaces the block on every run, so a
+# renderer that appended a stray newline would grow the file on each `make
+# generate` and nothing else would notice.
+writer(nil) do |out, status, dir|
+  expect_pass(failures, "writer is idempotent over a correct block", out, status)
+  written = read_in(dir, "SPEC.md")
+  unless written.include?("<!-- @zero-skip-roster:begin -->\n#{ZERO_SKIP_BLOCK}" \
+                          "<!-- @zero-skip-roster:end -->\n")
+    failures << "writer: a correct block was rewritten into something else:\n#{written}"
   end
 end
 

--- a/scripts/test-doc-constants.rb
+++ b/scripts/test-doc-constants.rb
@@ -1070,6 +1070,26 @@ out, status = gate ->(f) {
 expect_fail(failures, "content riding the roster's :begin marker", out, status,
             "@zero-skip-roster:begin must be alone on its line")
 
+# CRLF in a marked file. Spans are compared after chomping, and `chomp` eats
+# CRLF and LF alike, so a block converted to CRLF compares EQUAL to the
+# renderer's LF output: --check passes over a block that is not byte-for-byte
+# anything, and --write then rewrites the same lines and produces a diff. Check
+# green, generate dirty — the drift-gate failure mode, inside the gate.
+#
+# The whole block is converted, so every other rule still sees exactly what it
+# saw before and only the line endings differ. That is what makes it silent.
+out, status = gate ->(f) { f["SPEC.md"] = f["SPEC.md"].gsub("\n", "\r\n") }
+expect_fail(failures, "a marked file with CRLF line endings", out, status,
+            "carries a CR line ending")
+
+# An unmarked file's line endings are nobody's business here, so the rule is
+# scoped to files that actually carry a span. Without that scope this would be a
+# repo-wide reformatting demand smuggled in by a roster change.
+out, status = gate lambda { |f|
+  f["spec/api-gaps/entry.md"] = f["spec/api-gaps/entry.md"].gsub("\n", "\r\n")
+}
+expect_pass(failures, "CRLF in a file with no marked span is not this gate's business", out, status)
+
 # --- marker inventory (exact counts) -------------------------------------------
 
 out, status = gate ->(f) { f["COORDINATION.md"] = f["COORDINATION.md"].sub(" <!-- @bc3-pin -->", "") }

--- a/scripts/test-doc-constants.rb
+++ b/scripts/test-doc-constants.rb
@@ -1229,10 +1229,45 @@ writer lambda { |f|
 end
 
 # Structural marker damage IS fatal to the writer: it means a span it was
-# supposed to maintain was invisible to it.
-writer ->(f) { f["SPEC.md"] += "\nSomething. <!-- @nope -->\n" } do |out, status, _dir|
+# supposed to maintain was invisible to it. And it must be fatal BEFORE
+# anything is written — the check used to run after the write loop, so a file
+# with damaged markers was rewritten and then reported as unsyncable, which is
+# a message the code made false by writing first.
+#
+# The two assertions are separate on purpose: exiting non-zero was already true,
+# and leaving the file alone is the part that was not.
+writer ->(f) { f["SPEC.md"] += "\nSomething. <!-- @nope -->\n" } do |out, status, dir|
   if status.success?
     failures << "writer: malformed markers must be fatal, got exit 0:\n#{out}"
+  end
+end
+
+# The damage here is INSIDE a writable block's own markers, which is the case
+# that can scramble a file rather than merely fail it: a second complete roster
+# block makes the inventory wrong, and both spans would be spliced from offsets
+# the recorded error says not to trust. The stale block's text is the witness —
+# if the writer ran, it is gone.
+writer lambda { |f|
+  repin_to.call("e" * 40, "2026-10-10").call(f)
+  f["SPEC.md"] = f["SPEC.md"].sub("<!-- @zero-skip-roster:end -->",
+                                  "<!-- @zero-skip-roster:end -->\n\n" \
+                                  "<!-- @zero-skip-roster:begin -->\n" \
+                                  "a second block nobody declared\n" \
+                                  "<!-- @zero-skip-roster:end -->")
+} do |out, status, dir|
+  if status.success?
+    failures << "writer: a duplicated writable block must be fatal, got exit 0:\n#{out}"
+  end
+  written = read_in(dir, "SPEC.md")
+  unless written.include?("a second block nobody declared")
+    failures << "writer: aborted run still rewrote the damaged block:\n#{written}"
+  end
+  # Line spans must be untouched too, in every file: the abort is before the
+  # whole write, not just before the splice. The repin above is what gives the
+  # writer work to do here, so this asserts it did none of it.
+  coordination = read_in(dir, "COORDINATION.md")
+  unless coordination.include?("`#{SHORT}`")
+    failures << "writer: aborted run still rewrote a line span:\n#{coordination}"
   end
 end
 

--- a/scripts/test-doc-constants.rb
+++ b/scripts/test-doc-constants.rb
@@ -1012,6 +1012,39 @@ expect_fail(failures, "nested block begin", out, status, "inside an unclosed")
 out, status = gate ->(f) { f["SPEC.md"] += "\n<!-- @assertion-types:end -->\n" }
 expect_fail(failures, ":end without :begin", out, status, ":end without a matching :begin")
 
+# A block marker sharing its line. The body is the lines strictly BETWEEN the
+# markers, so content on the marker line is rendered into the document and
+# compared against nothing — it survives --check and --write preserves it. Both
+# cases below are green with the rule removed, which is the point: neither
+# checker can see the smuggled line, because neither is ever handed it.
+#
+# Exercised on TWO kinds deliberately. The roster case is where review found it;
+# the table case is the evidence that the rule belongs to the span arithmetic
+# rather than to this PR's kind, since the set comparison misses a row riding
+# the marker exactly as the byte comparison misses a bullet.
+out, status = gate ->(f) {
+  f["SPEC.md"] = f["SPEC.md"].sub("<!-- @zero-skip-roster:end -->",
+                                  %(- "a smuggled stale" — x. <!-- @zero-skip-roster:end -->))
+}
+expect_fail(failures, "content riding the roster's :end marker", out, status,
+            "@zero-skip-roster:end shares its line with other content")
+
+out, status = gate ->(f) {
+  f["SPEC.md"] = f["SPEC.md"].sub("<!-- @fixture-categories:end -->",
+                                  "| ghost | `ghost.json` | §9 | <!-- @fixture-categories:end -->")
+}
+expect_fail(failures, "content riding a table block's :end marker", out, status,
+            "@fixture-categories:end shares its line with other content")
+
+# ...and the :begin side, which has the same arithmetic and would need its own
+# rule if the check were written per-marker instead of per-line.
+out, status = gate ->(f) {
+  f["SPEC.md"] = f["SPEC.md"].sub("<!-- @zero-skip-roster:begin -->",
+                                  %(<!-- @zero-skip-roster:begin --> - "a smuggled stale" — x.))
+}
+expect_fail(failures, "content riding the roster's :begin marker", out, status,
+            "@zero-skip-roster:begin shares its line with other content")
+
 # --- marker inventory (exact counts) -------------------------------------------
 
 out, status = gate ->(f) { f["COORDINATION.md"] = f["COORDINATION.md"].sub(" <!-- @bc3-pin -->", "") }

--- a/scripts/test-doc-constants.rb
+++ b/scripts/test-doc-constants.rb
@@ -1027,14 +1027,38 @@ out, status = gate ->(f) {
                                   %(- "a smuggled stale" — x. <!-- @zero-skip-roster:end -->))
 }
 expect_fail(failures, "content riding the roster's :end marker", out, status,
-            "@zero-skip-roster:end shares its line with other content")
+            "@zero-skip-roster:end must be alone on its line")
 
 out, status = gate ->(f) {
   f["SPEC.md"] = f["SPEC.md"].sub("<!-- @fixture-categories:end -->",
                                   "| ghost | `ghost.json` | §9 | <!-- @fixture-categories:end -->")
 }
 expect_fail(failures, "content riding a table block's :end marker", out, status,
-            "@fixture-categories:end shares its line with other content")
+            "@fixture-categories:end must be alone on its line")
+
+# Four spaces makes the marker INDENTED CODE in CommonMark, so it is not an HTML
+# comment at all: it renders as visible literal text while the count still
+# matches and the body between the markers is still compared byte for byte —
+# SPEC quietly displaying the delimiters the convention promises are invisible.
+# Both markers are indented, so the block still pairs up and only the rendering
+# changes, which is what makes it a silent one.
+out, status = gate ->(f) {
+  f["SPEC.md"] = f["SPEC.md"]
+                 .sub("<!-- @zero-skip-roster:begin -->", "    <!-- @zero-skip-roster:begin -->")
+                 .sub("<!-- @zero-skip-roster:end -->", "    <!-- @zero-skip-roster:end -->")
+}
+expect_fail(failures, "block markers indented into a code block", out, status,
+            "@zero-skip-roster:begin must be alone on its line")
+
+# Three spaces is still an HTML block, and must keep working: the rule bounds
+# the indentation rather than demanding column zero, and a rule that rejected
+# legal Markdown would be one nobody could satisfy from a nested list.
+out, status = gate ->(f) {
+  f["SPEC.md"] = f["SPEC.md"]
+                 .sub("<!-- @zero-skip-roster:begin -->", "   <!-- @zero-skip-roster:begin -->")
+                 .sub("<!-- @zero-skip-roster:end -->", "   <!-- @zero-skip-roster:end -->")
+}
+expect_pass(failures, "block markers indented three spaces are still markers", out, status)
 
 # ...and the :begin side, which has the same arithmetic and would need its own
 # rule if the check were written per-marker instead of per-line.
@@ -1043,7 +1067,7 @@ out, status = gate ->(f) {
                                   %(<!-- @zero-skip-roster:begin --> - "a smuggled stale" — x.))
 }
 expect_fail(failures, "content riding the roster's :begin marker", out, status,
-            "@zero-skip-roster:begin shares its line with other content")
+            "@zero-skip-roster:begin must be alone on its line")
 
 # --- marker inventory (exact counts) -------------------------------------------
 
@@ -1246,6 +1270,28 @@ writer lambda { |f|
   unless coordination.include?("`#{SHORT}`")
     failures << "writer: a file earlier in scan order was rewritten before the roster " \
                 "failed to load:\n#{coordination}"
+  end
+end
+
+# The writer must never EMIT a document the checker then refuses. A roster value
+# carrying a marker-shaped HTML comment used to render straight through: --write
+# spliced it in and exited 0, and the next --check reported a structurally
+# malformed SPEC the writer itself had built. Refused in the loader now, so the
+# run fails with the YAML named and the file untouched.
+#
+# Asserted on the FILE, not only on the exit code: "it failed" was already true
+# of the second invocation, and the point is that the first one wrote nothing.
+writer lambda { |f|
+  f["spec/zero-skip-roster.yml"] =
+    f["spec/zero-skip-roster.yml"].sub(%(note: "a note"),
+                                       %(note: "a note <!-- @zero-skip-roster:end -->"))
+} do |out, status, dir|
+  if status.success?
+    failures << "writer: a marker-shaped value must be fatal, got exit 0:\n#{out}"
+  end
+  written = read_in(dir, "SPEC.md")
+  if written.scan("<!-- @zero-skip-roster:end -->").length != 1
+    failures << "writer: emitted a document with an injected marker:\n#{written}"
   end
 end
 

--- a/scripts/zero_skip_roster.rb
+++ b/scripts/zero_skip_roster.rb
@@ -350,7 +350,27 @@ module ZeroSkipRoster
                          "a skip is #{SKIP_KEYS.join(' + ')} and nothing else"
       end
 
-      Skip.new(name: scalar(runner, raw, "case", required: true, where: "#{where} `case`"),
+      # `case` is a COPIED KEY, not composed prose, and that distinction decides
+      # which rules may touch it. It must match the fixture's case name byte for
+      # byte, because it is what the manifest comparison keys on — so a rule
+      # about how a value ought to be WRITTEN cannot apply to it. If a fixture
+      # is ever named with a `<` or a trailing space, refusing the scalar makes
+      # that skip unrepresentable and check-fixture-execution permanently red,
+      # with no edit to this file that helps: rephrasing changes the key, which
+      # is the one thing it may not do.
+      #
+      # The residue is real and belongs in the open: such a name renders its
+      # markup into SPEC, and both gates stay green because both are faithful to
+      # it. That is a FIXTURE-NAMING problem, visible in the fixture, and the
+      # roster's job is to state what the runner skipped rather than to be the
+      # thing that makes a badly-named case impossible to record. No tracked
+      # fixture carries either character today.
+      #
+      # What still applies to it is the rule that is not about authoring at all:
+      # a control character or line separator, which no `case` can carry and
+      # still render onto the one line the roster gives it.
+      Skip.new(name: scalar(runner, raw, "case", required: true, authored: false,
+                            where: "#{where} `case`"),
                reason: scalar(runner, raw, "reason", required: true, where: "#{where} `reason`"))
     end
 
@@ -445,7 +465,11 @@ module ZeroSkipRoster
     SURROUNDING_SPACE_RE = /\A\p{Space}|\p{Space}\z/
     BLANK_RE             = /\A\p{Space}*\z/
 
-    def scalar(runner, raw, key, required: false, where: nil)
+    # `authored: false` marks a value this file COPIES rather than composes — see
+    # the `case` call site. Such a value is still held to what it must be able to
+    # render as, and exempt from every rule about how it ought to be written,
+    # because it is not this file's to write.
+    def scalar(runner, raw, key, required: false, where: nil, authored: true)
       where ||= "#{RELATIVE_PATH}: `#{runner}.#{key}`"
       unless raw.key?(key)
         raise Malformed, "#{where} is required" if required
@@ -481,7 +505,7 @@ module ZeroSkipRoster
       # allowed: it is not whitespace, it cannot hide a neighbouring character
       # from a rule that reads one, and refusing it belongs to a different
       # question than this one.
-      if (markup = value[RAW_MARKUP_RE])
+      if authored && (markup = value[RAW_MARKUP_RE])
         raise Malformed, "#{where} contains #{markup.inspect}. Values render verbatim into " \
                          "Markdown, so a character that opens raw HTML is markup, not text: it " \
                          "hides the rest of the block behind a comment or an open element, or " \
@@ -490,7 +514,7 @@ module ZeroSkipRoster
                          "rendered Markdown, so backticks around the character do not help it."
       end
 
-      if value.match?(SURROUNDING_SPACE_RE)
+      if authored && value.match?(SURROUNDING_SPACE_RE)
         raise Malformed, "#{where} is #{value.inspect}, which begins or ends with whitespace. " \
                          "Values render verbatim, so the space is content: it lands in SPEC, and " \
                          "at the end of a value it hides the character before it from the rules " \

--- a/scripts/zero_skip_roster.rb
+++ b/scripts/zero_skip_roster.rb
@@ -1,0 +1,259 @@
+# frozen_string_literal: true
+
+# SPEC §19's Zero-Skip roster: loader, validator, renderer.
+#
+# One roster, two gates, and they need different halves of it:
+#
+#   scripts/sync-doc-constants.rb renders it and requires SPEC.md's
+#   <!-- @zero-skip-roster:begin/end --> block to be byte-identical.
+#   scripts/check-fixture-execution.rb compares its case names, per runner,
+#   against the execution manifests a conformance run produces.
+#
+# Shared here rather than duplicated because the two gates must agree on what
+# the file MEANS. A second copy of "which keys are required, and what counts as
+# a skip" is a second thing to keep in step, and the one that drifts is whichever
+# gate the author was not editing.
+#
+# ## Why this file exists at all, which is the point of the whole change
+#
+# The roster used to live in SPEC.md as prose and be READ BACK OUT of it. The
+# justification was that every misreading surfaces as a set mismatch and never as
+# a passing comparison. That invariant was breached five times, each fix a new
+# selector: only `- ` bullets recognised; a duplicate block ignored; a duplicate
+# entry invisible to `Array#-`; blockquote, table and HTML-comment payloads; and
+# finally `include?('"')` being ASCII-only, so a curly-quoted or backticked
+# entry slipped past — as does a second quoted name on an otherwise canonical
+# bullet, which the live Kotlin line already carries (`yields "no response"`).
+#
+# The fifth variation of one bypass is evidence about the instrument. So the
+# direction reversed: prose is now an OUTPUT. Nothing parses the block, so there
+# is no character class to widen and no line shape to recognise — a byte SPEC
+# carries that this file does not produce is a diff, whatever it is made of.
+#
+# What that does NOT buy, stated plainly because the byte comparison is easy to
+# oversell: it makes SPEC's block faithful to this file. It says nothing about
+# whether this file is faithful to the runners — that is the manifest comparison
+# in check-fixture-execution.rb, and it is the half that needs a conformance run.
+# Nor does it check the classifications or the reasons; those stay judgement,
+# which is why §19 keeps its `[manual]` tag.
+
+require "yaml"
+
+module ZeroSkipRoster
+  RELATIVE_PATH = "spec/zero-skip-roster.yml"
+
+  # Hardcoded, and REQUIRED — all six, always. Deriving the set from whatever
+  # keys the file happens to carry is the absence bug this repo keeps relearning:
+  # a runner that quietly lost its section would shrink the expected set and both
+  # gates would go on reporting success over five, then four. The order is the
+  # render order, and it is the order SPEC has always used.
+  RUNNERS = %w[go python ruby typescript kotlin swift].freeze
+
+  LABELS = {
+    "go" => "Go", "python" => "Python", "ruby" => "Ruby",
+    "typescript" => "TypeScript", "kotlin" => "Kotlin", "swift" => "Swift"
+  }.freeze
+
+  SECTION_KEYS = %w[source classification note skips].freeze
+  SKIP_KEYS    = %w[case reason].freeze
+
+  Section = Struct.new(:runner, :source, :classification, :note, :skips, keyword_init: true)
+  Skip    = Struct.new(:name, :reason, keyword_init: true)
+
+  # Raised for anything the file could be other than a valid roster. Callers turn
+  # it into their own failure type; nothing recovers from it, because a roster
+  # that cannot be read is not a roster that says nothing — it is a gate with no
+  # source of truth, and both gates treat that as fatal rather than vacuous.
+  class Malformed < StandardError; end
+
+  class << self
+    # Returns { runner => Section } for all six runners, or raises Malformed.
+    def load(root)
+      path = File.join(root, RELATIVE_PATH)
+      raise Malformed, "#{RELATIVE_PATH} is missing" unless File.exist?(path)
+
+      # Encoding pinned, not left to the locale: the reasons carry em dashes and
+      # backticks, and under LC_ALL=C an unpinned read dies on the first
+      # non-ASCII byte instead of checking anything.
+      #
+      # `safe_load` with its defaults: no aliases, no arbitrary classes. Aliases
+      # are refused rather than merely unused — two runner sections sharing one
+      # anchor would edit as one section and read as two, and a roster whose
+      # entries change in pairs is worse than one that repeats itself.
+      #
+      # Rescuing Psych::Exception, not Psych::SyntaxError: the alias refusal is a
+      # sibling class, and left uncaught it exits non-zero with a Psych backtrace
+      # that names this loader instead of the file the reader has to fix.
+      doc = begin
+        YAML.safe_load(File.read(path, encoding: "UTF-8"), filename: RELATIVE_PATH)
+      rescue Psych::Exception => e
+        raise Malformed, "#{RELATIVE_PATH} is not valid YAML, or uses YAML this loader refuses " \
+                         "(anchors and aliases are refused on purpose): #{e.message}"
+      end
+
+      unless doc.is_a?(Hash)
+        raise Malformed, "#{RELATIVE_PATH}: expected a mapping at the top level, got #{describe(doc)}"
+      end
+
+      runners = doc["runners"]
+      unless runners.is_a?(Hash)
+        raise Malformed, "#{RELATIVE_PATH}: expected a `runners` mapping, got #{describe(runners)}"
+      end
+
+      missing = RUNNERS - runners.keys
+      unless missing.empty?
+        raise Malformed, "#{RELATIVE_PATH}: no section for #{missing.join(', ')}. All six runners " \
+                         "are required — a runner that skips nothing carries an empty `skips` list " \
+                         "and a note saying why. An absent section reads as unset and contributes " \
+                         "nothing to either comparison, which is how a runner's skips go unrecorded."
+      end
+
+      unknown = runners.keys - RUNNERS
+      unless unknown.empty?
+        raise Malformed, "#{RELATIVE_PATH}: section(s) for unknown runner(s): " \
+                         "#{unknown.map(&:to_s).sort.join(', ')}. Add them to RUNNERS in " \
+                         "#{File.basename(__FILE__)} or nothing compares them."
+      end
+
+      RUNNERS.to_h { |runner| [runner, section(runner, runners.fetch(runner))] }
+    end
+
+    # { runner => [case name] }, which is the projection the manifest comparison
+    # works in.
+    def case_names(roster)
+      roster.transform_values { |s| s.skips.map(&:name) }
+    end
+
+    # The exact lines SPEC.md must carry between the block markers — every
+    # section, then one trailing blank line, so the closing marker is preceded by
+    # a blank line the way the rest of the document's blocks are.
+    #
+    # Ordered by RUNNERS, never by the file's key order: the roster's claim is a
+    # set, and rendering in canonical order means reordering the YAML cannot
+    # produce a SPEC diff nobody meant to make.
+    def render_lines(roster)
+      RUNNERS.flat_map do |runner|
+        s = roster.fetch(runner)
+
+        # The qualifier list is what keeps the heading grammar to one rule
+        # instead of one per section shape. `none` is DERIVED from `skips` being
+        # empty rather than written down, so a section cannot claim to skip
+        # nothing while listing skips, and one that skips nothing cannot forget
+        # to say so.
+        qualifiers = []
+        qualifiers << "none" if s.skips.empty?
+        qualifiers << s.classification if s.classification
+        qualifiers << s.note if s.note
+
+        head = +"**#{LABELS.fetch(runner)}** (#{s.source})"
+        head << " — #{qualifiers.join('; ')}" unless qualifiers.empty?
+        head << (s.skips.empty? ? "." : ":")
+
+        [head, *s.skips.map { |skip| %(- "#{skip.name}" — #{skip.reason}) }, ""]
+      end
+    end
+
+    private
+
+    def section(runner, raw)
+      unless raw.is_a?(Hash)
+        raise Malformed, "#{RELATIVE_PATH}: `#{runner}` is #{describe(raw)}, not a mapping"
+      end
+
+      # Unknown keys are REFUSED, not ignored. A typo'd `skip:` or `cases:` would
+      # otherwise leave the section reading as "skips nothing" — a stale roster
+      # that passes, which is the failure this whole change exists to retire.
+      extra = raw.keys - SECTION_KEYS
+      unless extra.empty?
+        raise Malformed, "#{RELATIVE_PATH}: `#{runner}` carries unknown key(s) " \
+                         "#{extra.map(&:to_s).sort.join(', ')}; known keys are " \
+                         "#{SECTION_KEYS.join(', ')}. A misspelled key would silently contribute " \
+                         "nothing."
+      end
+
+      source = scalar(runner, raw, "source", required: true)
+      classification = scalar(runner, raw, "classification")
+      note = scalar(runner, raw, "note")
+
+      unless raw.key?("skips")
+        raise Malformed, "#{RELATIVE_PATH}: `#{runner}` has no `skips` key. Write `skips: []` and a " \
+                         "`note` saying why — an absent list and an empty one read the same to a " \
+                         "comparison, and only one of them was written on purpose."
+      end
+
+      skips = raw.fetch("skips")
+      unless skips.is_a?(Array)
+        raise Malformed, "#{RELATIVE_PATH}: `#{runner}.skips` is #{describe(skips)}, not a list"
+      end
+
+      entries = skips.each_with_index.map { |entry, i| skip(runner, entry, i) }
+
+      # Array#- removes EVERY occurrence, so a case named twice is invisible to
+      # the manifest comparison: both directions come back empty and the roster
+      # passes while carrying two possibly conflicting reasons for one case.
+      # Refused here rather than at the comparison so the render half cannot
+      # emit it either.
+      dupes = entries.map(&:name).tally.select { |_, n| n > 1 }.keys
+      unless dupes.empty?
+        raise Malformed, "#{RELATIVE_PATH}: `#{runner}` lists #{dupes.first.inspect} more than " \
+                         "once; the roster promises one line per runner × test, and a repeat is " \
+                         "invisible to the set comparison"
+      end
+
+      if entries.empty? && note.nil?
+        raise Malformed, "#{RELATIVE_PATH}: `#{runner}` skips nothing and says nothing. An empty " \
+                         "`skips` list needs a `note` explaining it — 'none' with no reason is " \
+                         "indistinguishable from a section somebody forgot to fill in."
+      end
+
+      Section.new(runner: runner, source: source, classification: classification, note: note,
+                  skips: entries)
+    end
+
+    def skip(runner, raw, index)
+      where = "#{RELATIVE_PATH}: `#{runner}.skips[#{index}]`"
+      raise Malformed, "#{where} is #{describe(raw)}, not a mapping" unless raw.is_a?(Hash)
+
+      extra = raw.keys - SKIP_KEYS
+      unless extra.empty?
+        raise Malformed, "#{where} carries unknown key(s) #{extra.map(&:to_s).sort.join(', ')}; " \
+                         "a skip is #{SKIP_KEYS.join(' + ')} and nothing else"
+      end
+
+      Skip.new(name: scalar(runner, raw, "case", required: true, where: "#{where} `case`"),
+               reason: scalar(runner, raw, "reason", required: true, where: "#{where} `reason`"))
+    end
+
+    # A present, non-empty, single-line string — or nil when the key is absent.
+    #
+    # An explicit `null` is refused rather than treated as absence: it is a key
+    # somebody wrote and left empty, which is a different act from omitting it,
+    # and the difference is exactly the one the empty-`skips` rule above turns
+    # on.
+    #
+    # Newlines are refused because every value here is rendered into ONE line.
+    # A multi-line note does not corrupt the byte comparison — SPEC would carry
+    # the newline too — but it would let a value spell a second heading or
+    # bullet, leaving a block that misdescribes its own shape while matching
+    # perfectly.
+    def scalar(runner, raw, key, required: false, where: nil)
+      where ||= "#{RELATIVE_PATH}: `#{runner}.#{key}`"
+      unless raw.key?(key)
+        raise Malformed, "#{where} is required" if required
+
+        return nil
+      end
+
+      value = raw.fetch(key)
+      raise Malformed, "#{where} is #{describe(value)}, not a string" unless value.is_a?(String)
+      raise Malformed, "#{where} is empty" if value.strip.empty?
+      raise Malformed, "#{where} spans more than one line; every value renders onto one" if value.include?("\n")
+
+      value
+    end
+
+    def describe(value)
+      value.nil? ? "null" : "a #{value.class}"
+    end
+  end
+end

--- a/scripts/zero_skip_roster.rb
+++ b/scripts/zero_skip_roster.rb
@@ -131,6 +131,21 @@ module ZeroSkipRoster
         raise Malformed, "#{RELATIVE_PATH}: expected a mapping at the top level, got #{describe(doc)}"
       end
 
+      # `runners` is the ONLY top-level key, for the reason every unknown-key
+      # rule below exists: reading `doc["runners"]` and ignoring the rest lets a
+      # misspelled or extra top-level mapping hold a whole roster that is
+      # visible in the file, rendered nowhere and compared against nothing.
+      # That is the same discarded claim the nested rules already refuse one
+      # level down, and it had no rule at the level where a reader would most
+      # plausibly paste one.
+      stray = doc.keys - %w[runners]
+      unless stray.empty?
+        raise Malformed, "#{RELATIVE_PATH}: unknown top-level key(s) " \
+                         "#{stray.map(&:to_s).sort.join(', ')}; `runners` is the only one. Roster " \
+                         "entries under any other key are read by nothing — neither gate would " \
+                         "ever see them, and the file would still look like it stated them."
+      end
+
       runners = doc["runners"]
       unless runners.is_a?(Hash)
         raise Malformed, "#{RELATIVE_PATH}: expected a `runners` mapping, got #{describe(runners)}"
@@ -341,11 +356,35 @@ module ZeroSkipRoster
     # and the difference is exactly the one the empty-`skips` rule above turns
     # on.
     #
-    # Newlines are refused because every value here is rendered into ONE line.
-    # A multi-line note does not corrupt the byte comparison — SPEC would carry
-    # the newline too — but it would let a value spell a second heading or
+    # Line breaks are refused because every value here is rendered into ONE
+    # line. A value that carries one does not corrupt the byte comparison — SPEC
+    # would carry it too — but it lets the value spell a second heading or
     # bullet, leaving a block that misdescribes its own shape while matching
-    # perfectly.
+    # perfectly, and a case name whose manifest projection is still the whole
+    # scalar. Which is the same false green, sourced from a character instead of
+    # from a parser.
+    #
+    # WRITTEN AS A CLASS, NOT AS A LIST OF CHARACTERS, and that is the whole
+    # point. This started as `include?("\n")`; review found a YAML
+    # double-quoted `\r`, which CommonMark also treats as a line ending.
+    # Answering that with `include?("\r")` would have been selector #2 on one
+    # predicate — the exact failure this change is a reaction to — and the next
+    # round brings U+2028, U+2029, U+0085, VT and FF, none of which anyone has
+    # written yet.
+    #
+    # So the rule is inverted the way the roster itself was: a value may contain
+    # no CONTROL character (\p{Cc}, which is every C0 and C1 code point — LF,
+    # CR, VT, FF, NEL, NUL, ESC) and no explicit line or paragraph separator
+    # (\p{Zl}, \p{Zp} — U+2028 and U+2029). There is no character class left to
+    # widen, and a spelling nobody has thought of is refused by default rather
+    # than admitted by default.
+    #
+    # It deliberately stops there. \p{Cf} (zero-width joiners, bidi controls,
+    # U+FEFF) is invisible but cannot break a line, and an invisible character
+    # in a case name fails the manifest comparison LOUDLY rather than passing
+    # it — a different failure, and not this rule's to close.
+    NOT_ONE_LINE_RE = /[\p{Cc}\p{Zl}\p{Zp}]/
+
     def scalar(runner, raw, key, required: false, where: nil)
       where ||= "#{RELATIVE_PATH}: `#{runner}.#{key}`"
       unless raw.key?(key)
@@ -357,7 +396,12 @@ module ZeroSkipRoster
       value = raw.fetch(key)
       raise Malformed, "#{where} is #{describe(value)}, not a string" unless value.is_a?(String)
       raise Malformed, "#{where} is empty" if value.strip.empty?
-      raise Malformed, "#{where} spans more than one line; every value renders onto one" if value.include?("\n")
+      if (offender = value[NOT_ONE_LINE_RE])
+        raise Malformed, "#{where} contains #{format('U+%04X', offender.ord)}, a control " \
+                         "character or line separator. Every value here renders onto ONE " \
+                         "line, and a value that can end a line spells a second heading or " \
+                         "bullet the block still matches byte for byte."
+      end
 
       value
     end

--- a/scripts/zero_skip_roster.rb
+++ b/scripts/zero_skip_roster.rb
@@ -385,6 +385,13 @@ module ZeroSkipRoster
     # it — a different failure, and not this rule's to close.
     NOT_ONE_LINE_RE = /[\p{Cc}\p{Zl}\p{Zp}]/
 
+    # Unicode whitespace at either boundary, and a value that is nothing else.
+    # \p{Space} rather than String#strip for the reason spelled out at the use
+    # site: strip is ASCII-only and misses NBSP, the Ogham space mark, the EN/EM
+    # quad family, NNBSP, MMSP and the ideographic space.
+    SURROUNDING_SPACE_RE = /\A\p{Space}|\p{Space}\z/
+    BLANK_RE             = /\A\p{Space}*\z/
+
     def scalar(runner, raw, key, required: false, where: nil)
       where ||= "#{RELATIVE_PATH}: `#{runner}.#{key}`"
       unless raw.key?(key)
@@ -395,21 +402,34 @@ module ZeroSkipRoster
 
       value = raw.fetch(key)
       raise Malformed, "#{where} is #{describe(value)}, not a string" unless value.is_a?(String)
-      raise Malformed, "#{where} is empty" if value.strip.empty?
+      raise Malformed, "#{where} is empty" if value.match?(BLANK_RE)
 
-      # Surrounding whitespace is REFUSED, not trimmed. Every value is rendered
+      # Surrounding whitespace is REFUSED, not trimmed. Every value renders
       # verbatim between characters the renderer supplies, so a leading or
       # trailing space is content: `note: "nothing to skip. "` renders
       # `nothing to skip. .`, and a trailing space on any value puts invisible
       # whitespace at the end of a line SPEC then matches byte for byte.
       #
-      # It also closes the terminator rule's one bypass rather than patching it.
-      # CLAUSE_TERMINATOR_RE anchors at the end, so a single trailing space hid
-      # the period from it — review found exactly that. Trimming here instead
-      # would silently rewrite what the author committed to a source of truth;
-      # refusing says which character to delete.
-      unless value == value.strip
-        raise Malformed, "#{where} is #{value.inspect}, which has leading or trailing whitespace. " \
+      # It also closes CLAUSE_TERMINATOR_RE's one bypass rather than patching
+      # it: that rule anchors at the end, so a single trailing space hid the
+      # period from it. Refused rather than trimmed, because trimming silently
+      # rewrites what the author committed to a source of truth, while refusing
+      # names the character to delete.
+      #
+      # MATCHED AS UNICODE WHITESPACE, and this is the second time the same
+      # lesson arrived. The rule was first written `value == value.strip`, and
+      # String#strip is ASCII-only: of the eight whitespace code points worth
+      # testing, it removes two. `note: "nothing to skip.\u00A0"` walked
+      # straight through and hid the period again — selector #1 on a predicate
+      # written to end a selector treadmill. \p{Space} is the property the
+      # question was always about.
+      #
+      # It stops at White_Space, so U+200B ZERO WIDTH SPACE is deliberately
+      # allowed: it is not whitespace, it cannot hide a neighbouring character
+      # from a rule that reads one, and refusing it belongs to a different
+      # question than this one.
+      if value.match?(SURROUNDING_SPACE_RE)
+        raise Malformed, "#{where} is #{value.inspect}, which begins or ends with whitespace. " \
                          "Values render verbatim, so the space is content: it lands in SPEC, and " \
                          "at the end of a value it hides the character before it from the rules " \
                          "that read one."

--- a/scripts/zero_skip_roster.rb
+++ b/scripts/zero_skip_roster.rb
@@ -396,6 +396,24 @@ module ZeroSkipRoster
       value = raw.fetch(key)
       raise Malformed, "#{where} is #{describe(value)}, not a string" unless value.is_a?(String)
       raise Malformed, "#{where} is empty" if value.strip.empty?
+
+      # Surrounding whitespace is REFUSED, not trimmed. Every value is rendered
+      # verbatim between characters the renderer supplies, so a leading or
+      # trailing space is content: `note: "nothing to skip. "` renders
+      # `nothing to skip. .`, and a trailing space on any value puts invisible
+      # whitespace at the end of a line SPEC then matches byte for byte.
+      #
+      # It also closes the terminator rule's one bypass rather than patching it.
+      # CLAUSE_TERMINATOR_RE anchors at the end, so a single trailing space hid
+      # the period from it — review found exactly that. Trimming here instead
+      # would silently rewrite what the author committed to a source of truth;
+      # refusing says which character to delete.
+      unless value == value.strip
+        raise Malformed, "#{where} is #{value.inspect}, which has leading or trailing whitespace. " \
+                         "Values render verbatim, so the space is content: it lands in SPEC, and " \
+                         "at the end of a value it hides the character before it from the rules " \
+                         "that read one."
+      end
       if (offender = value[NOT_ONE_LINE_RE])
         raise Malformed, "#{where} contains #{format('U+%04X', offender.ord)}, a control " \
                          "character or line separator. Every value here renders onto ONE " \

--- a/scripts/zero_skip_roster.rb
+++ b/scripts/zero_skip_roster.rb
@@ -57,6 +57,19 @@ module ZeroSkipRoster
   SECTION_KEYS = %w[source classification note skips].freeze
   SKIP_KEYS    = %w[case reason].freeze
 
+  # A qualifier (`classification`, `note`) is a CLAUSE, and the renderer owns
+  # every terminator around it: qualifiers are joined with "; " and the heading
+  # ends in ":" or ".". So a qualifier carrying its own renders `nothing to
+  # skip..` or `architectural.; a note:` — malformed prose that neither gate can
+  # object to afterwards, because both compare SPEC against exactly what the
+  # renderer produced, doubled period and all. The YAML said "a clause, NOT a
+  # sentence" in a comment; this is that sentence made enforceable.
+  #
+  # `reason` is deliberately NOT held to the mirror rule. It renders last on its
+  # own line with nothing appended, so it has nothing to double up against, and
+  # a reason ending in `)` or a backtick is ordinary rather than suspect.
+  CLAUSE_TERMINATOR_RE = /[.!?;:,]\z/
+
   Section = Struct.new(:runner, :source, :classification, :note, :skips, keyword_init: true)
   Skip    = Struct.new(:name, :reason, keyword_init: true)
 
@@ -84,8 +97,21 @@ module ZeroSkipRoster
       # Rescuing Psych::Exception, not Psych::SyntaxError: the alias refusal is a
       # sibling class, and left uncaught it exits non-zero with a Psych backtrace
       # that names this loader instead of the file the reader has to fix.
+      #
+      # The AST pass runs FIRST, and it is the one thing safe_load cannot do for
+      # us: duplicate mapping keys are legal YAML, and Psych keeps the LAST one
+      # silently. `go:` written twice, `skips:` written twice, `case:` written
+      # twice — each loads as a single value with the earlier claim discarded
+      # without a word. That is precisely the duplicate-section false green this
+      # change exists to retire, reappearing inside the instrument that replaced
+      # the parser: the discarded entry would sit in the source of truth,
+      # render nowhere, compare against nothing, and still read to a human as
+      # rostered.
+      text = File.read(path, encoding: "UTF-8")
+
       doc = begin
-        YAML.safe_load(File.read(path, encoding: "UTF-8"), filename: RELATIVE_PATH)
+        reject_duplicate_keys(Psych.parse(text, filename: RELATIVE_PATH), "")
+        YAML.safe_load(text, filename: RELATIVE_PATH)
       rescue Psych::Exception => e
         raise Malformed, "#{RELATIVE_PATH} is not valid YAML, or uses YAML this loader refuses " \
                          "(anchors and aliases are refused on purpose): #{e.message}"
@@ -155,6 +181,48 @@ module ZeroSkipRoster
 
     private
 
+    # Refuses a repeated mapping key anywhere in the document, reading the
+    # PARSER'S OWN structure rather than the text. A regex over the raw YAML
+    # would be the selector treadmill again — it would have to learn quoting,
+    # indentation, flow mappings, comments and block scalars just to say where a
+    # key is and whether it is one. The parser already knows all of that; the
+    # AST is where it says so, and a spelling it accepts as a key is a key by
+    # definition.
+    #
+    # Every level is covered by one walk, because "which levels matter" is the
+    # question that gets answered wrongly later: a second `runners:`, a second
+    # `go:`, a second `skips:` and a second `case:` are the same defect at four
+    # depths, and enumerating them would leave the fifth.
+    def reject_duplicate_keys(node, path)
+      case node
+      when Psych::Nodes::Stream, Psych::Nodes::Document
+        node.children.each { |child| reject_duplicate_keys(child, path) }
+      when Psych::Nodes::Sequence
+        node.children.each_with_index { |child, i| reject_duplicate_keys(child, "#{path}[#{i}]") }
+      when Psych::Nodes::Mapping
+        seen = {}
+        node.children.each_slice(2) do |key, value|
+          # A non-scalar key (a list or mapping used as a key) has no name to
+          # compare and cannot be one of ours; the unknown-key rules below
+          # refuse it by its own path. Recurse into its value regardless, so a
+          # duplicate nested under one is still found.
+          name = key.is_a?(Psych::Nodes::Scalar) ? key.value : nil
+          here = name.nil? ? "#{path}.?" : (path.empty? ? name : "#{path}.#{name}")
+
+          if name && seen.key?(name)
+            raise Malformed, "#{RELATIVE_PATH}: `#{here}` is written more than once " \
+                             "(lines #{seen.fetch(name)} and #{key.start_line + 1}). YAML allows " \
+                             "it and keeps only the LAST, so the earlier one would be discarded " \
+                             "in silence — a claim written into the roster that renders nowhere " \
+                             "and is compared against nothing."
+          end
+
+          seen[name] = key.start_line + 1 if name
+          reject_duplicate_keys(value, here)
+        end
+      end
+    end
+
     def section(runner, raw)
       unless raw.is_a?(Hash)
         raise Malformed, "#{RELATIVE_PATH}: `#{runner}` is #{describe(raw)}, not a mapping"
@@ -172,8 +240,8 @@ module ZeroSkipRoster
       end
 
       source = scalar(runner, raw, "source", required: true)
-      classification = scalar(runner, raw, "classification")
-      note = scalar(runner, raw, "note")
+      classification = clause(runner, raw, "classification")
+      note = clause(runner, raw, "note")
 
       unless raw.key?("skips")
         raise Malformed, "#{RELATIVE_PATH}: `#{runner}` has no `skips` key. Write `skips: []` and a " \
@@ -222,6 +290,21 @@ module ZeroSkipRoster
 
       Skip.new(name: scalar(runner, raw, "case", required: true, where: "#{where} `case`"),
                reason: scalar(runner, raw, "reason", required: true, where: "#{where} `reason`"))
+    end
+
+    # A `scalar` that is also a clause: see CLAUSE_TERMINATOR_RE for why the
+    # renderer cannot tolerate one that terminates itself.
+    def clause(runner, raw, key)
+      value = scalar(runner, raw, key)
+      if value&.match?(CLAUSE_TERMINATOR_RE)
+        raise Malformed, "#{RELATIVE_PATH}: `#{runner}.#{key}` ends in terminating punctuation " \
+                         "(#{value[-1].inspect}). It is a clause the renderer punctuates: it is " \
+                         "joined to the other qualifiers with `; ` and the heading is closed with " \
+                         "`.` or `:`, so #{value.inspect} renders as #{"#{value}.".inspect}. Drop " \
+                         "the final character."
+      end
+
+      value
     end
 
     # A present, non-empty, single-line string — or nil when the key is absent.

--- a/scripts/zero_skip_roster.rb
+++ b/scripts/zero_skip_roster.rb
@@ -409,18 +409,33 @@ module ZeroSkipRoster
     # \p{Space} rather than String#strip for the reason spelled out at the use
     # site: strip is ASCII-only and misses NBSP, the Ogham space mark, the EN/EM
     # quad family, NNBSP, MMSP and the ideographic space.
-    # An HTML comment delimiter, in either direction. Values render VERBATIM
-    # into a Markdown document, so a value carrying one is markup rather than
-    # text: `<!--` opens a comment that swallows the rest of the block and
-    # whatever follows it in SPEC, and a full `<!-- @zero-skip-roster:end -->`
-    # injects a doc-constant MARKER — the writer emits it and exits 0, and the
-    # next --check reports a structurally malformed document the writer built.
+    # RAW MARKUP: the two characters that can begin it in HTML.
     #
-    # Both were reported separately, and they are one mechanism: a value that
-    # can open or close an HTML comment. There is no third instance, because
-    # those are the only two delimiters. Marker injection is a strict subset
-    # rather than a rule of its own, since every marker is an HTML comment.
-    HTML_COMMENT_RE = /<!--|-->/
+    # This rule started as `/<!--|-->/`, closing two separately reported
+    # symptoms — a value opening a comment that swallows the rest of SPEC, and a
+    # value injecting a doc-constant marker the writer then emits. Review came
+    # back with `note: "<details>"`, which needs neither: values render VERBATIM
+    # into a Markdown document, GitHub renders raw HTML in it, and an open
+    # `<details>` collapses everything after it while both gates stay green.
+    #
+    # That is selector #2 on one predicate, and the answer is not `<details>`
+    # and then `<script>` and then `<iframe>`. Raw HTML has exactly two openers:
+    # `<` begins every tag and every comment, `&` begins every entity. Refusing
+    # both closes the class INCLUDING the spellings nobody has written, and it
+    # subsumes the comment rule rather than sitting beside it — one rule where
+    # there were two.
+    #
+    # It costs nothing: no value in the roster contains either character, and
+    # neither does the block they render to. A reason needing `<` can spell it
+    # in a backticked code span, which is how the rest of SPEC writes one.
+    #
+    # WHAT IT DOES NOT CLOSE, said plainly rather than implied. Markdown's own
+    # constructs — a `[link](url)`, a table pipe, an emphasis marker — still
+    # render, and this rule does not touch them. They cannot hide content or
+    # inject document structure the way raw HTML can, and refusing them would
+    # take the backticks the roster genuinely needs. If that boundary is ever
+    # wrong, the answer is a positive grammar for a value, not a third character.
+    RAW_MARKUP_RE = /[<&]/
     SURROUNDING_SPACE_RE = /\A\p{Space}|\p{Space}\z/
     BLANK_RE             = /\A\p{Space}*\z/
 
@@ -460,11 +475,12 @@ module ZeroSkipRoster
       # allowed: it is not whitespace, it cannot hide a neighbouring character
       # from a rule that reads one, and refusing it belongs to a different
       # question than this one.
-      if (markup = value[HTML_COMMENT_RE])
+      if (markup = value[RAW_MARKUP_RE])
         raise Malformed, "#{where} contains #{markup.inspect}. Values render verbatim into " \
-                         "Markdown, so an HTML comment delimiter is markup, not text: it hides " \
-                         "the rest of the block, or injects a doc-constant marker the writer " \
-                         "then emits and the next check refuses."
+                         "Markdown, so a character that opens raw HTML is markup, not text: it " \
+                         "hides the rest of the block behind a comment or an open element, or " \
+                         "injects a doc-constant marker the writer then emits and the next check " \
+                         "refuses. Write it inside a backticked code span."
       end
 
       if value.match?(SURROUNDING_SPACE_RE)

--- a/scripts/zero_skip_roster.rb
+++ b/scripts/zero_skip_roster.rb
@@ -107,10 +107,20 @@ module ZeroSkipRoster
       # the parser: the discarded entry would sit in the source of truth,
       # render nowhere, compare against nothing, and still read to a human as
       # rostered.
+      #
+      # A second YAML DOCUMENT is the same defect one level out, and it is
+      # breach 2 of the old reader — "a second complete roster block silently
+      # ignored" — reproduced exactly: `safe_load` returns the first document
+      # and discards the rest without a word, so a roster appended after a `---`
+      # would render nowhere and be compared against nothing. Found by asking
+      # what else could be written into this file and go unread, which is the
+      # question the prose reader was never asked five times running.
       text = File.read(path, encoding: "UTF-8")
 
       doc = begin
-        reject_duplicate_keys(Psych.parse(text, filename: RELATIVE_PATH), "")
+        stream = Psych.parse_stream(text, filename: RELATIVE_PATH)
+        reject_extra_documents(stream)
+        reject_duplicate_keys(stream, "")
         YAML.safe_load(text, filename: RELATIVE_PATH)
       rescue Psych::Exception => e
         raise Malformed, "#{RELATIVE_PATH} is not valid YAML, or uses YAML this loader refuses " \
@@ -180,6 +190,23 @@ module ZeroSkipRoster
     end
 
     private
+
+    # One document, or none. `safe_load` reads the FIRST and drops the rest in
+    # silence, so a second roster after a `---` is a second complete claim
+    # nothing reads — the old reader's duplicate-block breach, in a file format
+    # instead of in prose.
+    #
+    # ZERO documents is deliberately allowed through rather than caught here: an
+    # empty file has nothing hidden in it, and the top-level mapping rule below
+    # already names it exactly ("expected a mapping at the top level, got null").
+    # Two errors for one input would just be the less specific one winning.
+    def reject_extra_documents(stream)
+      return if stream.children.length <= 1
+
+      raise Malformed, "#{RELATIVE_PATH} holds #{stream.children.length} YAML documents; a roster " \
+                       "is one. Everything after the first `---` is dropped on load, so a second " \
+                       "roster written here would render nowhere and be compared against nothing."
+    end
 
     # Refuses a repeated mapping key anywhere in the document, reading the
     # PARSER'S OWN structure rather than the text. A regex over the raw YAML

--- a/scripts/zero_skip_roster.rb
+++ b/scripts/zero_skip_roster.rb
@@ -120,7 +120,7 @@ module ZeroSkipRoster
       doc = begin
         stream = Psych.parse_stream(text, filename: RELATIVE_PATH)
         reject_extra_documents(stream)
-        reject_duplicate_keys(stream, "")
+        check_mapping_keys(stream, "")
         YAML.safe_load(text, filename: RELATIVE_PATH)
       rescue Psych::Exception => e
         raise Malformed, "#{RELATIVE_PATH} is not valid YAML, or uses YAML this loader refuses " \
@@ -235,12 +235,12 @@ module ZeroSkipRoster
     # question that gets answered wrongly later: a second `runners:`, a second
     # `go:`, a second `skips:` and a second `case:` are the same defect at four
     # depths, and enumerating them would leave the fifth.
-    def reject_duplicate_keys(node, path)
+    def check_mapping_keys(node, path)
       case node
       when Psych::Nodes::Stream, Psych::Nodes::Document
-        node.children.each { |child| reject_duplicate_keys(child, path) }
+        node.children.each { |child| check_mapping_keys(child, path) }
       when Psych::Nodes::Sequence
-        node.children.each_with_index { |child, i| reject_duplicate_keys(child, "#{path}[#{i}]") }
+        node.children.each_with_index { |child, i| check_mapping_keys(child, "#{path}[#{i}]") }
       when Psych::Nodes::Mapping
         seen = {}
         node.children.each_slice(2) do |key, value|
@@ -251,6 +251,26 @@ module ZeroSkipRoster
           name = key.is_a?(Psych::Nodes::Scalar) ? key.value : nil
           here = name.nil? ? "#{path}.?" : (path.empty? ? name : "#{path}.#{name}")
 
+          # A MERGE key, which is the duplicate-key defect wearing a different
+          # key. `<<: {skips: [...]}` beside a `skips:` is resolved by Psych
+          # before the Hash exists and the explicit field wins, so the merged
+          # entries vanish — authored roster content rendered nowhere and
+          # compared against nothing. The rule above cannot see it: `<<` and
+          # `skips` are two different keys in the AST, which is exactly why it
+          # needs saying separately rather than being assumed covered.
+          #
+          # Refused rather than resolved, for the reason aliases are: a section
+          # that inherits from somewhere else edits as one thing and reads as
+          # two, and this roster is short enough that repetition is cheaper than
+          # indirection.
+          if name == "<<"
+            raise Malformed, "#{RELATIVE_PATH}: `#{path}` uses a YAML merge key (`<<`) on line " \
+                             "#{key.start_line + 1}. Merges are refused: the merged keys are " \
+                             "resolved away before anything checks them, and any field the " \
+                             "section also states explicitly silently wins over the merged one. " \
+                             "Write the section out."
+          end
+
           if name && seen.key?(name)
             raise Malformed, "#{RELATIVE_PATH}: `#{here}` is written more than once " \
                              "(lines #{seen.fetch(name)} and #{key.start_line + 1}). YAML allows " \
@@ -260,7 +280,7 @@ module ZeroSkipRoster
           end
 
           seen[name] = key.start_line + 1 if name
-          reject_duplicate_keys(value, here)
+          check_mapping_keys(value, here)
         end
       end
     end
@@ -389,6 +409,18 @@ module ZeroSkipRoster
     # \p{Space} rather than String#strip for the reason spelled out at the use
     # site: strip is ASCII-only and misses NBSP, the Ogham space mark, the EN/EM
     # quad family, NNBSP, MMSP and the ideographic space.
+    # An HTML comment delimiter, in either direction. Values render VERBATIM
+    # into a Markdown document, so a value carrying one is markup rather than
+    # text: `<!--` opens a comment that swallows the rest of the block and
+    # whatever follows it in SPEC, and a full `<!-- @zero-skip-roster:end -->`
+    # injects a doc-constant MARKER — the writer emits it and exits 0, and the
+    # next --check reports a structurally malformed document the writer built.
+    #
+    # Both were reported separately, and they are one mechanism: a value that
+    # can open or close an HTML comment. There is no third instance, because
+    # those are the only two delimiters. Marker injection is a strict subset
+    # rather than a rule of its own, since every marker is an HTML comment.
+    HTML_COMMENT_RE = /<!--|-->/
     SURROUNDING_SPACE_RE = /\A\p{Space}|\p{Space}\z/
     BLANK_RE             = /\A\p{Space}*\z/
 
@@ -428,6 +460,13 @@ module ZeroSkipRoster
       # allowed: it is not whitespace, it cannot hide a neighbouring character
       # from a rule that reads one, and refusing it belongs to a different
       # question than this one.
+      if (markup = value[HTML_COMMENT_RE])
+        raise Malformed, "#{where} contains #{markup.inspect}. Values render verbatim into " \
+                         "Markdown, so an HTML comment delimiter is markup, not text: it hides " \
+                         "the rest of the block, or injects a doc-constant marker the writer " \
+                         "then emits and the next check refuses."
+      end
+
       if value.match?(SURROUNDING_SPACE_RE)
         raise Malformed, "#{where} is #{value.inspect}, which begins or ends with whitespace. " \
                          "Values render verbatim, so the space is content: it lands in SPEC, and " \

--- a/scripts/zero_skip_roster.rb
+++ b/scripts/zero_skip_roster.rb
@@ -426,8 +426,14 @@ module ZeroSkipRoster
     # there were two.
     #
     # It costs nothing: no value in the roster contains either character, and
-    # neither does the block they render to. A reason needing `<` can spell it
-    # in a backticked code span, which is how the rest of SPEC writes one.
+    # neither does the block they render to.
+    #
+    # A value that wants one must be REPHRASED, not quoted. This rule reads the
+    # scalar, so backticks around the character do not exempt it — a code span
+    # would in fact render it harmlessly, but recognising that means teaching
+    # this rule where Markdown code spans begin and end, which is a parser, in
+    # the file whose entire argument is that there is no parser. Refusing the
+    # character and saying so is the cheaper honest answer.
     #
     # WHAT IT DOES NOT CLOSE, said plainly rather than implied. Markdown's own
     # constructs — a `[link](url)`, a table pipe, an emphasis marker — still
@@ -480,7 +486,8 @@ module ZeroSkipRoster
                          "Markdown, so a character that opens raw HTML is markup, not text: it " \
                          "hides the rest of the block behind a comment or an open element, or " \
                          "injects a doc-constant marker the writer then emits and the next check " \
-                         "refuses. Write it inside a backticked code span."
+                         "refuses. Rephrase the value: this rule reads the scalar, not the " \
+                         "rendered Markdown, so backticks around the character do not help it."
       end
 
       if value.match?(SURROUNDING_SPACE_RE)

--- a/spec/doc-constants.json
+++ b/spec/doc-constants.json
@@ -2,7 +2,11 @@
   "$comment": [
     "Policy for scripts/sync-doc-constants.rb (make doc-constants-check).",
     "",
-    "THE GENERAL RULE, so a seventh kind does not have to be inferred from six examples: anything DERIVED from a machine-readable source and restated in prose gets a marker and an exact count here. The marker says 'this span is a claim about the current value of that source'; the count says 'this file carries exactly N such claims', so deleting one fails instead of silencing the check. A scalar claim is a LINE kind and the writer keeps it current. A claim the writer cannot author is a BLOCK kind — a table whose rows carry a human-written column (an assertion type's meaning, a fixture's owning spec sections) is the recurring shape — and --check is what holds it, by set comparison against the derived source. Whichever kind it is, the checker must fail when EITHER side parses to nothing: with both vacuity guards removed, an emptied table compared against an empty source is trivially satisfied and the gate exits 0, which is the one hole a set comparison cannot close on its own. Prose that merely mentions a value it is not claiming stays unmarked; see the A/B rule below and in AGENTS.md.",
+    "THE GENERAL RULE, so the next kind does not have to be inferred from the existing ones: anything DERIVED from a machine-readable source and restated in prose gets a marker and an exact count here. The marker says 'this span is a claim about the current value of that source'; the count says 'this file carries exactly N such claims', so deleting one fails instead of silencing the check. LINE vs BLOCK is about the SPAN — one line, or a region between :begin/:end — and nothing else. WRITABLE is the separate question, and it has one test: can the writer author every character of the span? A scalar constant it can, and does. A table whose rows carry a human-written column (an assertion type's meaning, a fixture's owning spec sections) it cannot, so --check holds those by set comparison against the derived source and --write leaves them alone. Whichever kind it is, the checker must fail when EITHER side parses to nothing: with both vacuity guards removed, an emptied table compared against an empty source is trivially satisfied and the gate exits 0, which is the one hole a set comparison cannot close on its own. Prose that merely mentions a value it is not claiming stays unmarked; see the A/B rule below and in AGENTS.md.",
+    "",
+    "This file used to state that rule as 'a claim the writer cannot author is a BLOCK kind', which conflated the two axes because every block kind happened to be unwritable. @zero-skip-roster is the block kind that is not, and the distinction is now stated above rather than implied by a coincidence.",
+    "",
+    "zero-skip-roster — SPEC §19's Zero-Skip roster, RENDERED from spec/zero-skip-roster.yml and compared for BYTE equality. It is the first writable block kind, and it is writable for the general rule's reason: no column of it is hand-written, so the writer can author the whole span. It is also the only kind checked with no parser behind it. Its predecessor read the roster back out of SPEC's prose on the argument that a misreading always surfaces as a mismatch and never as a passing comparison; that argument was breached five times, each fix a new selector for a new spelling (an unrecognised list marker, a duplicate block, a duplicate entry, a payload riding a blockquote or table row, an ASCII-only quote test that curly quotes and backticks walk through). String equality has no selectors to widen: every one of those is now text inside a generated block, and text the renderer did not produce is a diff. What it buys is that SPEC's block is faithful to the YAML — NOT that the YAML is faithful to the runners, which is scripts/check-fixture-execution.rb's set comparison against the execution manifests, and which needs a conformance run this gate cannot have. Vacuity is closed in the loader rather than the checker: all six runner sections are required and each renders at least a heading, so neither an emptied YAML nor an emptied block can be read as agreement.",
     "",
     "markerCounts — the EXACT number of spans each file carries for a given HTML",
     "comment. Any deviation fails: too few means a claim was deleted or unmarked,",
@@ -51,6 +55,9 @@
       "SPEC.md": 1
     },
     "fixture-section-map": {
+      "SPEC.md": 1
+    },
+    "zero-skip-roster": {
       "SPEC.md": 1
     },
     "operation-count": {

--- a/spec/zero-skip-roster.yml
+++ b/spec/zero-skip-roster.yml
@@ -55,8 +55,9 @@
 # and the block still matches byte for byte. `<` and `&` are the sharpest,
 # because they are markup rather than text: they open an HTML comment or element
 # that hides everything after it, or inject a marker the writer emits and the
-# next check refuses. A reason that genuinely needs one writes it inside a
-# backticked code span, the way the rest of SPEC does.
+# next check refuses. A value that wants one must be REPHRASED: the rule reads
+# the scalar rather than the rendered Markdown, so backticks around the
+# character do not exempt it.
 #
 # The character rules are written as CLASSES rather than lists of spellings, so
 # there is nothing to add when the next one is thought of.

--- a/spec/zero-skip-roster.yml
+++ b/spec/zero-skip-roster.yml
@@ -41,15 +41,23 @@
 # replaced a parser to retire, and it is checked against the parsed document
 # rather than the loaded Hash, which no longer knows the duplicate happened.
 #
-# For the same reason this file is ONE YAML document, `runners` is its ONLY
-# top-level key, and no value may contain a control character or a Unicode
-# line/paragraph separator. Those are one failure in four costumes: text after a
-# second `---`, text under a misspelled top-level key, and text after a bare CR
-# or U+2028 inside a quoted scalar are each a claim written here that renders
-# nowhere, or renders as a line the roster never stated. Which is precisely how
-# the prose reader used to ignore a second roster block. The last of them is
-# written as a CLASS rather than a list of characters, so there is no further
-# spelling to add when the next one is thought of.
+# The same reasoning runs through every other rule the loader enforces, and they
+# are one failure in several costumes rather than a list to memorise. This file
+# is ONE YAML document; `runners` is its ONLY top-level key; merge keys (`<<`)
+# are refused alongside aliases; and no value may contain a control character, a
+# Unicode line or paragraph separator, or an HTML comment delimiter.
+#
+# Text after a second `---`, text under a misspelled top-level key, and entries
+# merged in by a `<<` that an explicit field then overrides are each a claim
+# written here and read by nothing — which is precisely how the prose reader used
+# to ignore a second roster block. A bare CR or U+2028 inside a quoted scalar is
+# the same thing from the other side: it renders a line the roster never stated,
+# and the block still matches byte for byte. `<!--` is the sharpest, because it
+# is markup rather than text: it hides the rest of the block, or injects a marker
+# the writer emits and the next check refuses.
+#
+# The character rules are written as CLASSES rather than lists of spellings, so
+# there is nothing to add when the next one is thought of.
 #
 #   source          Required. The runner file and skip constant, rendered
 #                   verbatim inside the parentheses of the heading. Kotlin's and

--- a/spec/zero-skip-roster.yml
+++ b/spec/zero-skip-roster.yml
@@ -34,6 +34,13 @@
 # read as "not stated yet" and contribute nothing to either comparison, which is
 # how a runner's skips go unrecorded.
 #
+# A key written TWICE is refused at every level — a repeated runner section, a
+# repeated field, a repeated `case`. YAML allows it and keeps only the last, so
+# the earlier claim would be discarded in silence: written here, rendered
+# nowhere, compared against nothing. That is the same false green this file
+# replaced a parser to retire, and it is checked against the parsed document
+# rather than the loaded Hash, which no longer knows the duplicate happened.
+#
 #   source          Required. The runner file and skip constant, rendered
 #                   verbatim inside the parentheses of the heading. Kotlin's and
 #                   Swift's carry a clause rather than a constant name, because
@@ -44,10 +51,15 @@
 #                   roster is stale.
 #
 #   classification  Optional. One word for why the skips exist at all
-#                   (`architectural`); omitted where the reasons carry it.
+#                   (`architectural`); omitted where the reasons carry it. A
+#                   clause, like `note` below, and held to the same rule.
 #
 #   note            Optional. A clause, NOT a sentence: the renderer supplies
-#                   the terminating punctuation, so write it without one.
+#                   the terminating punctuation, so write it without one. This
+#                   is ENFORCED, not merely asked for — a qualifier ending in
+#                   `. ! ? ; : ,` is refused by the loader, because
+#                   `nothing to skip.` renders `nothing to skip..` and no gate
+#                   downstream can object to prose the renderer itself produced.
 #
 #   skips           Required, possibly empty. Each entry is
 #                   { case: <exact case name>, reason: <complete sentence> }.

--- a/spec/zero-skip-roster.yml
+++ b/spec/zero-skip-roster.yml
@@ -41,10 +41,15 @@
 # replaced a parser to retire, and it is checked against the parsed document
 # rather than the loaded Hash, which no longer knows the duplicate happened.
 #
-# For the same reason this file is ONE YAML document. Everything after a second
-# `---` is dropped on load, so a second roster written there would be a complete
-# claim nothing ever reads — which is precisely how the prose reader used to
-# ignore a second roster block.
+# For the same reason this file is ONE YAML document, `runners` is its ONLY
+# top-level key, and no value may contain a control character or a Unicode
+# line/paragraph separator. Those are one failure in four costumes: text after a
+# second `---`, text under a misspelled top-level key, and text after a bare CR
+# or U+2028 inside a quoted scalar are each a claim written here that renders
+# nowhere, or renders as a line the roster never stated. Which is precisely how
+# the prose reader used to ignore a second roster block. The last of them is
+# written as a CLASS rather than a list of characters, so there is no further
+# spelling to add when the next one is thought of.
 #
 #   source          Required. The runner file and skip constant, rendered
 #                   verbatim inside the parentheses of the heading. Kotlin's and

--- a/spec/zero-skip-roster.yml
+++ b/spec/zero-skip-roster.yml
@@ -1,0 +1,143 @@
+# SPEC §19 Zero-Skip roster — the source of truth for what each conformance
+# runner does not execute.
+#
+# Purpose: SPEC §19 claims to enumerate "every skip a default (mock-mode)
+# conformance run reports, one line per runner × test, verbatim from the
+# runners' skip mechanisms". That roster used to live in SPEC.md as prose and be
+# READ BACK OUT of it by a parser. It lives here instead, and SPEC's block is
+# now RENDERED from this file — the prose is an output, not an input.
+#
+# What enforces it, in two halves that answer different questions:
+#
+#   scripts/sync-doc-constants.rb (`make doc-constants-check`) renders the
+#   <!-- @zero-skip-roster:begin/end --> block in SPEC.md from this file and
+#   requires the text between those markers to be BYTE-IDENTICAL. `--write`
+#   (reached from `make generate` via sync-api-version) rewrites it. Nothing
+#   parses the block, so nothing can misread it: a character SPEC carries that
+#   this file does not produce is a diff, whatever it is made of.
+#
+#   scripts/check-fixture-execution.rb (`make check-fixture-execution`) compares
+#   the `skips` below, per runner, for set equality against the execution
+#   manifests the runners write (conformance/manifests/<runner>.json). A skip
+#   added to a runner without an entry here, or an entry left behind after a gap
+#   closes, fails the build. It needs a conformance run; the block check does
+#   not, which is why the two live in different gates.
+#
+# The CLASSIFICATION and the reasons stay judgement — nothing asserts them, and
+# that half is why §19 keeps its `[manual]` tag.
+#
+# --- Entry semantics ----------------------------------------------------------
+#
+# `runners` holds exactly six keys — go, python, ruby, typescript, kotlin,
+# swift — and every one is required. A runner is not omitted when it skips
+# nothing; it carries an empty `skips` list and says why. An absent key would
+# read as "not stated yet" and contribute nothing to either comparison, which is
+# how a runner's skips go unrecorded.
+#
+#   source          Required. The runner file and skip constant, rendered
+#                   verbatim inside the parentheses of the heading. Kotlin's and
+#                   Swift's carry a clause rather than a constant name, because
+#                   their skip constants are EMPTY and their single entry
+#                   arrives from the `link-header` tag branch. That distinction
+#                   is load-bearing documentation: a reader who greps
+#                   `KOTLIN_SKIPS` finds nothing and must not conclude the
+#                   roster is stale.
+#
+#   classification  Optional. One word for why the skips exist at all
+#                   (`architectural`); omitted where the reasons carry it.
+#
+#   note            Optional. A clause, NOT a sentence: the renderer supplies
+#                   the terminating punctuation, so write it without one.
+#
+#   skips           Required, possibly empty. Each entry is
+#                   { case: <exact case name>, reason: <complete sentence> }.
+#                   `case` must match the fixture case name byte for byte — it
+#                   is what the manifest comparison keys on. `reason` is
+#                   rendered verbatim after an em dash, so it carries its own
+#                   final period.
+#
+# An empty `skips` renders as "— none" in the heading. That word is DERIVED, not
+# written: a section cannot claim to skip nothing while listing skips, and one
+# that skips nothing cannot forget to say so.
+#
+# --- Rendering ----------------------------------------------------------------
+#
+# One section per runner, in the order of scripts/zero_skip_roster.rb's RUNNERS,
+# which is the order SPEC has always used. This file's key order is irrelevant
+# to the output; do not rely on it.
+#
+#   **<Label>** (<source>)[ — <qualifiers joined by "; ">]<":" or ".">
+#   - "<case>" — <reason>
+#
+# where the qualifiers are, in order: `none` when there are no skips,
+# `classification`, `note`. The terminator is ":" when skips follow and "." when
+# none do.
+#
+# Lines are not wrapped. A wrapped heading would be a second rendering rule to
+# get byte-identical, and the bullets have never been wrapped either.
+
+runners:
+  go:
+    source: "`conformance/runner/go/main.go` `goSDKSkips`"
+    classification: architectural
+    note: "same-origin logic is covered by `TestIsSameOrigin` unit tests"
+    skips:
+      - case: "Mixed-case host and explicit default port stay on the mocked origin"
+        reason: "Go runner dials `configOverrides.baseUrl` directly; its `httptest` mock owns its origin, so origin-interception normalization does not apply."
+      - case: "Bracketed IPv6 loopback origin stays on the mocked origin"
+        reason: "same as above."
+
+  # Python's `SKIPS` is genuinely empty, and the note is the whole content of
+  # this section: the `link-header` fixture RUNS here — only its `requestCount`
+  # assertion is suppressed — so it is not a skip and must not be rostered as
+  # one.
+  python:
+    source: "`conformance/runner/python/runner.py` `SKIPS`"
+    note: "the `link-header` fixture above runs; only its `requestCount` assertion is suppressed"
+    skips: []
+
+  ruby:
+    source: "`conformance/runner/ruby/runner.rb` `RUBY_SKIPS`"
+    skips:
+      - case: "PUT operation is naturally idempotent"
+        reason: "GET-only retry (waiver 2B.3)."
+      - case: "DELETE operation is naturally idempotent"
+        reason: "GET-only retry (waiver 2B.3)."
+      - case: "POST operation retries when marked idempotent"
+        reason: "GET-only retry (waiver 2B.3)."
+      - case: "Subscribe POST retries when marked idempotent"
+        reason: "GET-only retry (waiver 2B.3)."
+      - case: "CreateBookmark POST retries when marked idempotent"
+        reason: "GET-only retry (waiver 2B.3)."
+      - case: "DeleteBookmark DELETE retries when marked idempotent"
+        reason: "GET-only retry (waiver 2B.3)."
+      - case: "UpdateMyNote PUT retries when marked idempotent"
+        reason: "GET-only retry (waiver 2B.3)."
+      - case: "UpdateCalendar PUT retries when marked idempotent"
+        reason: "GET-only retry (waiver 2B.3)."
+      - case: "PrioritizeAssignment POST retries when marked idempotent"
+        reason: "GET-only retry (waiver 2B.3)."
+      - case: "DeprioritizeAssignment DELETE retries when marked idempotent"
+        reason: "GET-only retry (waiver 2B.3)."
+      - case: "Network error on an idempotent POST is retried then succeeds"
+        reason: "GET-only network retry (waiver 2B.3)."
+
+  typescript:
+    source: "`conformance/runner/typescript/runner.test.ts` `TS_SDK_SKIPS`"
+    skips:
+      - case: "Large integer IDs preserved without precision loss"
+        reason: "`Number` is 53-bit (waiver 1B.6)."
+
+  kotlin:
+    source: "`kotlin/conformance/.../Main.kt` — `KOTLIN_SKIPS` is empty; the entry below comes from the `link-header` tag branch"
+    classification: architectural
+    skips:
+      - case: "List operation returns first page with Link header"
+        reason: "the SDK auto-paginates, and its status model reports the last consumed response, so a one-response queue yields \"no response\" (see the tag-branch discussion above)."
+
+  swift:
+    source: "`conformance/runner/swift/.../Runner.swift` — `temporarySkips` is empty; the entry below comes from the `link-header` tag branch"
+    classification: architectural
+    skips:
+      - case: "List operation returns first page with Link header"
+        reason: "same as Kotlin: auto-pagination plus a last-consumed-response status model."

--- a/spec/zero-skip-roster.yml
+++ b/spec/zero-skip-roster.yml
@@ -45,16 +45,18 @@
 # are one failure in several costumes rather than a list to memorise. This file
 # is ONE YAML document; `runners` is its ONLY top-level key; merge keys (`<<`)
 # are refused alongside aliases; and no value may contain a control character, a
-# Unicode line or paragraph separator, or an HTML comment delimiter.
+# Unicode line or paragraph separator, or `<` or `&`.
 #
 # Text after a second `---`, text under a misspelled top-level key, and entries
 # merged in by a `<<` that an explicit field then overrides are each a claim
 # written here and read by nothing — which is precisely how the prose reader used
 # to ignore a second roster block. A bare CR or U+2028 inside a quoted scalar is
 # the same thing from the other side: it renders a line the roster never stated,
-# and the block still matches byte for byte. `<!--` is the sharpest, because it
-# is markup rather than text: it hides the rest of the block, or injects a marker
-# the writer emits and the next check refuses.
+# and the block still matches byte for byte. `<` and `&` are the sharpest,
+# because they are markup rather than text: they open an HTML comment or element
+# that hides everything after it, or inject a marker the writer emits and the
+# next check refuses. A reason that genuinely needs one writes it inside a
+# backticked code span, the way the rest of SPEC does.
 #
 # The character rules are written as CLASSES rather than lists of spellings, so
 # there is nothing to add when the next one is thought of.

--- a/spec/zero-skip-roster.yml
+++ b/spec/zero-skip-roster.yml
@@ -41,6 +41,11 @@
 # replaced a parser to retire, and it is checked against the parsed document
 # rather than the loaded Hash, which no longer knows the duplicate happened.
 #
+# For the same reason this file is ONE YAML document. Everything after a second
+# `---` is dropped on load, so a second roster written there would be a complete
+# claim nothing ever reads — which is precisely how the prose reader used to
+# ignore a second roster block.
+#
 #   source          Required. The runner file and skip constant, rendered
 #                   verbatim inside the parentheses of the heading. Kotlin's and
 #                   Swift's carry a clause rather than a constant name, because


### PR DESCRIPTION
Based on `main`. **Supersedes #745's roster-reader hardening** — see the last
section; this is not stacked on it.

SPEC §19's Zero-Skip roster moves into `spec/zero-skip-roster.yml`, SPEC's block
becomes **generated** from it, and `parse_roster` — the reader that pulled the
roster back out of SPEC's prose — is **deleted**. Prose is an output now.

## Why delete rather than harden

`parse_roster` was defended by one invariant: *every misreading surfaces as a
set mismatch, never as a passing comparison*. That invariant has been breached
five times:

1. only `- ` bullets were recognised, so a stale entry written `* `, `+ `, `1. `
   or indented was skipped (fixed by inverting the default, `4ce947b6`);
2. a second, complete roster block was silently ignored;
3. a case listed twice under one runner is invisible to `Array#-` — both diffs
   come back empty;
4. blockquote / table-row / HTML-comment payloads carried a claim past the
   list-marker rule;
5. `include?('"')` is ASCII-only, so `> - “curly stale” — x.` and
   `` | Go | `backtick stale` | x | `` pass green — **and** a canonical bullet
   with a second quoted name (`- "real" — also supersedes "stale ghost"`) drops
   the second name. The live Kotlin entry already carries a second quoted string
   (`yields "no response"`), so this is not hypothetical.

1 through 3 are answered on `main`, each by one more selector. **4 and 5 were
verified directly against the committed reader, not reasoned about**, and #745
answers them the same way, with two more selectors.

Per AGENTS.md, the fifth variation of one bypass is evidence about the
instrument, not a queue of tasks. Deleting the reader removes the class: there
is no character class to widen and no line shape to recognise.

## What replaces it

- **`spec/zero-skip-roster.yml`** is the source of truth — six required runner
  sections, 16 entries, reasons carried over verbatim. Modelled on
  `spec/fixtures/manifest.yaml`, header comment and all.
- **`scripts/zero_skip_roster.rb`** loads, validates and renders it. Shared,
  because both gates have to agree on what the file means.
- **`make doc-constants-check`** renders the block and requires the text between
  `<!-- @zero-skip-roster:begin/end -->` to be **byte-identical**. String
  equality only — no parsing, no regexes over the block. `--write` (reached from
  `make generate` via `sync-api-version`) rewrites it.
- **`make check-fixture-execution`** compares the YAML's case names, per runner,
  against the execution manifests — same set-equality semantics, same
  `[file, name]` manifest projection, unchanged on purpose.

This is the **first writable BLOCK kind**, which contradicted a rule
`spec/doc-constants.json` stated outright ("a claim the writer cannot author is
a BLOCK kind"). That conflated two axes because every block kind happened to be
unwritable. The `$comment` now separates them: LINE vs BLOCK is about the span;
writable is "can the writer author every character of it", which here it can.

## What the byte comparison does and does not buy

It makes SPEC's block faithful to the YAML. That is all it makes.

- It says **nothing** about whether the YAML is faithful to the runners — that
  is the manifest comparison, and it needs a conformance run, which is why the
  two halves live in different gates.
- It does **not** check the classifications or the reasons. They stay judgement,
  which is why §19 keeps its `[manual]` tag.
- Vacuity is closed in the loader, not the comparison: all six runner sections
  are required and each renders at least a heading, so neither an emptied YAML
  nor an emptied block can read as agreement. Both are committed self-test cases
  rather than a guard that cannot fire.
- One guarantee changes hands rather than disappearing: the old reader failed
  when SPEC carried no roster block at all. That now comes from
  `spec/doc-constants.json`, which declares `SPEC.md: 1` for this marker — the
  same protection every other marked span has, and it fails the same way if the
  block is deleted. Deleting the block, the marker and the declaration together
  still silences it, exactly as it does for every existing kind.
- The old bypasses are now just text inside a generated block. A curly-quoted
  stale entry smuggled between the markers is a diff like any other — exercised
  as a self-test case, not asserted in a comment.

## Review round: the defect the replacement reintroduced

Both bots found it independently, and they were right. `Psych.safe_load` accepts
**duplicate mapping keys** and keeps only the LAST, so two `go:` sections, two
`skips:` fields or two `case:` fields load as one value with the earlier claim
discarded in silence — written into the source of truth, rendered nowhere,
compared against nothing, and still reading to a human as rostered. That is the
duplicate-section false green this whole change exists to retire, reappearing
inside the instrument that replaced the parser.

Refused from the **parsed AST**, not by a regex over the text — a regex would be
the selector treadmill again, having to learn quoting, indentation, flow
mappings, comments and block scalars just to say where a key is. One walk covers
every depth, because "which levels matter" is the question that gets answered
wrongly later. The error names both line numbers.

Self-review of that fix then found a third, unreported by either bot and the
same class one level out: `safe_load` returns the **first YAML document** and
drops the rest in silence, so a second roster written after a `---` is a
complete claim that renders nowhere and is compared against nothing — breach 2
of the deleted reader ("a second complete roster block silently ignored"),
reproduced in the file format. `Psych.parse_stream` now sees every document, the
duplicate-key walk runs over the stream, and more than one document is refused.
Zero documents is deliberately let through: an empty file hides nothing, and the
top-level mapping rule already names that input exactly.

The second bot finding is the same shape one level down: the contract said `note` is
a clause and the renderer supplies the terminator — in a **comment**, which is
not a gate — so `note: "nothing to skip."` rendered `nothing to skip..` and both
gates then accepted it as canonical, because both compare SPEC against exactly
what the renderer produced. Enforced in the loader now, for `classification`
too, since it is joined with `; ` and the argument applies verbatim. `reason` is
deliberately **not** held to the mirror rule: it renders last on its line with
nothing appended, so it has nothing to double up against.

## Review round 2: three more, same class

All three are Copilot's, all three are text visible in the source that the gates
compare against nothing, and all three are answered by widening a rule rather
than adding a case to it.

- **A block marker must own its line.** A block's body is the lines strictly
  *between* its markers, so `- "stale" — x. <!-- @zero-skip-roster:end -->`
  renders an extra bullet from outside `span.lines`; `--check` passes and
  `--write` preserves it. **Held for every block kind**, not the one it was found
  in: the hole is in the span arithmetic, so a row riding a table block's marker
  is equally invisible to the *set* comparison. All eight block markers in tracked
  Markdown are already standalone, so this pins practice rather than migrating
  anything. Line markers stay exempt.
- **A value may not carry a line ending — written as a class.** The guard was
  `include?("\n")`; a YAML double-quoted `\r` walks through it. Adding `\r`
  would have been selector #2 on one predicate, with U+2028, U+2029, U+0085 and
  VT queued behind it, so the rule inverts instead: no `\p{Cc}`, no `\p{Zl}`,
  no `\p{Zp}`. It stops deliberately at `\p{Cf}` — invisible, but it cannot end
  a line, and in a case name it fails the manifest comparison loudly rather than
  passing it.
- **`runners` is the only top-level key.** The loader read `doc["runners"]` and
  ignored the rest, so a misspelled top-level mapping could hold a whole roster
  read by nothing — the nested unknown-key rule missing at the level a reader is
  likeliest to paste one.

And one the tests found rather than review: writing the separator case for a
`case` name produced `Encoding::InvalidByteSequenceError` instead of a refusal.
`load_manifest`'s read was **unpinned**, so under `LC_ALL=C` — how CI runs — a
non-ASCII byte in any case name dies with a backtrace rather than a verdict. It
never fired because every tracked fixture case name is ASCII, and it was the
file's one unpinned read, beside a roster reader that pinned its own and that
this PR deletes. Pinned, with a case that runs the gate under `LC_ALL=C`.

There is deliberately **no** `case`-name test for the separator, and the suite
says why: a case name is compared byte-exact, so a separator in one is a loud
mismatch rather than a false green, and such a case would pass off the mismatch.

## Review round 3

Codex raised two, one of which round 2 had already closed (unknown top-level
keys — both bots found it, independently). The other is real and new:

- **The writer wrote before it checked.** `scan_file`'s structural errors were
  reported at the *end* of `--write`, so a file with damaged markers was
  rewritten and then reported as "nothing could be synced" — a message the code
  made false by writing first. It mattered little while every writable span was
  one line rewritten in place; it matters now that a writable **block** is
  spliced, its length can change, and the offsets come from the same scan that
  recorded the error. The check moves ahead of the write loop.
- **Whitespace around a value is content** (Copilot, as a suppressed comment).
  `CLAUSE_TERMINATOR_RE` anchors at the end, so `note: "nothing to skip. "` hid
  the period and rendered `nothing to skip. .`. Fixed by refusing surrounding
  whitespace on **every** value rather than by teaching the terminator regex to
  `rstrip` — the narrow fix answers the two qualifier fields and leaves `source`,
  `case` and `reason`, where a trailing space lands invisibly at the end of a
  rendered line that SPEC then matches byte for byte. Refused rather than
  trimmed: trimming silently rewrites what the author committed to a source of
  truth.

## Review round 4

Both against round 3's own fixes, and both the same mistake — a rule moved one
step and stopped one step short.

- **The preflight did not cover the render.** Moving the structural check ahead
  of the write loop closed the failures `scan_file` *records* and left every
  failure that only appears when a block body is *demanded*: the bodies were
  lambdas called inside the splice, so a malformed roster raised mid-loop, after
  `COORDINATION.md`'s stale pin had already been rewritten. Bodies are now
  rendered up front, so "aborted" and "nothing written" mean the same thing.
  Only kinds actually marked are forced, so a repo with no roster marker still
  never loads the roster file.
- **`String#strip` is ASCII-only**, which made round 3's whitespace rule a
  selector rather than a class — written to end a treadmill and joining it.
  It removes two of the eight whitespace code points worth testing, so
  `note: "nothing to skip.<NBSP>"` walked through the fix for the ASCII case and
  hid the period again. Matched as `\p{Space}` at both boundaries now. It stops
  at White_Space on purpose: U+200B is not whitespace and cannot hide a
  neighbouring character from a rule that reads one.

## Review round 5, and a question about the instrument

Three more mechanisms, each verified against the committed loader before a rule
was written:

- **A YAML merge key** is the duplicate-key defect wearing a different key.
  `<<: {skips: [...]}` beside an explicit `skips:` is resolved by Psych before
  the Hash exists and the explicit field wins, so the merged entries vanish —
  and the duplicate rule genuinely cannot see it, because `<<` and `skips` are
  two distinct keys in the AST. Refused for the reason aliases already are.
- **Markup in a value**, reported twice (a bare `<!--` hiding the rest of the
  document; an injected `<!-- @zero-skip-roster:end -->`). One mechanism, one
  rule: a value may not open or close an HTML comment. The marker case is the
  worse half — `--write` splices it in and exits 0, and the next `--check`
  reports a structurally malformed SPEC the writer itself built — and it is a
  strict subset, since every marker *is* an HTML comment.
- **A marker indented four spaces** is indented code in CommonMark, so it is not
  an HTML comment at all: it renders as visible text while the count still
  matches and the body is still compared byte for byte. Bounded at three spaces,
  which is the limit and the reasoning `FENCE_RE` in the same file already
  carries.

**On the pattern, because five rounds of "one more rule" is exactly what
AGENTS.md says to stop and look at.** These are not five widenings of one
matcher — each closes a distinct *mechanism* by which authored text reaches the
document unchecked (a key resolved away, a document dropped, a character that
ends a line, a delimiter that starts markup), and each is written as a class
rather than a spelling. The mutations are the evidence: narrowing the newest
rule to the spelling that was reported leaves three of its six cases green.

But the honest reading is that the loader now holds six "a value may not X"
rules, and **the terminating instrument for that family is not a seventh — it is
a positive grammar for what a value may contain**, which would subsume all of
them. That is a design change with a real question underneath it (what does a
`reason` legitimately contain?), so it is raised here rather than taken
unilaterally. Happy to do it in this PR or leave it as a follow-up.

## Review round 6

- **`op_count` resolved lazily inside `rewrite_line`** — the third report of one
  defect (errors checked after the loop; block bodies rendered in the splice;
  now the operation count), so it is fixed as a place rather than a third patch.
  `rewrite_line` takes **values, never thunks**, and every deferred input the
  loop can demand is resolved in one spot above it. The invariant is a property
  of the signature now, not a discipline. Only what is marked is forced, so the
  laziness that keeps this gate's fixtures minimal survives.
- **SPEC claimed the next `make` reverts a hand edit.** It does not: `all:
  check`, so `make` *rejects* it and stops; only `make sync-api-version`
  rewrites the block. A false claim in the section whose subject is false
  claims.

## Review round 7 — and the rule count goes down

`note: "<details>"` renders raw HTML that collapses everything after it on
GitHub, needing no comment delimiter at all. That made the previous round's
`/<!--|-->/` a selector, with `<script>` and `<iframe>` queued behind it.

Raw HTML has exactly two openers: `<` begins every tag and every comment, `&`
begins every entity. Refusing both closes the class **and replaces** the comment
rule rather than joining it — one rule where there were two. It costs nothing:
no value in the roster contains either character. A bare `-->` is deliberately
no longer refused, since with `<` gone no value can open a comment for it to
close; refusing a closer that cannot close anything would be the fortress.

Markdown's own constructs (links, table pipes, emphasis) still render and are
deliberately untouched: none can hide content or inject document structure the
way raw HTML can, and refusing them would take the backticks the roster needs on
nearly every line. **The open design question** — a positive grammar for what a
value may contain, which would subsume the remaining per-mechanism rules — is
flagged for the author rather than decided in a review round.

## Review rounds 8–9

- **"Byte-identical" was not byte equality.** Spans are chomped, and `chomp`
  eats CRLF and LF alike, so a CRLF block passed `--check` byte-unequal and
  `--write` then rewrote it. Closed by refusing CR in files that carry a span,
  which makes the existing claim true rather than qualifying it — with no CR,
  "the lines match" and "the bytes match" are the same sentence. Scoped to
  marked files, so a roster change is not a repo-wide reformatting demand.
- **The remediation advice could not be followed.** The markup rule reads the
  scalar, so `<` in backticks is refused too, while three places told authors to
  use a code span. All three now say to rephrase, and say why.
- **The markup rule was too broad for `case`** — the first finding pointing that
  way. A case name is *copied*, not composed: it must match the fixture byte for
  byte, so rephrasing changes the key. Split by **provenance**: copied values are
  exempt from the rules about how a value is written and still held to the one
  about whether it can render at all. Bounded from both sides by mutation, since
  a too-wide exemption is a hole and a too-narrow one is the bug.

## Visible SPEC diff

The block is now rendered, so it is no longer hand-wrapped: four headings that
were wrapped over two lines are single lines. Python's section reads
`— none; the link-header fixture above runs…` where it read `— none. The
link-header…`; the "none" is now derived from the section having no skips rather
than written, so a section cannot claim to skip nothing while listing skips.
Every case name and reason is byte-identical to what was there before.

## Verification

Re-run at this head, after rebasing onto `main`, all under `LC_ALL=C` and all
exit 0:

- `ruby scripts/sync-doc-constants.rb --check`
- `ruby scripts/test-doc-constants.rb`
- `ruby scripts/test-check-fixture-execution.rb`
- `make doc-constants-check`
- `ruby scripts/check-fixture-execution.rb` and `--partial`, against real
  execution manifests from a full conformance run (198 non-live cases across six
  runners, maximum overlap 2 of 6)

Every new self-test case was shown to fail against un-fixed code, each mutation
asserted to match exactly one site (changed line numbers printed) and restored
by `cp` + `diff -q`: 23 for the original change (matrix in the first comment),
plus 31 across the nine review rounds (matrices in the three review-fix commit
messages). Two are load-bearing beyond "the guard fires": narrowing the
line-ending class to the reported character leaves all four non-CR cases green,
scoping the standalone-marker rule to `@zero-skip-roster` leaves the table case
green, and patching the terminator regex to `rstrip` instead of refusing
whitespace leaves all three whitespace cases green — each the argument for a
wider rule stated as a test rather than as an opinion. Reverting the whitespace rule to
`value == value.strip` turns both Unicode rows green and leaves the ASCII ones
red. Two are the defect reproduced rather than removed: moving the writer's
abort back after the write loop, and restoring the previous commit's
`sync-doc-constants.rb` verbatim — against that real un-fixed file the
partial-write case fails alone, with no collateral, which a synthetic mutation
of the same code could not show. Every review-round
case fails as *"expected FAILURE, gate exited 0"* with its guard removed (the
`LC_ALL=C` one breaks a passing case instead) — genuine false greens, not
wrong-fragment near misses. Each mutation was additionally verified to have
changed the file **on disk**, so a probe that silently matched nothing cannot be
mistaken for a guard that held.

Full `make check` is **not** re-run at this head: it is broken in this worktree
by a local Go toolchain mismatch (`go1.26.5` driver against a `go1.26.2`
stdlib), unrelated to any file here. CI covers it.

Known and pre-existing, carried over from the earlier full run: `make check` in
the default locale passes, but under `LC_ALL=C` it dies in
`conformance/runner/ruby/runner.rb` on an unpinned `File.read` of a fixture
containing an em dash (`Encoding::InvalidByteSequenceError`, reachable with two
lines of Ruby on an unmodified checkout). No file this PR touches is involved.

## Supersedes #745's hardening

Three of #745's commits harden the reader this PR deletes:

- `457c14da6` Key the roster reader on the claim, not the list marker
- `c50ec61f4` Run the payload rule ahead of the heading branch
- `c69612d0a` State what the roster reader does not close

Those are breaches 4 and 5 answered with two more selectors. This PR is based on
`main` and deletes the reader outright, so it **supersedes** them rather than
sitting on top of them: they should be dropped from #745, not merged and then
removed here. #745's other commits (the §5 service roster, #600) are untouched,
stand on their own, and are independent of this change.
