### PR TITLE
Wire Python's last two generated services, and test the inventory

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -3647,8 +3647,11 @@ For ASCII text (all conformance test fixtures today), these are equivalent.
 Counts are of accessors actually wired onto the client, against §5's canonical
 roster. The Kotlin and Swift rows are marked, because §5's roster is derived from
 exactly those two files and a restatement of a gated value has to be gated too.
-The other four are hand-verified and dated below — no gate derives them, and
-building one means a sixth hand-copy of each generator's split tables.
+Of the other four, Python's is held by its own accessor-inventory test, which
+derives the roster from `python/src/basecamp/generated/services/` and fails when
+an accessor is missing. The remaining three are hand-verified and dated below —
+no gate derives them, and building one means a sixth hand-copy of each
+generator's split tables.
 
 | SDK | Account-scoped services |
 |-----|------------------------|
@@ -3657,11 +3660,13 @@ building one means a sixth hand-copy of each generator's split tables.
 | Ruby | 53 — full canonical set |
 | TypeScript | 53 — full canonical set, on the flat client alongside `authorization` (no `AccountClient` tier; see Client Topology above) |
 | Go | 51 accessors. Two services are folded rather than missing: `automation`'s sole operation is `LineupService.ListMarkers`, and `clientVisibility`'s is `RecordingsService.SetClientVisibility`. `timesheets` is spelled `Timesheet` (singular). Capability is 53/53; the surface is not. Hand-written service wrappers around the generated OpenAPI client — not fully generated. |
-| Python | 51 — `gauges` and `myNotifications` are a genuine wiring gap, not a fold: `generated/services/gauges.py` and `generated/services/my_notifications.py` both exist and neither `client.py` nor `async_client.py` references them (#732). Sync and async agree exactly. |
+| Python | 53 — full canonical set. `gauges` and `my_notifications` were a wiring gap rather than a fold, and were wired in #732; the same change added an accessor-inventory test (`python/tests/test_client.py`) deriving its roster from `generated/services/`, so the next unwired service fails rather than going unnoticed. Sync and async agree exactly. |
 
 Verified 2026-08-13 against the accessor declarations in each SDK's client
 (Go `AccountClient` methods, Ruby `Client#for_account` accessors, TS
-`defineService` calls, Python `_service` properties).
+`defineService` calls). Python was re-verified 2026-08-16 when #732 wired the
+last two, and no longer relies on that date: its `_service` properties are
+checked against the generated package on every `make py-check`.
 
 ### Event Feed Connector Scenario Lane (§23)
 

--- a/python/README.md
+++ b/python/README.md
@@ -455,7 +455,7 @@ token.is_expired(buffer_seconds=60)  # True if expiring within 60s
 
 ## Services
 
-All services are constructed from an `AccountClient`, obtained via `client.for_account(account_id)`. The table below covers the common ones; see `basecamp/generated/services/` for the full set. Most of that set is also reachable as an accessor on the account client — `account.projects` — but not all of it is: a generated service with no accessor yet is constructed directly from the account client instead — `GaugesService(account)` for a sync `AccountClient`, `AsyncGaugesService(account)` for the `AsyncAccountClient` that `AsyncClient.for_account` returns. Both are exported from `basecamp.generated.services`, and the pairing matters: the sync class calls the async client's methods without awaiting them, so it returns coroutines rather than responses. SPEC.md Appendix F records which services currently need this (#732).
+All services are constructed from an `AccountClient`, obtained via `client.for_account(account_id)`. Every service under `basecamp/generated/services/` is reachable as an accessor on the account client — `account.projects` — and the table below covers the common ones; see that directory for the full set.
 
 | Category | Service | Accessor |
 |----------|---------|----------|

--- a/python/src/basecamp/async_client.py
+++ b/python/src/basecamp/async_client.py
@@ -356,6 +356,12 @@ class AsyncAccountClient:
         return self._service("reports", lambda: AsyncReportsService(self))
 
     @property
+    def gauges(self):
+        from basecamp.generated.services.gauges import AsyncGaugesService
+
+        return self._service("gauges", lambda: AsyncGaugesService(self))
+
+    @property
     def timeline(self):
         from basecamp.generated.services.timeline import AsyncTimelineService
 
@@ -414,6 +420,12 @@ class AsyncAccountClient:
         from basecamp.generated.services.my_assignments import AsyncMyAssignmentsService
 
         return self._service("my_assignments", lambda: AsyncMyAssignmentsService(self))
+
+    @property
+    def my_notifications(self):
+        from basecamp.generated.services.my_notifications import AsyncMyNotificationsService
+
+        return self._service("my_notifications", lambda: AsyncMyNotificationsService(self))
 
     @property
     def calendars(self):

