### PR TITLE
Tell the Kotlin composites' own decode failure from one an auth strategy threw

### DIFF
--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/BasecampException.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/BasecampException.kt
@@ -117,9 +117,10 @@ sealed class BasecampException(
          * never sent (#730).
          *
          * Presence is the discriminator, and it cannot be forged from outside
-         * the SDK: the constructor that sets this slot is internal and the
-         * decoder wrapper is its only caller. The value is the decoder's own
-         * message, which is what the composites were reaching into [cause] for.
+         * the SDK: the only constructor that sets this slot is private, reached
+         * through the internal [Companion.malformedBody] factory the decoder
+         * wrapper alone calls. The value is the decoder's own message, which is
+         * what the composites were reaching into [cause] for.
          *
          * [cause] still carries the same exception it always did — callers and
          * both conformance runners read it, and a
@@ -138,22 +139,41 @@ sealed class BasecampException(
             cause: Throwable? = null,
         ) : this(message, httpStatus, hint, retryable, requestId, cause, decodeFailure = null)
 
-        /**
-         * The SPEC §6 malformed-2xx-body shape, and the only producer of
-         * [decodeFailure]. Statusless because the request succeeded, so no HTTP
-         * status describes the failure, and non-retryable because re-requesting
-         * cannot repair a malformed body — neither is a caller's to vary, which
-         * is why they are fixed here rather than passed.
-         */
-        internal constructor(message: String, decodeFailure: SerializationException) : this(
-            message,
-            httpStatus = null,
-            hint = null,
-            retryable = false,
-            requestId = null,
-            cause = decodeFailure,
-            decodeFailure = decodeFailure,
-        )
+        internal companion object {
+            /**
+             * The SPEC §6 malformed-2xx-body shape, and the only producer of
+             * [decodeFailure]. Statusless because the request succeeded, so no
+             * HTTP status describes the failure, and non-retryable because
+             * re-requesting cannot repair a malformed body — neither is a
+             * caller's to vary, which is why they are fixed here rather than
+             * passed.
+             *
+             * A factory and not a constructor, because `internal` does not
+             * survive the JVM boundary for `<init>`: constructors cannot be
+             * name-mangled, so an internal *constructor* is emitted public and
+             * Java sees `Api(String, SerializationException)`. That would be the
+             * shortest overload Java is offered — Kotlin default arguments do
+             * not exist for Java callers, which see only the full-arity public
+             * constructor — so a Java-authored `AuthStrategy` writing the
+             * natural `new Api(message, decodeError)` would set this slot and
+             * bring back the exact bug the slot exists to kill. Internal
+             * *functions* are name-mangled (`malformedBody$…`), so this one
+             * cannot be selected from Java by accident. `ApiConstructorSurfaceTest`
+             * holds both halves of that on the JVM target.
+             */
+            internal fun malformedBody(
+                message: String,
+                decodeFailure: SerializationException,
+            ): Api = Api(
+                message,
+                httpStatus = null,
+                hint = null,
+                retryable = false,
+                requestId = null,
+                cause = decodeFailure,
+                decodeFailure = decodeFailure,
+            )
+        }
     }
 
     /** Validation error (400, 422). */

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/BasecampException.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/BasecampException.kt
@@ -116,16 +116,20 @@ sealed class BasecampException(
          * gets relabelled a malformed response body — for a request that was
          * never sent (#730).
          *
-         * Presence is the discriminator, and it cannot be forged from outside
-         * the SDK: the only constructor that sets this slot is private, reached
-         * through the internal [Companion.malformedBody] factory the decoder
-         * wrapper alone calls. The value is the decoder's own message, which is
-         * what the composites were reaching into [cause] for.
+         * Presence is the discriminator. The only constructor that sets this
+         * slot is private, reached through the internal [Companion.malformedBody]
+         * factory the decoder wrapper alone calls, so no caller reaches it by
+         * writing the natural thing. The value is the decoder's own message,
+         * which is what the composites were reaching into [cause] for.
+         *
+         * That is an accident guarantee and not an unforgeable one — see
+         * [Companion.malformedBody] for what it does and does not stop.
          *
          * [cause] still carries the same exception it always did — callers and
-         * both conformance runners read it, and a
-         * [kotlinx.serialization.MissingFieldException] there still reports its
-         * `missingFields`.
+         * the **Kotlin** conformance runner read it (Swift's has no `cause` to
+         * read: `BasecampError.api` carries none, which is the whole premise of
+         * #750), and a [kotlinx.serialization.MissingFieldException] there still
+         * reports its `missingFields`.
          */
         internal val decodeFailure: SerializationException?,
     ) : BasecampException(message, CODE_API, hint, httpStatus, retryable, requestId, cause) {
@@ -157,9 +161,21 @@ sealed class BasecampException(
              * constructor — so a Java-authored `AuthStrategy` writing the
              * natural `new Api(message, decodeError)` would set this slot and
              * bring back the exact bug the slot exists to kill. Internal
-             * *functions* are name-mangled (`malformedBody$…`), so this one
-             * cannot be selected from Java by accident. `ApiConstructorSurfaceTest`
+             * *functions* are name-mangled (`malformedBody$…`), so this one is
+             * not what a Java caller reaches for. `ApiConstructorSurfaceTest`
              * holds both halves of that on the JVM target.
+             *
+             * **What this does not claim.** A mangled name is still a legal Java
+             * identifier, so Java source CAN call
+             * `Api.Companion.malformedBody$…` on purpose and set the marker.
+             * That is left open deliberately. The failure being prevented is an
+             * accident — picking the convenient overload — and the deliberate
+             * case buys its author nothing: the same `AuthStrategy` can already
+             * throw, through the *public* constructor, an `Api` carrying the
+             * composite's own message and hint verbatim, for an identical
+             * user-visible outcome. Hiding this factory behind a synthetic
+             * bridge would close a path whose equivalent stays one line away,
+             * which is armour, not a guarantee.
              */
             internal fun malformedBody(
                 message: String,

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/BasecampException.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/BasecampException.kt
@@ -1,5 +1,7 @@
 package com.basecamp.sdk
 
+import kotlinx.serialization.SerializationException
+
 /**
  * Sealed class hierarchy for Basecamp API errors.
  *
@@ -92,14 +94,67 @@ sealed class BasecampException(
      * sanctions that shape as a statusless, non-retryable `api_error`; passing a
      * placeholder like `0` would claim an HTTP status that never existed.
      */
-    class Api(
+    class Api private constructor(
         message: String,
-        httpStatus: Int? = null,
-        hint: String? = null,
-        retryable: Boolean = httpStatus != null && httpStatus in 500..599,
-        requestId: String? = null,
-        cause: Throwable? = null,
-    ) : BasecampException(message, CODE_API, hint, httpStatus, retryable, requestId, cause)
+        httpStatus: Int?,
+        hint: String?,
+        retryable: Boolean,
+        requestId: String?,
+        cause: Throwable?,
+        /**
+         * The response decoder's own refusal, set on the exception
+         * [com.basecamp.sdk.services.BaseService] raises for a malformed 2xx
+         * body and on nothing else.
+         *
+         * The SPEC §18 composites re-hint a decode failure of the GET they
+         * issue, so what they have to answer is "did this come out of the
+         * *response decoder*". `cause is SerializationException` reads like an
+         * answer and is not one: `BasecampHttpClient` propagates an
+         * already-classified [BasecampException] from the auth strategy
+         * untouched, so a token provider that classifies its own JSON failure
+         * as `Api(cause = SerializationException(...))` matches that test and
+         * gets relabelled a malformed response body — for a request that was
+         * never sent (#730).
+         *
+         * Presence is the discriminator, and it cannot be forged from outside
+         * the SDK: the constructor that sets this slot is internal and the
+         * decoder wrapper is its only caller. The value is the decoder's own
+         * message, which is what the composites were reaching into [cause] for.
+         *
+         * [cause] still carries the same exception it always did — callers and
+         * both conformance runners read it, and a
+         * [kotlinx.serialization.MissingFieldException] there still reports its
+         * `missingFields`.
+         */
+        internal val decodeFailure: SerializationException?,
+    ) : BasecampException(message, CODE_API, hint, httpStatus, retryable, requestId, cause) {
+
+        constructor(
+            message: String,
+            httpStatus: Int? = null,
+            hint: String? = null,
+            retryable: Boolean = httpStatus != null && httpStatus in 500..599,
+            requestId: String? = null,
+            cause: Throwable? = null,
+        ) : this(message, httpStatus, hint, retryable, requestId, cause, decodeFailure = null)
+
+        /**
+         * The SPEC §6 malformed-2xx-body shape, and the only producer of
+         * [decodeFailure]. Statusless because the request succeeded, so no HTTP
+         * status describes the failure, and non-retryable because re-requesting
+         * cannot repair a malformed body — neither is a caller's to vary, which
+         * is why they are fixed here rather than passed.
+         */
+        internal constructor(message: String, decodeFailure: SerializationException) : this(
+            message,
+            httpStatus = null,
+            hint = null,
+            retryable = false,
+            requestId = null,
+            cause = decodeFailure,
+            decodeFailure = decodeFailure,
+        )
+    }
 
     /** Validation error (400, 422). */
     class Validation(

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/services/BaseService.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/services/BaseService.kt
@@ -562,14 +562,14 @@ abstract class BaseService(
 
     /**
      * The one place a decode failure is rendered — and, through the internal
-     * constructor it calls, the only producer of
+     * factory it calls, the only producer of
      * [BasecampException.Api.decodeFailure]. That slot is how the §18
      * composites tell this exception from any other `api_error` that happens to
      * carry a [SerializationException] as its `cause`, which an auth strategy's
      * already-classified failure can (#730).
      */
     private fun malformedBody(operation: String, cause: SerializationException): BasecampException.Api =
-        BasecampException.Api(
+        BasecampException.Api.malformedBody(
             message = BasecampException.truncateMessage(
                 "$operation returned a body that does not decode: ${cause.message}"
             ),

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/services/BaseService.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/services/BaseService.kt
@@ -525,10 +525,11 @@ abstract class BaseService(
      *
      * **One mapped type, deliberately.** [SerializationException] is the type
      * kotlinx uses to say "this body is not what the model expects", and the
-     * `cause` it becomes here is a contract other code reads: the §18
-     * composites re-hint off `cause is SerializationException`, and the
-     * conformance runner tells a decoder rejection from a real `api_error` the
-     * same way. A second mapped type would be a second cause type they would
+     * `cause` it becomes here is a contract other code reads: the conformance
+     * runner tells a decoder rejection from a real `api_error` that way, and
+     * the §18 composites read the same exception through
+     * [BasecampException.Api.decodeFailure], the internal slot [malformedBody]
+     * alone fills. A second mapped type would be a second cause type they would
      * each have to learn, so anything that is a decode failure is made to speak
      * this one *where it is raised* instead — see
      * [com.basecamp.sdk.serialization.FlexibleLongSerializer], whose numeric
@@ -559,15 +560,20 @@ abstract class BaseService(
             throw malformedBody(operation, e)
         }
 
-    /** The one place a decode failure is rendered. */
+    /**
+     * The one place a decode failure is rendered — and, through the internal
+     * constructor it calls, the only producer of
+     * [BasecampException.Api.decodeFailure]. That slot is how the §18
+     * composites tell this exception from any other `api_error` that happens to
+     * carry a [SerializationException] as its `cause`, which an auth strategy's
+     * already-classified failure can (#730).
+     */
     private fun malformedBody(operation: String, cause: SerializationException): BasecampException.Api =
         BasecampException.Api(
             message = BasecampException.truncateMessage(
                 "$operation returned a body that does not decode: ${cause.message}"
             ),
-            httpStatus = null,
-            retryable = false,
-            cause = cause,
+            decodeFailure = cause,
         )
 
     /**

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/services/DocumentsService.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/services/DocumentsService.kt
@@ -95,9 +95,16 @@ class DocumentsService(client: AccountClient) :
      * non-retryable [BasecampException.Api] carrying the [SerializationException]
      * as its `cause`. What the base layer cannot know is this composite's own
      * account of the failure: which record failed to decode, and the escape
-     * hatch for writing it deliberately. That is what is restated here, keyed
-     * off the `cause` so any other [BasecampException.Api] passes through
-     * untouched.
+     * hatch for writing it deliberately. That is what is restated here.
+     *
+     * The restatement is keyed off [BasecampException.Api.decodeFailure], the
+     * internal slot the base layer's decoder wrapper alone fills, so any other
+     * [BasecampException.Api] passes through untouched. Reading `cause is
+     * SerializationException` instead would catch more than this GET's decode:
+     * an auth strategy that classifies its own JSON failure that way has its
+     * exception propagated untouched by `BasecampHttpClient`, and would arrive
+     * here relabelled as a malformed document — for a request that was never
+     * sent (#730).
      *
      * (Bare JSON scalars are refused as well as structural mismatches. They
      * were not until #598 removed the client-wide `isLenient`, which rendered a
@@ -107,7 +114,7 @@ class DocumentsService(client: AccountClient) :
         try {
             get(documentId)
         } catch (e: BasecampException.Api) {
-            val decodeFailure = e.cause as? SerializationException ?: throw e
+            val decodeFailure = e.decodeFailure ?: throw e
             throw BasecampException.Api(
                 message = "GetDocument returned a body that does not decode as a document: " +
                     "${decodeFailure.message}",

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/services/SchedulesService.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/services/SchedulesService.kt
@@ -277,8 +277,16 @@ class SchedulesService(client: AccountClient) :
      * non-retryable [BasecampException.Api] carrying that exception as its
      * `cause`. What the base layer cannot know is this composite's own account
      * of the failure: which record failed to decode, and the escape hatch for
-     * writing it deliberately. That is what is restated here, keyed off the
-     * `cause` so any other [BasecampException.Api] passes through untouched.
+     * writing it deliberately. That is what is restated here.
+     *
+     * The restatement is keyed off [BasecampException.Api.decodeFailure], the
+     * internal slot the base layer's decoder wrapper alone fills, so any other
+     * [BasecampException.Api] passes through untouched. Reading `cause is
+     * SerializationException` instead would catch more than this GET's decode:
+     * an auth strategy that classifies its own JSON failure that way has its
+     * exception propagated untouched by `BasecampHttpClient`, and would arrive
+     * here relabelled as a malformed schedule entry — for a request that was
+     * never sent (#730).
      *
      * (Bare JSON scalars are refused as well as structural mismatches. They
      * were not until #598 removed the client-wide `isLenient`, which rendered a
@@ -288,7 +296,7 @@ class SchedulesService(client: AccountClient) :
         try {
             getEntry(entryId)
         } catch (e: BasecampException.Api) {
-            val decodeFailure = e.cause as? SerializationException ?: throw e
+            val decodeFailure = e.decodeFailure ?: throw e
             throw BasecampException.Api(
                 message = "GetScheduleEntry returned a body that does not decode as a schedule " +
                     "entry: ${decodeFailure.message}",

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/services/TodolistsService.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/services/TodolistsService.kt
@@ -100,8 +100,16 @@ class TodolistsService(client: AccountClient) :
      * [SerializationException] as its `cause`. What the base layer cannot know
      * is this composite's own account of the failure: which record failed to
      * decode, and the escape hatch for writing it deliberately. That is what is
-     * restated here, keyed off the `cause` so any other [BasecampException.Api]
-     * passes through untouched.
+     * restated here.
+     *
+     * The restatement is keyed off [BasecampException.Api.decodeFailure], the
+     * internal slot the base layer's decoder wrapper alone fills, so any other
+     * [BasecampException.Api] passes through untouched. Reading `cause is
+     * SerializationException` instead would catch more than this GET's decode:
+     * an auth strategy that classifies its own JSON failure that way has its
+     * exception propagated untouched by `BasecampHttpClient`, and would arrive
+     * here relabelled as a malformed todolist — for a request that was never
+     * sent (#730).
      *
      * (Bare JSON scalars are refused as well as structural mismatches. They
      * were not until #598 removed the client-wide `isLenient`, which rendered a
@@ -111,7 +119,7 @@ class TodolistsService(client: AccountClient) :
         try {
             get(id)
         } catch (e: BasecampException.Api) {
-            val decodeFailure = e.cause as? SerializationException ?: throw e
+            val decodeFailure = e.decodeFailure ?: throw e
             throw BasecampException.Api(
                 message = "GetTodolistOrGroup returned a body that does not decode as a " +
                     "todolist: ${decodeFailure.message}",

--- a/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/DocumentsServiceTest.kt
+++ b/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/DocumentsServiceTest.kt
@@ -6,12 +6,15 @@ import com.basecamp.sdk.generated.services.UpdateDocumentBody
 import io.ktor.client.engine.mock.*
 import io.ktor.http.*
 import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
+import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
 /**
@@ -107,10 +110,74 @@ class DocumentsServiceTest {
         // re-requesting cannot repair a malformed body.
         assertEquals(null, error.httpStatus)
         assertEquals(false, error.retryable)
-        assertTrue(error.hint != null, "expected a hint naming the escape hatch")
+        // The composite's own account of the failure, not the base layer's:
+        // which record failed to decode, and the escape hatch. This is the half
+        // of the discriminator that must keep firing — see
+        // updateDoesNotRelabelAnAuthStrategyFailure for the half that must not.
+        assertTrue(
+            error.message!!.contains("GetDocument returned a body that does not decode as a document"),
+            "expected the composite's message, got: ${error.message}",
+        )
+        assertTrue(
+            error.hint?.contains("Use replace to write the record deliberately") == true,
+            "expected a hint naming the escape hatch, got: ${error.hint}",
+        )
         // The ordering is what matters: no PUT. A guard that fires after the
         // PUT has already lost the field.
         assertEquals(listOf("GET"), capture.methods)
+
+        client.close()
+    }
+
+    /**
+     * An auth strategy's already-classified failure is not this GET's decode
+     * failure (#730).
+     *
+     * `BasecampHttpClient` propagates a `BasecampException` thrown by the
+     * strategy untouched, deliberately: a token provider's own classification
+     * is not the SDK's to overwrite. So a provider that decodes a JSON token
+     * response and classifies its own decode failure as
+     * `Api(cause = SerializationException(...))` lands in this composite's
+     * catch — and while the discriminator was `cause is SerializationException`
+     * it matched, and the caller was told "GetDocument returned a body that
+     * does not decode as a document", with the merge-safe hint attached, for a
+     * request that was never sent.
+     *
+     * The discriminator is now the internal slot only the response decoder
+     * fills, so the strategy's exception arrives as itself.
+     */
+    @Test
+    fun updateDoesNotRelabelAnAuthStrategyFailure() = runTest {
+        var requests = 0
+        val thrown = BasecampException.Api(
+            message = "the token endpoint returned a body that does not decode",
+            cause = SerializationException("Unexpected JSON token at offset 0"),
+        )
+        val client = testBasecampClient {
+            auth(AuthStrategy { throw thrown })
+            enableRetry = false
+            engine = MockEngine {
+                requests += 1
+                respond(
+                    content = fullDocumentJson(),
+                    status = HttpStatusCode.OK,
+                    headers = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString()),
+                )
+            }
+        }
+
+        val error = assertFailsWith<BasecampException.Api> {
+            client.forAccount("12345").documents
+                .update(42, UpdateDocumentBody(content = "<p>New body.</p>"))
+        }
+
+        assertSame(thrown, error, "the strategy's own exception must reach the caller unchanged")
+        assertEquals(
+            "the token endpoint returned a body that does not decode", error.message,
+            "an auth failure must not be restated as a malformed document",
+        )
+        assertNull(error.hint, "the merge-safe escape hatch does not answer an auth failure")
+        assertEquals(0, requests, "auth failed, so no request was ever sent")
 
         client.close()
     }

--- a/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/SchedulesServiceTest.kt
+++ b/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/SchedulesServiceTest.kt
@@ -5,6 +5,7 @@ import com.basecamp.sdk.generated.services.ReplaceScheduleEntryBody
 import io.ktor.client.engine.mock.*
 import io.ktor.http.*
 import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonArray
 import kotlinx.serialization.json.jsonArray
@@ -14,6 +15,8 @@ import kotlinx.serialization.json.long
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertNull
+import kotlin.test.assertSame
 import kotlin.test.assertTrue
 
 /**
@@ -477,9 +480,77 @@ class SchedulesServiceTest {
     // boolean as a String instead of rejecting it. See `DecoderStrictnessTest`.
     @Test
     fun updateRefusesAWrongTypedSummary() = runTest {
-        assertRefusesRead(
+        val error = assertRefusesRead(
             fullEntryJson().replace("\"summary\": \"Team Meeting\"", "\"summary\": [\"nope\"]")
         ) { account -> account.schedules.updateEntry(1069479523, description = "<div>New.</div>") }
+
+        // The composite's own account of the failure, not the base layer's:
+        // which record failed to decode, and the escape hatch. This is the half
+        // of the discriminator that must keep firing — see
+        // updateDoesNotRelabelAnAuthStrategyFailure for the half that must not.
+        assertTrue(
+            error.message!!.contains(
+                "GetScheduleEntry returned a body that does not decode as a schedule entry"
+            ),
+            "expected the composite's message, got: ${error.message}",
+        )
+        assertTrue(
+            error.hint?.contains("Use replaceEntry to write the record deliberately") == true,
+            "expected a hint naming the escape hatch, got: ${error.hint}",
+        )
+    }
+
+    /**
+     * An auth strategy's already-classified failure is not this GET's decode
+     * failure (#730).
+     *
+     * `BasecampHttpClient` propagates a `BasecampException` thrown by the
+     * strategy untouched, deliberately: a token provider's own classification
+     * is not the SDK's to overwrite. So a provider that decodes a JSON token
+     * response and classifies its own decode failure as
+     * `Api(cause = SerializationException(...))` lands in this composite's
+     * catch — and while the discriminator was `cause is SerializationException`
+     * it matched, and the caller was told "GetScheduleEntry returned a body
+     * that does not decode as a schedule entry", with the merge-safe hint
+     * attached, for a request that was never sent.
+     *
+     * The discriminator is now the internal slot only the response decoder
+     * fills, so the strategy's exception arrives as itself.
+     */
+    @Test
+    fun updateDoesNotRelabelAnAuthStrategyFailure() = runTest {
+        var requests = 0
+        val thrown = BasecampException.Api(
+            message = "the token endpoint returned a body that does not decode",
+            cause = SerializationException("Unexpected JSON token at offset 0"),
+        )
+        val client = testBasecampClient {
+            auth(AuthStrategy { throw thrown })
+            enableRetry = false
+            engine = MockEngine {
+                requests += 1
+                respond(
+                    content = fullEntryJson(),
+                    status = HttpStatusCode.OK,
+                    headers = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString()),
+                )
+            }
+        }
+
+        val error = assertFailsWith<BasecampException.Api> {
+            client.forAccount("999").schedules
+                .updateEntry(1069479523, description = "<div>New.</div>")
+        }
+
+        assertSame(thrown, error, "the strategy's own exception must reach the caller unchanged")
+        assertEquals(
+            "the token endpoint returned a body that does not decode", error.message,
+            "an auth failure must not be restated as a malformed schedule entry",
+        )
+        assertNull(error.hint, "the merge-safe escape hatch does not answer an auth failure")
+        assertEquals(0, requests, "auth failed, so no request was ever sent")
+
+        client.close()
     }
 
     // all_day is NOT NULL DEFAULT false and every partial emits it. Defaulting

--- a/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/TodolistsServiceTest.kt
+++ b/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/TodolistsServiceTest.kt
@@ -6,6 +6,7 @@ import com.basecamp.sdk.generated.todolists
 import io.ktor.client.engine.mock.*
 import io.ktor.http.*
 import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.SerializationException
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.JsonObject
 import kotlinx.serialization.json.jsonObject
@@ -15,6 +16,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertNotNull
 import kotlin.test.assertNull
+import kotlin.test.assertSame
 import kotlin.test.assertTrue
 import kotlin.test.fail
 
@@ -335,7 +337,21 @@ class TodolistsServiceTest {
             // re-requesting cannot repair a malformed body.
             assertEquals(null, error.httpStatus)
             assertEquals(false, error.retryable)
-            assertTrue(error.hint != null, "expected a hint naming the escape hatch")
+            // The composite's own account of the failure, not the base layer's:
+            // which record failed to decode, and the escape hatch. This is the
+            // half of the discriminator that must keep firing — see
+            // updateDoesNotRelabelAnAuthStrategyFailure for the half that must
+            // not.
+            assertTrue(
+                error.message!!.contains(
+                    "GetTodolistOrGroup returned a body that does not decode as a todolist"
+                ),
+                "expected the composite's message, got: ${error.message}",
+            )
+            assertTrue(
+                error.hint?.contains("Use replace to write the record deliberately") == true,
+                "expected a hint naming the escape hatch, got: ${error.hint}",
+            )
             // The ordering is what matters: no PUT. A guard that fires after
             // the PUT has already lost the field.
             assertEquals(
@@ -344,6 +360,59 @@ class TodolistsServiceTest {
             )
             client.close()
         }
+    }
+
+    /**
+     * An auth strategy's already-classified failure is not this GET's decode
+     * failure (#730).
+     *
+     * `BasecampHttpClient` propagates a `BasecampException` thrown by the
+     * strategy untouched, deliberately: a token provider's own classification
+     * is not the SDK's to overwrite. So a provider that decodes a JSON token
+     * response and classifies its own decode failure as
+     * `Api(cause = SerializationException(...))` lands in this composite's
+     * catch — and while the discriminator was `cause is SerializationException`
+     * it matched, and the caller was told "GetTodolistOrGroup returned a body
+     * that does not decode as a todolist", with the merge-safe hint attached,
+     * for a request that was never sent.
+     *
+     * The discriminator is now the internal slot only the response decoder
+     * fills, so the strategy's exception arrives as itself.
+     */
+    @Test
+    fun updateDoesNotRelabelAnAuthStrategyFailure() = runTest {
+        var requests = 0
+        val thrown = BasecampException.Api(
+            message = "the token endpoint returned a body that does not decode",
+            cause = SerializationException("Unexpected JSON token at offset 0"),
+        )
+        val client = testBasecampClient {
+            auth(AuthStrategy { throw thrown })
+            enableRetry = false
+            engine = MockEngine {
+                requests += 1
+                respond(
+                    content = todolistJson,
+                    status = HttpStatusCode.OK,
+                    headers = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString()),
+                )
+            }
+        }
+
+        val error = assertFailsWith<BasecampException.Api> {
+            client.forAccount("12345").todolists
+                .update(42, UpdateTodolistBody(name = "Renamed list"))
+        }
+
+        assertSame(thrown, error, "the strategy's own exception must reach the caller unchanged")
+        assertEquals(
+            "the token endpoint returned a body that does not decode", error.message,
+            "an auth failure must not be restated as a malformed todolist",
+        )
+        assertNull(error.hint, "the merge-safe escape hatch does not answer an auth failure")
+        assertEquals(0, requests, "auth failed, so no request was ever sent")
+
+        client.close()
     }
 
     /**

--- a/kotlin/sdk/src/jvmTest/kotlin/com/basecamp/sdk/ApiConstructorSurfaceTest.kt
+++ b/kotlin/sdk/src/jvmTest/kotlin/com/basecamp/sdk/ApiConstructorSurfaceTest.kt
@@ -1,0 +1,122 @@
+package com.basecamp.sdk
+
+import kotlinx.serialization.SerializationException
+import java.lang.reflect.Constructor
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+/**
+ * The malformed-body marker on [BasecampException.Api] must not be settable
+ * from Java (#751 review).
+ *
+ * `decodeFailure` answers "did this `api_error` come out of the response
+ * decoder?", and the §18 composites re-hint off it. The whole guarantee is that
+ * only `BaseService`'s decoder wrapper can fill it — an auth strategy that
+ * fills it too puts back the #730 bug, an authentication failure relabelled as
+ * a malformed Basecamp response for a request that was never sent.
+ *
+ * `internal` alone does not carry that guarantee across the JVM boundary, and
+ * the distinction is exactly the one this test pins:
+ *
+ * - Internal **constructors** are emitted `public`, because `<init>` cannot be
+ *   name-mangled. An `internal constructor(message: String, decodeFailure:
+ *   SerializationException)` — the shape this SDK shipped first — is a public
+ *   two-arg constructor to Java. Worse, it is the *shortest* one on offer:
+ *   Kotlin default arguments do not exist for Java callers, so without
+ *   `@JvmOverloads` Java sees only the six-arg `Api(String, Integer, String,
+ *   boolean, String, Throwable)` beside it. A Java `AuthStrategy` classifying
+ *   its own token-response decode failure would naturally write
+ *   `new Api(message, decodeError)` and set the marker by accident.
+ * - Internal **functions** ARE name-mangled (`malformedBody$…`), so a factory
+ *   is not selectable by accident from Java.
+ *
+ * This is the accident/regression class, not deliberate evasion: nobody has to
+ * be working around anything for a Java-authored `AuthStrategy` on the JVM
+ * target to pick the convenient overload. Reflection is the closest the
+ * toolchain gets to a Java caller here — `commonTest` cannot host Java source,
+ * and this SDK has no Java sample module — so what is asserted is the emitted
+ * constructor surface javac would choose from, not a compiled Java call site.
+ * The compiler's own view of that surface is the same list.
+ */
+class ApiConstructorSurfaceTest {
+
+    /**
+     * Constructors javac can actually select: public and not synthetic.
+     *
+     * Synthetic members are excluded because javac refuses to resolve them from
+     * source. Kotlin emits two here — the default-arguments bridge and the
+     * accessor for the private marker constructor — and both also carry a
+     * trailing `DefaultConstructorMarker` no Java call site would write.
+     */
+    private val javaSelectableConstructors: List<Constructor<*>>
+        get() = BasecampException.Api::class.java.constructors.filterNot { it.isSynthetic }
+
+    @Test
+    fun noJavaSelectableConstructorTakesADecoderException() {
+        val offenders = javaSelectableConstructors.filter { constructor ->
+            constructor.parameterTypes.any { SerializationException::class.java.isAssignableFrom(it) }
+        }
+
+        assertTrue(
+            offenders.isEmpty(),
+            "the malformed-body marker must be unreachable from Java, but these constructors " +
+                "accept a SerializationException directly: " +
+                offenders.joinToString { it.parameterTypes.joinToString(prefix = "(", postfix = ")") { p -> p.simpleName } },
+        )
+    }
+
+    /**
+     * The control for the assertion above: it must be passing because the
+     * marker constructor is gone, not because reflection found nothing to
+     * inspect. The public constructor's shape is also the thing #751 promised
+     * to keep byte-identical, so a change to it should be deliberate.
+     *
+     * `cause: Throwable` is intentionally still here — a Java caller may pass a
+     * `SerializationException` AS the cause, and that is fine. It classifies
+     * their own failure without claiming this SDK's decoder produced it, which
+     * is the whole distinction.
+     */
+    @Test
+    fun thePublicConstructorKeepsItsShape() {
+        val signatures = javaSelectableConstructors
+            .map { it.parameterTypes.map { p -> p.simpleName } }
+
+        assertEquals(
+            listOf(listOf("String", "Integer", "String", "boolean", "String", "Throwable")),
+            signatures,
+            "exactly one Java-selectable constructor is expected, unchanged since #751",
+        )
+    }
+
+    /**
+     * The producer stays name-mangled. Dropping `internal` from the factory —
+     * or making it `@JvmStatic`, or moving it back to a constructor — puts a
+     * plainly-named `malformedBody`, or none at all, on the Java surface, which
+     * is the same accident one step over.
+     *
+     * Everything here is looked up by reflection rather than by referring to
+     * `Api.Companion` in source, deliberately: this test has to COMPILE against
+     * the shape it rejects. Naming the companion would turn its verdict on the
+     * un-fixed code into "unresolved reference", and a guard that can only fail
+     * by failing to build proves nothing about what the build emitted.
+     */
+    @Test
+    fun theMarkerFactoryIsOnlyReachableUnderAMangledName() {
+        val surface = BasecampException.Api::class.java.declaredClasses.toList() +
+            BasecampException.Api::class.java
+        val names = surface
+            .flatMap { it.methods.asSequence() }
+            .map { it.name }
+            .filter { it.startsWith("malformedBody") }
+
+        assertTrue(
+            names.none { it == "malformedBody" },
+            "the marker factory must not be callable under its plain name from Java, got: $names",
+        )
+        assertTrue(
+            names.any { it.startsWith("malformedBody$") },
+            "expected the mangled internal factory to exist on Api or its companion, got: $names",
+        )
+    }
+}

--- a/kotlin/sdk/src/jvmTest/kotlin/com/basecamp/sdk/ApiConstructorSurfaceTest.kt
+++ b/kotlin/sdk/src/jvmTest/kotlin/com/basecamp/sdk/ApiConstructorSurfaceTest.kt
@@ -8,13 +8,22 @@ import kotlin.test.assertTrue
 
 /**
  * The malformed-body marker on [BasecampException.Api] must not be settable
- * from Java (#751 review).
+ * from Java **by accident** (#751 review).
  *
  * `decodeFailure` answers "did this `api_error` come out of the response
- * decoder?", and the §18 composites re-hint off it. The whole guarantee is that
- * only `BaseService`'s decoder wrapper can fill it — an auth strategy that
- * fills it too puts back the #730 bug, an authentication failure relabelled as
- * a malformed Basecamp response for a request that was never sent.
+ * decoder?", and the §18 composites re-hint off it. An auth strategy that fills
+ * it too puts back the #730 bug: an authentication failure relabelled as a
+ * malformed Basecamp response for a request that was never sent.
+ *
+ * **The claim is bounded, deliberately.** What is prevented here is a Java
+ * caller picking the convenient overload without meaning anything by it. Java
+ * source can still call the mangled factory (`malformedBody$…`) on purpose —
+ * `$` is a legal identifier character — and that is left open: the same
+ * `AuthStrategy` can already throw, through the public constructor, an `Api`
+ * carrying the composite's own message and hint verbatim, so the deliberate
+ * path has an equivalent one line away and closing it would buy nothing. These
+ * tests are named for what they hold: no Java-SELECTABLE constructor takes a
+ * decoder exception, and the factory is reachable only under a MANGLED name.
  *
  * `internal` alone does not carry that guarantee across the JVM boundary, and
  * the distinction is exactly the one this test pins:


### PR DESCRIPTION
Closes #730. Follow-up filed as #750.

## The bug

The three Kotlin merge-safe composites identify a decode failure by inspecting the cause of the `BasecampException.Api` their GET raised:

```kotlin
} catch (e: BasecampException.Api) {
    val decodeFailure = e.cause as? SerializationException ?: throw e
```

That is a *pattern*, and anyone can match it. `BasecampHttpClient.authenticateClassified` propagates an already-classified `BasecampException` from the auth strategy untouched — deliberately, and its docstring says so. So an `AuthStrategy` that classifies its own JSON failure as `Api(cause = SerializationException(...))` — a token provider decoding a token response, say — lands in this catch, matches, and the caller is told:

> GetDocument returned a body that does not decode as a document: …

with the merge-safe hint attached, **for a request that was never sent**. Wrong message, misleading hint, and a pointer at the wrong subsystem. Same class of conflation #604 fixed in the base layer, surviving one layer up.

Verified in source before fixing: `BasecampHttpClient.kt:69-79` (propagate-as-is), `BaseService.request` (`catch (e: BasecampException) { … throw e }`), composite catches at `SchedulesService.kt:290`, `DocumentsService.kt:109`, `TodolistsService.kt:113`.

## The fix — identity, not shape

`BasecampException.Api` gains an internal `decodeFailure: SerializationException?` slot, fillable only through a **private** constructor reached by the internal factory `Api.malformedBody`, whose only caller is `BaseService.malformedBody` — the one place a decode failure is rendered. Its presence is the discriminator; its value is the decoder's message the composites were reaching into `cause` for. Each catch becomes:

```kotlin
val decodeFailure = e.decodeFailure ?: throw e
```

Nothing outside the SDK module can produce that slot, so the ambiguity is removed rather than tested for a second time.

### Alternatives, and why they lost

- **Narrow the try/catch to the decode call** — unavailable, not inferior. The composite's `try` already wraps exactly one expression, and the decode happens inside the generated wire method, where #604 already narrowed it to the decode expression. A composite doing its own decode is what AGENTS.md Hard Rule 2 forbids.
- **Wrap `cause` in an internal marker type** — loses on evidence. `cause` is the cross-module channel: the Kotlin conformance runner reads `(e as? BasecampException.Api)?.cause as? SerializationException` (`kotlin/conformance/.../Main.kt:554`), `MissingFieldException.missingFields` is a real caller API, and `DecodeIsolationTest` pins `cause.cause` as the `NumberFormatException` under a numeric refusal. A wrapper shifts all three by one hop for no gain. `cause` is untouched here, so the conformance runner needs no change.
- **A flag set across the decode** — shared mutable state on a service instance that concurrent coroutines share. No.

Public API is unchanged: `Api`'s public constructor keeps its exact signature and defaults; the new slot and the constructor that sets it are `internal`.

## Round 2 — keeping the marker off Java's API (`8b4f0b8d7`)

Codex raised a P2 that was correct and more reachable than argued. `internal` on a **constructor** does not survive the JVM boundary: `<init>` cannot be name-mangled, so the first version emitted

```
public BasecampException$Api(java.lang.String, kotlinx.serialization.SerializationException)
```

— public, non-synthetic, two args. And it was the *convenient* overload: Kotlin default arguments do not exist for Java callers and there is no `@JvmOverloads`, so the only other constructor Java saw was the full six-arg form. A Java-authored `AuthStrategy` classifying its own token-response decode failure writes `new Api(message, decodeError)`, sets the marker, and the composite relabels an auth failure as a malformed response — #730 back through the slot added to kill it. Accident class; no adversary needs naming.

The marker constructor is now `private`, reached through an internal **factory** (internal *functions* are mangled: `malformedBody$com_basecamp_basecamp_sdk`). Emitted surface after the fix:

```
private   Api(String, Integer, String, boolean, String, Throwable, SerializationException)   ACC_PRIVATE
public    Api(String, Integer, String, boolean, String, Throwable)                           ACC_PUBLIC
public    Api(String, …, Throwable, int, DefaultConstructorMarker)                           ACC_PUBLIC, ACC_SYNTHETIC
public    Api(String, …, Throwable, SerializationException, DefaultConstructorMarker)        ACC_PUBLIC, ACC_SYNTHETIC
```

Both marker-bearing bridges are synthetic (javac will not resolve those from source) and carry a trailing `DefaultConstructorMarker` no call site would write. The public constructor's signature and defaults are byte-identical, as promised.

New guard `ApiConstructorSurfaceTest` lives in **jvmTest**, because this is a property of what the JVM target emits: (1) no Java-selectable — public, non-synthetic — constructor takes a `SerializationException`; (2) the Java-selectable set is exactly the six-arg constructor, so (1) cannot pass vacuously; (3) no plainly-named `malformedBody` on the Java surface while a mangled one exists.

It looks the companion up reflectively rather than naming `Api.Companion`, and that is load-bearing: the first draft named it, so against the un-fixed shape the "red" run was an *unresolved reference*, not a failing assertion — a guard that can only fail by failing to compile proves nothing about what the build emitted. Reflective, it compiles against both shapes and reports **3/3 assertion failures** on the un-fixed code with **0 compile errors**, the first naming `(String, SerializationException)`, gradle `REAL_EXIT=1`.

What this does not prove, stated plainly: reflection over emitted constructors is the closest the toolchain gets to a Java caller here (no Java source set, no sample module), so it asserts the surface javac would choose from, not a compiled Java call site.

The `cause` channel the Kotlin conformance runner reads is untouched, and demonstrated rather than asserted: setting `cause = null` in the new factory fails **6 of 10** `DecodeIsolationTest` cases. The conformance suite passes 197/0/1-skipped — green there means the runner's `cause` branch does not *misfire* (it is a fixture-repair guard); `DecodeIsolationTest` is what proves it still fires.

## Red proofs — one regression test per call site

Each site's test was shown to fail against the un-fixed line by reverting **that one site alone** (exactly one line changed, diffed and verified on disk, restored by `cp` + `diff -q`, never `git checkout --`):

| mutated site | failing test | the other two suites |
|---|---|---|
| `DocumentsService.kt:117` | `DocumentsServiceTest.updateDoesNotRelabelAnAuthStrategyFailure` (1 of 10 failed) | Schedules 21/21, Todolists 24/24 green |
| `SchedulesService.kt:299` | `SchedulesServiceTest.updateDoesNotRelabelAnAuthStrategyFailure` (1 of 21 failed) | Documents 10/10, Todolists 24/24 green |
| `TodolistsService.kt:122` | `TodolistsServiceTest.updateDoesNotRelabelAnAuthStrategyFailure` (1 of 24 failed) | Schedules 21/21, Documents 10/10 green |

Each failure reads `the strategy's own exception must reach the caller unchanged ==> expected: <…the token endpoint returned a body that does not decode> but was: <…Get{Document,ScheduleEntry,TodolistOrGroup} returned a body that…>`, i.e. the relabelling itself, with a gradle `REAL_EXIT=1`.

`assertFailsWith<BasecampException.Api>` alone would be vacuous here — the class is right in both worlds. The assertions are `assertSame` on the strategy's own instance, the message, `hint == null`, and zero requests issued.

The positive half is guarded too: mutating `malformedBody` to leave the slot unset (simulating an over-narrow discriminator) fails **11** tests across the three suites, so the fix cannot pass by never re-hinting anything. The existing malformed-body tests were strengthened from `hint != null` to assert the composite's message and the escape-hatch hint text.

## Verification

Re-run on the round-2 head:

- Cold run with all Kotlin build dirs removed (`kotlin/{sdk,generator,conformance}/build`) and `--no-build-cache`: `:conformance:test :basecamp-sdk:check :generator:test` — `compileKotlinJvm`, `jvmTest`, `:conformance:test`, `:generator:test` all EXECUTED, none `FROM-CACHE`/`UP-TO-DATE`, **555 jvm tests, 0 failures**, `REAL_EXIT=0`.
- `make kt-test` → `REAL_EXIT=0`; `make kt-check-drift` → 250/250, no drift, `REAL_EXIT=0`; `make conformance-kotlin` → 197 passed, 0 failed, 1 skipped, `REAL_EXIT=0`.
- Regenerates nothing: the diff is 5 hand-written main files + 4 test files, no `generated/` paths.

## Scope

Kotlin-local by design. Swift answers the same question by substring sniff (`malformedBodyPhrase` in `swift/Sources/Basecamp/Services/BaseService.swift`), because `BasecampError.api` has no `cause` slot at all; unifying the two means an associated value — a Class C break — plus both conformance runners. That is filed as #750.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Distinguishes Kotlin composites’ own response decode failures from auth strategy exceptions and prevents accidental Java construction of decode-marked errors. Previously, composites relabeled any `BasecampException.Api` with a `kotlinx.serialization.SerializationException` cause; now they only re-hint when `decodeFailure` is present, which only the SDK sets.

- `BasecampException.Api` adds internal `decodeFailure`; the marker-bearing constructor is private and reachable only via internal, mangled factory `Api.malformedBody(...)`. The public 6‑arg constructor is unchanged; `jvmTest` `ApiConstructorSurfaceTest` asserts no Java-selectable constructor accepts `SerializationException` and the factory is only available under a mangled name.
- `BaseService.malformedBody` now uses `Api.malformedBody(...)` to set the marker while keeping `cause` intact.
- `DocumentsService`, `SchedulesService`, and `TodolistsService` now use `e.decodeFailure ?: throw e`, so auth-strategy `Api` exceptions pass through unchanged and only true response decode failures get composite-specific messages and hints.
- Tests updated to prove non-relabeling of auth failures and correct re-hinting on real decode failures.

Impact
- No migration required. Callers receive original auth-strategy `Api` exceptions; decode failures still get composite-specific messages and hints. Kotlin-only change; no generated files changed; Swift unaffected.

<sup>Written for commit acd1b22904c7e9fe81b5b19da02091fc2535735c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-sdk/pull/751?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