--- a/python/src/basecamp/client.py
+++ b/python/src/basecamp/client.py
@@ -357,6 +357,12 @@ class AccountClient:
         return self._service("reports", lambda: ReportsService(self))
 
     @property
+    def gauges(self):
+        from basecamp.generated.services.gauges import GaugesService
+
+        return self._service("gauges", lambda: GaugesService(self))
+
+    @property
     def timeline(self):
         from basecamp.generated.services.timeline import TimelineService
 
@@ -415,6 +421,12 @@ class AccountClient:
         from basecamp.generated.services.my_assignments import MyAssignmentsService
 
         return self._service("my_assignments", lambda: MyAssignmentsService(self))
+
+    @property
+    def my_notifications(self):
+        from basecamp.generated.services.my_notifications import MyNotificationsService
+
+        return self._service("my_notifications", lambda: MyNotificationsService(self))
 
     @property
     def calendars(self):

--- a/python/tests/services/test_gauges_service.py
+++ b/python/tests/services/test_gauges_service.py
@@ -1,12 +1,4 @@
-"""Tests for the generated gauges service routes (all seven operations).
-
-``gauges`` is NOT wired onto ``Client``/``AsyncClient`` today — the service
-exists and is generated, but no ``account.gauges`` property exposes it (tracked
-separately). These tests therefore construct the generated service directly over
-an account client, exactly as ``test_my_notifications.py`` does for the other
-unwired service. When the wiring lands these tests keep passing unchanged; only
-the construction helpers below would need to move to ``account.gauges``.
-"""
+"""Tests for the generated gauges service routes (all seven operations)."""
 
 from __future__ import annotations
 
@@ -55,11 +47,11 @@ def _link_to(url: str) -> dict[str, str]:
 
 
 def _gauges() -> GaugesService:
-    return GaugesService(Client(access_token="test-token").for_account("12345"))
+    return Client(access_token="test-token").for_account("12345").gauges
 
 
 def _async_gauges() -> AsyncGaugesService:
-    return AsyncGaugesService(AsyncClient(access_token="test-token").for_account("12345"))
+    return AsyncClient(access_token="test-token").for_account("12345").gauges
 
 
 class TestListGauges:

--- a/python/tests/services/test_my_notifications.py
+++ b/python/tests/services/test_my_notifications.py
@@ -42,10 +42,8 @@ class TestSyncMyNotifications:
             return_value=httpx.Response(200, json=_bubble_ups())
         )
 
-        from basecamp.generated.services.my_notifications import MyNotificationsService
-
         account = Client(access_token="test-token").for_account("12345")
-        result = MyNotificationsService(account).get_bubble_ups()
+        result = account.my_notifications.get_bubble_ups()
 
         assert route.called
         assert len(result) == 2
@@ -61,8 +59,7 @@ class TestSyncMyNotifications:
         )
 
         from basecamp.errors import NotFoundError
-        from basecamp.generated.services.my_notifications import MyNotificationsService
 
         account = Client(access_token="test-token").for_account("12345")
         with pytest.raises(NotFoundError):
-            MyNotificationsService(account).get_bubble_ups()
+            account.my_notifications.get_bubble_ups()

--- a/python/tests/test_client.py
+++ b/python/tests/test_client.py
@@ -1,10 +1,62 @@
 from __future__ import annotations
 
+import importlib
+import inspect
+import pkgutil
+
 import pytest
 
+import basecamp.generated.services as generated_services
+from basecamp.async_client import AsyncAccountClient, AsyncClient
 from basecamp.auth import BearerAuth, StaticTokenProvider
-from basecamp.client import Client
+from basecamp.client import AccountClient, Client
 from basecamp.services.authorization import AuthorizationService
+
+# --- Grouped-client accessor inventory ---------------------------------------
+#
+# The roster is derived from the generated service package rather than typed out
+# here, so a newly generated service enters this test the moment it is generated
+# and fails until someone wires an accessor for it. A hand-copied literal list
+# would have to be edited by the same person who forgot the accessor, which is
+# exactly how `gauges` and `my_notifications` shipped unreachable (#732).
+#
+# One spelling rule stands between a module filename and its accessor name: the
+# generator emits `webhooks_service.py` rather than `webhooks.py` to avoid a
+# clash with the `basecamp.webhooks` package (`generate_services.py`'s
+# `service_filename`), and the accessor is `webhooks`. It is stated as data,
+# not as a branch, and nothing else is normalized.
+_MODULE_TO_ACCESSOR = {"webhooks_service": "webhooks"}
+
+# Properties on an account client that are not service accessors.
+_INFRASTRUCTURE_PROPERTIES = {"account_id", "config", "http", "hooks"}
+
+
+def _generated_service_modules() -> list[str]:
+    """Every non-underscore module under `basecamp/generated/services/`."""
+    return sorted(m.name for m in pkgutil.iter_modules(generated_services.__path__) if not m.name.startswith("_"))
+
+
+def _service_classes(module_name: str) -> tuple[type, type]:
+    """The (sync, async) service classes a generated module defines.
+
+    Read off the module itself — `inspect` finds the classes it declares, so no
+    class-name spelling has to be re-derived from the filename here.
+    """
+    module = importlib.import_module(f"{generated_services.__name__}.{module_name}")
+    declared = [
+        obj
+        for _, obj in inspect.getmembers(module, inspect.isclass)
+        if obj.__module__ == module.__name__ and obj.__name__.endswith("Service")
+    ]
+    sync = [c for c in declared if not c.__name__.startswith("Async")]
+    async_ = [c for c in declared if c.__name__.startswith("Async")]
+    assert len(sync) == 1, f"{module_name}: expected one sync service class, got {[c.__name__ for c in sync]}"
+    assert len(async_) == 1, f"{module_name}: expected one async service class, got {[c.__name__ for c in async_]}"
+    return sync[0], async_[0]
+
+
+GENERATED_SERVICE_MODULES = _generated_service_modules()
+EXPECTED_ACCESSORS = sorted(_MODULE_TO_ACCESSOR.get(m, m) for m in GENERATED_SERVICE_MODULES)
 
 
 class TestClientConstruction:
@@ -72,3 +124,67 @@ class TestAuthorizationProperty:
         a = client.authorization
         b = client.authorization
         assert a is b
+
+
+class TestGroupedClientAccessorInventory:
+    """Every generated service must be reachable from an account client.
+
+    `make py-check-drift` compares the generated service layer against the
+    OpenAPI spec; nothing asked whether `Client` reaches what was generated, so
+    two services shipped with no accessor at all (#732). This is that question.
+    """
+
+    def test_roster_is_not_empty(self):
+        # Guards the derivation itself: an import or path change that yielded an
+        # empty roster would make every assertion below vacuously true.
+        assert len(EXPECTED_ACCESSORS) > 40
+        assert len(EXPECTED_ACCESSORS) == len(GENERATED_SERVICE_MODULES)
+
+    @pytest.mark.parametrize("accessor", EXPECTED_ACCESSORS)
+    def test_sync_account_client_exposes_accessor(self, account, accessor):
+        assert hasattr(type(account), accessor), (
+            f"AccountClient has no `{accessor}` property; "
+            f"basecamp/generated/services/ defines that service but client.py does not wire it"
+        )
+
+    @pytest.mark.parametrize("accessor", EXPECTED_ACCESSORS)
+    def test_async_account_client_exposes_accessor(self, accessor):
+        async_account = AsyncClient(access_token="test-token").for_account("999")
+        assert hasattr(type(async_account), accessor), (
+            f"AsyncAccountClient has no `{accessor}` property; "
+            f"basecamp/generated/services/ defines that service but async_client.py does not wire it"
+        )
+
+    @pytest.mark.parametrize("module_name", GENERATED_SERVICE_MODULES)
+    def test_accessor_resolves_to_that_module_s_service(self, account, module_name):
+        # Presence alone would pass if `gauges` returned the wrong service, so
+        # resolve it and check the class it actually yields. Hand-written
+        # composites (§18) subclass their generated service, so `isinstance`
+        # holds for them too.
+        accessor = _MODULE_TO_ACCESSOR.get(module_name, module_name)
+        sync_class, async_class = _service_classes(module_name)
+
+        service = getattr(account, accessor)
+        assert isinstance(service, sync_class), f"account.{accessor} returned {type(service).__name__}"
+        assert not isinstance(service, async_class)
+
+    @pytest.mark.parametrize("module_name", GENERATED_SERVICE_MODULES)
+    def test_async_accessor_resolves_to_the_async_service(self, module_name):
+        # The pairing matters: an async accessor handed the sync class would
+        # return coroutines' worth of un-awaited calls, which reads as success.
+        accessor = _MODULE_TO_ACCESSOR.get(module_name, module_name)
+        _sync_class, async_class = _service_classes(module_name)
+
+        async_account = AsyncClient(access_token="test-token").for_account("999")
+        service = getattr(async_account, accessor)
+        assert isinstance(service, async_class), f"async account.{accessor} returned {type(service).__name__}"
+
+    @pytest.mark.parametrize("client_class", [AccountClient, AsyncAccountClient])
+    def test_no_accessor_without_a_generated_service(self, client_class):
+        # The other direction: an accessor left behind by a removed or renamed
+        # service. Everything that is a property and is not one of the four
+        # infrastructure properties is expected to be a service accessor.
+        accessors = {
+            name for name, value in vars(client_class).items() if isinstance(value, property)
+        } - _INFRASTRUCTURE_PROPERTIES
+        assert accessors == set(EXPECTED_ACCESSORS)


### PR DESCRIPTION
`gauges` and `my_notifications` had no accessor on `AccountClient` or `AsyncAccountClient` — 51 of the 53 generated services were reachable. Both service modules ship, both are exported from `basecamp.generated.services`, and neither client ever named them, so `GaugesService` has been unreachable since #221.

Nothing observed the gap. `make py-check-drift` compares the generated service layer against the OpenAPI spec; it never asks whether the client reaches what was generated. The two tests that touched these services constructed them by hand over an account client, which passes whether or not a user could get there.

## The test is the larger half

`TestGroupedClientAccessorInventory` in `python/tests/test_client.py` (which had no accessor coverage at all) derives its roster from `basecamp/generated/services/` rather than a hand-copied literal — a newly generated service enters the test the moment it is generated and fails until someone wires it. A literal list would have to be edited by the same person who forgot the accessor, which is how this shipped.

One spelling rule is encoded as data: `webhooks_service.py` → `webhooks` (`generate_services.py`'s `service_filename` renames it to avoid clashing with the `basecamp.webhooks` package). Nothing else is normalized. The sync/async service classes are read off each module with `inspect` rather than re-derived from the filename, so no class-name spelling is restated either.

Four things are checked:

1. every generated module has a sync accessor
2. every generated module has an async accessor
3. the accessor resolves to *that module's own* service class, sync paired with sync and async with async — presence alone would pass if `gauges` returned the wrong service
4. the other direction: no accessor survives its generated service

Plus a guard that the derived roster is non-empty, so a path change can't make the rest vacuously true.

## Red proofs

Each case was shown to fail against un-fixed code. Every mutation was applied to a real input, verified on disk, and restored by `cp` + `diff -q`.

| Mutation | Result |
|---|---|
| both clients reverted to `origin/main` (51 accessors, verified on disk) | 10 failed — presence ×4, resolve ×4, no-orphans ×2 |
| `gauges` accessor points at `GoogleDocumentsService` | 1 failed: `test_accessor_resolves_to_that_module_s_service[gauges]` — presence still passed, which is the point |
| async `my_notifications` handed the *sync* class | 1 failed: `test_async_accessor_resolves_to_the_async_service[my_notifications]` |
| invented `gadgets` accessor with no generated service | 1 failed: `test_no_accessor_without_a_generated_service[AccountClient]`, naming `gadgets` |
| roster derivation pointed at an empty path | 3 failed, including the non-empty guard (`assert 0 > 40`) |

## Also

- The two hand-constructing tests now go through `account.gauges` / `account.my_notifications`, and their docstring caveats are gone.
- SPEC.md Appendix F's Python row: 51 → 53, noting it is now held by a test rather than by the hand-verification date.
- `python/README.md`'s paragraph telling users to construct unwired services themselves is deleted.

`LC_ALL=C make py-check` passes (1486 passed, 4 skipped; mypy, ruff, format clean), as do `doc-constants-check` and `check-readme-env-vars`.

Closes #732

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wires Python’s last two generated services onto the account clients and adds an accessor-inventory test so all generated services stay reachable. Previously, `gauges` and `my_notifications` existed under `basecamp.generated.services` but had no accessors; now both `AccountClient` and `AsyncAccountClient` expose `account.gauges` and `account.my_notifications`. Closes #732.

**Review notes**
- Adds `gauges` and `my_notifications` properties to `python/src/basecamp/client.py` and `python/src/basecamp/async_client.py`, each returning the correct sync/async service class from `basecamp.generated.services`.
- Introduces `TestGroupedClientAccessorInventory` in `python/tests/test_client.py`, which derives the roster from `basecamp/generated/services/`, checks sync and async accessor presence, resolves to the module’s own service classes, and asserts no orphan accessors; includes the `webhooks_service` → `webhooks` mapping.
- Updates service tests to use `account.gauges` and `account.my_notifications` instead of hand-constructed services.
- Updates `SPEC.md` (Python row to 53, now guarded by the test) and simplifies `python/README.md` (removes the “construct unwired services” guidance).

**Migration**
- Replace direct construction with accessors:
  - `GaugesService(account)` → `account.gauges`
  - `MyNotificationsService(account)` → `account.my_notifications`

<sup>Written for commit 2e7d24ddac19f51815a8d1dfa05b45007cd52d49. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-sdk/pull/748?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

