### PR TITLE
Check that an operation lands on the same service in every SDK

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -211,6 +211,36 @@ jobs:
         env:
           LC_ALL: C
 
+      # The sibling of the two steps above and a different invariant: not which
+      # services exist, but which service each OPERATION hangs off. An operation
+      # routed to a different but already-existing service in ONE generator's
+      # table leaves the service-name union unchanged (so the gate above passes),
+      # the global operationId set unchanged (so every per-SDK
+      # check-*-service-drift passes), and the SDK compiling with its tests
+      # exercising the method wherever it now lives. Nothing else in this
+      # workflow looks at the pairing.
+      #
+      # Its own step rather than relying on `make check` membership: no CI job
+      # runs the full `make check`, so a gate that is only wired into that target
+      # is not covered here at all.
+      #
+      # Under LC_ALL=C so CI exercises the non-UTF-8-locale path (the reads are
+      # pinned to UTF-8; this proves it stays that way). The generated trees carry
+      # non-ASCII text in their @generated banners, so an unpinned read raises
+      # InvalidByteSequenceError before anything is compared.
+      - name: Five SDKs agree which service each operation lives on
+        run: make check-operation-assignment-parity
+        env:
+          LC_ALL: C
+
+      # The run above only ever exercises the PASSING case. This drives synthetic
+      # five-SDK trees through the same gate, including the wholesale class-swap
+      # case that a cheaper grouping comparison would pass.
+      - name: Operation assignment parity gate self-test (synthetic trees)
+        run: make test-check-operation-assignment-parity
+        env:
+          LC_ALL: C
+
       # The third Go surface. go-check-drift compares generated operations
       # against the hand-written go/pkg/basecamp wrappers; nothing watched the
       # GROUPED client until this gate, which is how ArchiveProject and

--- a/Makefile
+++ b/Makefile
@@ -1252,7 +1252,7 @@ tools:
 # Spec-shape lints
 #------------------------------------------------------------------------------
 
-.PHONY: check-gradle-serialization test-check-gradle-serialization check-bucket-flat-parity check-service-inventory-parity test-check-service-inventory-parity validate-api-gaps check-deprecation-parity kt-check-optional-arrays-and-scalars go-check-optional-pointers test-enhance-request-reachability check-fixture-coverage check-idempotency-parity check-write-semantics-parity check-retry-metadata-parity check-runner-test-reachability check-fixture-execution check-replay-decoder-parity check-readme-env-vars test-check-readme-env-vars lint-npm-lockfile-writes test-lint-npm-lockfile-writes test-assert-sdk-built test-assert-lockfiles-unchanged check-projected-examples
+.PHONY: check-gradle-serialization test-check-gradle-serialization check-bucket-flat-parity check-service-inventory-parity test-check-service-inventory-parity check-operation-assignment-parity test-check-operation-assignment-parity validate-api-gaps check-deprecation-parity kt-check-optional-arrays-and-scalars go-check-optional-pointers test-enhance-request-reachability check-fixture-coverage check-idempotency-parity check-write-semantics-parity check-retry-metadata-parity check-runner-test-reachability check-fixture-execution check-replay-decoder-parity check-readme-env-vars test-check-readme-env-vars lint-npm-lockfile-writes test-lint-npm-lockfile-writes test-assert-sdk-built test-assert-lockfiles-unchanged check-projected-examples
 
 # Verify every bucket-scoped GET list operation has a flat-path counterpart
 # (or is justified in spec/bucket-scoped-allowlist.txt). Cross-project SDK
@@ -1282,6 +1282,28 @@ check-service-inventory-parity:
 # normalization, then mutates one; the tracked tree is never written to.
 test-check-service-inventory-parity:
 	@ruby ./scripts/test-check-service-inventory-parity.rb
+
+# The sibling of the two targets above, and a DIFFERENT QUESTION: not which
+# services exist, but which service each OPERATION hangs off. If one generator
+# routes an operation to a different but ALREADY-EXISTING service, the service
+# name union is unchanged (so the gate above sees nothing), the global operationId
+# set is unchanged (so every per-SDK check-*-service-drift sees nothing), and the
+# SDK compiles with its tests exercising the method wherever it now lives. Five
+# SDKs then expose account.cardTables.get and one exposes account.cards.get, both
+# "present". Keyed on (method, path) rather than operationId because Ruby carries
+# operationId on reads only. Go is out of scope: it has no split table to
+# disagree with, and 27 of its operationIds are deliberately assigned elsewhere.
+check-operation-assignment-parity:
+	@echo "==> Checking cross-SDK operation assignment parity..."
+	@./scripts/check-operation-assignment-parity
+
+# Drive that gate from outside with synthetic repository trees, same shape as the
+# self-test above. Its live run only ever exercises the PASSING case. The roster
+# is scraped from openapi.json and the real Swift services rather than written
+# down, and the builder rotates through every request helper the gate declares a
+# pattern for, so a dead pattern fails the positive control.
+test-check-operation-assignment-parity:
+	@ruby ./scripts/test-check-operation-assignment-parity.rb
 
 # Verify @deprecated propagates to all six SDKs in the right signal class
 # (compiler=Kotlin; editor=TS/Go; doc-only=Ruby/Python/Swift), that the clean
@@ -1543,7 +1565,7 @@ check:
 	 if [ $$rc -ne 0 ]; then exit $$rc; fi; \
 	 echo "==> All checks passed"
 
-check-targets: check-gradle-serialization test-check-gradle-serialization lint-actions sync-spec-version-check smithy-check smithy-mapper-test behavior-model-check provenance-check sync-api-version-check doc-constants-check url-routes-check bc3-route-parity test-bc3-route-parity go-check-drift go-check-wrapper-drift go-check-generated-drift check-grouped-client-coverage test-check-grouped-client-coverage auth-routable-check check-service-inventory-parity test-check-service-inventory-parity kt-check-drift swift-check-drift go-check ts-check rb-check kt-check swift-check py-check check-bucket-flat-parity validate-api-gaps check-deprecation-parity check-fixture-coverage kt-check-optional-arrays-and-scalars go-check-optional-pointers test-enhance-request-reachability check-idempotency-parity check-write-semantics-parity check-retry-metadata-parity check-runner-test-reachability conformance check-fixture-execution check-replay-decoder-parity check-readme-env-vars test-check-readme-env-vars lint-npm-lockfile-writes test-lint-npm-lockfile-writes test-assert-sdk-built test-assert-lockfiles-unchanged check-projected-examples
+check-targets: check-gradle-serialization test-check-gradle-serialization lint-actions sync-spec-version-check smithy-check smithy-mapper-test behavior-model-check provenance-check sync-api-version-check doc-constants-check url-routes-check bc3-route-parity test-bc3-route-parity go-check-drift go-check-wrapper-drift go-check-generated-drift check-grouped-client-coverage test-check-grouped-client-coverage auth-routable-check check-service-inventory-parity test-check-service-inventory-parity check-operation-assignment-parity test-check-operation-assignment-parity kt-check-drift swift-check-drift go-check ts-check rb-check kt-check swift-check py-check check-bucket-flat-parity validate-api-gaps check-deprecation-parity check-fixture-coverage kt-check-optional-arrays-and-scalars go-check-optional-pointers test-enhance-request-reachability check-idempotency-parity check-write-semantics-parity check-retry-metadata-parity check-runner-test-reachability conformance check-fixture-execution check-replay-decoder-parity check-readme-env-vars test-check-readme-env-vars lint-npm-lockfile-writes test-lint-npm-lockfile-writes test-assert-sdk-built test-assert-lockfiles-unchanged check-projected-examples
 	@:
 
 # Clean all build artifacts

--- a/scripts/check-operation-assignment-parity
+++ b/scripts/check-operation-assignment-parity
@@ -51,10 +51,14 @@
 # states the method and the path for all 250, because it has to in order to make
 # the request.
 #
-# AND IT IS A MULTISET-SHAPED KEY, NOT A `{service -> path set}`, which is how
-# #756 words it. Paths collide verb-agnostically inside a single service:
-# `boosts` has GET and DELETE on /boosts/{}, `campfires` has GET and POST on
-# .../integrations.json. A set of paths per service silently loses those.
+# THE METHOD IS PART OF THE KEY, WHICH IS WHY IT IS NOT THE `{service -> path
+# set}` #756 words it as. Paths collide verb-agnostically inside a single
+# service: `boosts` has GET and DELETE on /boosts/{}, `campfires` has GET and
+# POST on .../integrations.json. A set of paths per service silently merges
+# those, so a reassignment of one of a pair would leave the set unchanged. With
+# the method included the key identifies exactly one operation — asserted against
+# openapi.json below rather than assumed, which is what lets the assignment be a
+# plain map instead of something that has to count.
 #
 # NO SIXTH HAND-COPY. openapi.json appears below for exactly two things: the
 # ROSTER of operations each SDK must be shown to emit, and the operationId used
@@ -332,9 +336,11 @@ if expected.length < MIN_OPERATIONS
        "the anchor collapsed, so nothing could be checked against it"])
 end
 
+# Only ever called with a key that came OUT of `expected`, so there is no
+# not-found branch to write.
 def label(expected, key)
-  op_id, sdk_path = expected[key]
-  op_id ? "#{op_id} (#{key.first} #{sdk_path})" : "#{key.first} #{key.last}"
+  op_id, sdk_path = expected.fetch(key)
+  "#{op_id} (#{key.first} #{sdk_path})"
 end
 
 # ---------------------------------------------------------------- extraction

--- a/scripts/check-operation-assignment-parity
+++ b/scripts/check-operation-assignment-parity
@@ -1,0 +1,447 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Guard: the five generated SDKs hang each OPERATION off the same service.
+#
+# `scripts/check-service-inventory-parity` answers "which services exist". This
+# answers "which service does a given operation live on", and they are different
+# questions with different data — #756 was filed separately from #755 for the
+# same reason. Do not merge them: the sibling gate's success line states exactly
+# one quantity, and its own header forbids growing per-SDK rules into it.
+#
+# WHAT IS UNDETECTABLE WITHOUT THIS. `SERVICE_SPLITS` maps tag -> {service ->
+# [operationIds]} and is transcribed by hand into five generator configs
+# (typescript/scripts, ruby/scripts, python/scripts,
+# kotlin/generator/.../Config.kt, swift's ServiceGrouper). If ONE of them routes
+# an operation to a DIFFERENT BUT ALREADY-EXISTING service, every gate stays
+# green:
+#
+#   - the service-name union is unchanged, so check-service-inventory-parity
+#     sees nothing: both services still exist in every SDK
+#   - the global operationId set is unchanged, so every per-SDK
+#     check-*-service-drift sees nothing: each SDK still matches its own
+#     generator, and the operation is still emitted somewhere
+#   - the SDK compiles, and its tests exercise the method wherever it now lives
+#
+# Five SDKs then expose `account.cardTables.get`, one exposes
+# `account.cards.get`, and both are "present". This gate is the only thing that
+# looks at the pairing.
+#
+# WHY GO IS NOT HERE, and it is not an oversight. `grep -rn
+# "SERVICE_SPLITS\|TAG_TO_SERVICE" go/` returns nothing: Go's service layer is
+# hand-authored wrappers over one flat oapi-codegen client
+# (go/pkg/generated/client.gen.go), which has no service grouping at all. Go has
+# no split table that could disagree with the other five, so it is outside this
+# failure mode entirely — the bug class is five tables, and five sources cover it
+# completely.
+#
+# Go is also deliberately assigned differently, which is the second reason. It
+# re-exposes TrashRecording on TEN services (cards.Trash(), documents.Trash(),
+# ...), and SetClientVisibility, ListLineupMarkers and the progress reports all
+# sit elsewhere by design: 27 operationIds that a six-source gate would have to
+# exempt. That carve-out table would be an order of magnitude larger than
+# check-service-inventory-parity's GO_CARVE_OUTS and would encode intent, not
+# drift. A gate whose exemption list is bigger than its signal is not a gate.
+#
+# THE KEY IS `(method, path)`, NOT operationId, and that is forced by Ruby.
+# operationId would be the better key — three pairwise diffs (TS<->KT, TS<->SW,
+# TS<->PY) come back empty on it — but Ruby carries `operation:` on reads only
+# (http_get, paginate, paginate_wrapped); http_put, http_post, http_delete and
+# http_post_raw never do, so it is available for 125 of 250 operations. Every SDK
+# states the method and the path for all 250, because it has to in order to make
+# the request.
+#
+# AND IT IS A MULTISET-SHAPED KEY, NOT A `{service -> path set}`, which is how
+# #756 words it. Paths collide verb-agnostically inside a single service:
+# `boosts` has GET and DELETE on /boosts/{}, `campfires` has GET and POST on
+# .../integrations.json. A set of paths per service silently loses those.
+#
+# NO SIXTH HAND-COPY. openapi.json appears below for exactly two things: the
+# ROSTER of operations each SDK must be shown to emit, and the operationId used
+# to LABEL a failure. It is never consulted for which service an operation
+# belongs on — deriving the expected assignment from openapi.json plus one
+# canonical split table is #756's "expensive, total" option 2, which is the shape
+# #745 rejected and which this gate deliberately does not build. The comparison
+# here is SDK against SDK.
+#
+# EXTRACTION COMPLETENESS IS CHECKED EXACTLY, so there is no MIN_ floor on the
+# per-SDK reads. A regex that stops matching returns nothing rather than an
+# error, which reads as "all clear" — the failure mode the sibling gate's
+# MIN_SERVICES floor exists to catch approximately. Here the anchor is exact:
+# openapi.json states how many operations there are and what their methods and
+# paths are, so an unrecognized request helper in one SDK is reported by NAME
+# ("typescript never emits PUT /account/logo.json") rather than as a count that
+# looks plausible. The one floor is on the anchor itself.
+#
+# THE SERVICE NAME COMES FROM THE CLASS DECLARATION, NOT THE FILENAME, and that
+# is what keeps this gate free of a per-SDK naming table. Filenames diverge —
+# `card-tables.ts`, `card_tables_service.rb`, `card_tables.py`, `card-tables.kt`,
+# `CardTablesService.swift`, plus the one module `generate_services.py` renames —
+# and reading them would mean transcribing check-service-inventory-parity's
+# per-source drop/strip/rename/spelling table a second time. The CLASS is
+# `#{service}Service` in all five, so one universal rule serves: squash to
+# lowercase alphanumerics, strip a trailing `service`. It also lands on the same
+# spelling Ruby and Python already emit in OperationInfo (`service:
+# "cardtables"`), which is what the failure messages below quote.
+#
+# The strip is `sub`, not `gsub`, and that is COSMETIC — say so rather than
+# implying a guarantee. A service group whose own name ended in "Service" would
+# be class `NotificationServiceService` in all five renderings, so any consistent
+# strip rule leaves all five agreeing and the verdict is the same either way;
+# only the name in the message changes. Reading the class rather than the filename
+# is what actually removes the hazard, because it removes the five different
+# spellings. (Measured: making this `gsub` turns no self-test case red, and the
+# suite says so instead of pretending otherwise.)
+#
+# It also has to be name-aware rather than a partition comparison. Comparing only
+# how operations are GROUPED would pass if one SDK swapped two classes' contents
+# wholesale, since the blocks and the name set are both unchanged and the sibling
+# gate compares name sets, not names to contents.
+#
+# NORMALIZATION IS DATA, NOT BRANCHES, same as the sibling gate. Each source is
+# a list of request-call patterns with named `method`/`path` captures (or a
+# constant `method:` where the helper implies the verb), plus one class pattern.
+# There is no per-SDK code path. If a new SDK needs something that is not one of
+# these fields, that is a finding about the generator, not a place to add an
+# `if`.
+#
+# Every read is pinned to UTF-8. The generated trees carry non-ASCII text (em
+# dashes in the @generated banners), so under LC_ALL=C an unpinned read raises
+# InvalidByteSequenceError and the gate fails before comparing anything. The CI
+# step runs under LC_ALL=C so that stays proven rather than asserted.
+#
+# Env seams (for scripts/test-check-operation-assignment-parity.rb — the tracked
+# tree is never written to):
+#   OPERATION_ASSIGNMENT_ROOT  repository root the sources are resolved against
+#
+# Usage: scripts/check-operation-assignment-parity
+
+require "json"
+require "set"
+
+REPO_ROOT = File.expand_path("..", __dir__)
+ROOT = ENV["OPERATION_ASSIGNMENT_ROOT"] || REPO_ROOT
+UTF8 = "UTF-8"
+
+# Floor on the ANCHOR, not on the SDK reads. openapi.json is walked with two
+# nested Hash iterations; a shape change (a moved `paths` key, a $ref-ed path
+# item) yields fewer operations rather than an error, and a collapsed anchor
+# would report all 250 operations as "extra" in all five SDKs — 1250 lines of
+# true statements describing the wrong problem. Deliberately far below the real
+# value: this catches collapse, not drift.
+MIN_OPERATIONS = 200
+
+# Every openapi.json path is account-scoped; the SDKs put the account in the base
+# URL and never in the path, so the prefix is stripped before comparing. Asserted
+# rather than assumed, because a convention change here would otherwise surface
+# as every operation missing from every SDK.
+ACCOUNT_PREFIX = %r{\A/\{accountId\}}
+
+# The five renderings. Each is a directory of generated service files.
+#
+#   class_pattern  captures the service class name; also splits the file, so
+#                  operations are attributed to the class they sit in rather
+#                  than to the file
+#   calls          request-call patterns. `(?<method>)`/`(?<path>)` are named so
+#                  a source whose generator emits them in the other order needs
+#                  no code; `method:` supplies the verb where the helper implies
+#                  it (a paginating read is always a GET)
+#   async_prefix   a second class per file mirroring the first (Python only)
+SOURCES = [
+  {
+    id: "typescript",
+    path: "typescript/src/generated/services",
+    ext: ".ts",
+    drop: ["index"],
+    class_pattern: /^export class (\w+) extends BaseService\b/,
+    calls: [
+      { pattern: /this\.client\.(?<method>GET|POST|PUT|DELETE|PATCH)\(\s*"(?<path>[^"]*)"/ },
+      # THE ONE GENERATED METHOD THAT CONCATENATES ITS URL. `updateAccountLogo`
+      # is the only `this.baseUrl` site in the whole generated TypeScript tree
+      # (typescript/src/generated/services/account.ts), and the only one that
+      # does not hand a literal path to openapi-fetch.
+      #
+      # Recorded as an EXTRA PATTERN rather than as an exemption, and the
+      # difference is the whole point. Exempting `PUT /account/logo.json` from
+      # TypeScript would mean this gate could never see that method move to
+      # another service — a hole in exactly the invariant being built. Reading it
+      # instead keeps TypeScript at 250/250. If the generator changes this
+      # emission shape the pattern stops matching, and the completeness check
+      # below says so by name; it cannot fail silent.
+      { pattern: /`\$\{this\.baseUrl\}`\s*\+\s*`(?<path>[^`]*)`;\s*return this\.requestMultipartUpload\(\s*\{.*?\},\s*url,\s*"(?<method>[A-Z]+)"/m },
+    ],
+  },
+  {
+    id: "ruby",
+    path: "ruby/lib/basecamp/generated/services",
+    ext: ".rb",
+    # Hand-written infrastructure living under generated/ by exception
+    # (AGENTS.md Hard Rule 1). It declares the http_* helpers the patterns below
+    # match on, in YARD @!method tags and in delegating definitions.
+    drop: ["base_service"],
+    class_pattern: /^\s*class (\w+) < BaseService\b/,
+    calls: [
+      # Anchored to the start of an indented line so the helper DECLARATIONS and
+      # doc comments in base_service.rb cannot be mistaken for call sites if the
+      # drop above ever slips.
+      { pattern: /^[ \t]+http_(?<method>get|put|post|delete|patch)\("(?<path>[^"]*)"/ },
+      { pattern: /^[ \t]+http_post_raw\("(?<path>[^"]*)"/, method: "post" },
+      { pattern: /^[ \t]+http_put_multipart\("(?<path>[^"]*)"/, method: "put" },
+      { pattern: /^[ \t]+paginate(?:_wrapped)?\("(?<path>[^"]*)"/, method: "get" },
+    ],
+  },
+  {
+    id: "python",
+    path: "python/src/basecamp/generated/services",
+    ext: ".py",
+    # `__init__.py` is the barrel; `_base.py` and `_async_base.py` are the
+    # hand-written base classes (AGENTS.md Hard Rule 1).
+    drop: ["__init__", "_base", "_async_base"],
+    class_pattern: /^class (\w+)\((?:Async)?BaseService\):/,
+    # EVERY PYTHON SERVICE IS EMITTED TWICE, sync and async, and the async twin
+    # is not redundant here: it is a second transcription of the same assignment
+    # by the same generator. The two are required to agree and the sync one is
+    # used, so an async class that drifted is reported as itself rather than
+    # doubling every key and making the multiset unreadable.
+    async_prefix: "Async",
+    calls: [
+      { pattern: /self\._request(?:_multipart_void|_void)?\(\s*OperationInfo\([^)]*\),\s*"(?<method>[A-Z]+)",\s*f?"(?<path>[^"]*)"/m },
+      { pattern: /self\._request_(?:paginated_wrapped|paginated|list)\(\s*OperationInfo\([^)]*\),\s*f?"(?<path>[^"]*)"/m, method: "GET" },
+      { pattern: /self\._request_raw\(\s*OperationInfo\([^)]*\),\s*f?"(?<path>[^"]*)"/m, method: "POST" },
+    ],
+  },
+  {
+    id: "kotlin",
+    path: "kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/services",
+    ext: ".kt",
+    drop: ["Types"],
+    # `open class` for the six services a hand-written composite overrides
+    # (SPEC.md section 18).
+    class_pattern: /^(?:open )?class (\w+)\(client: AccountClient\)/,
+    calls: [
+      # Kotlin appends its query string OUTSIDE the literal (`"..." + qs`), so
+      # capturing to the closing quote drops it without a rule.
+      { pattern: /http(?<method>Get|Put|Post|Delete|Patch)\("(?<path>[^"]*)"/ },
+      { pattern: /httpPostBinary\("(?<path>[^"]*)"/, method: "Post" },
+      { pattern: /httpPutMultipart\("(?<path>[^"]*)"/, method: "Put" },
+    ],
+  },
+  {
+    id: "swift",
+    path: "swift/Sources/Basecamp/Generated/Services",
+    ext: ".swift",
+    class_pattern: /^public final class (\w+): BaseService\b/,
+    calls: [
+      { pattern: /method: "(?<method>[A-Z]+)",\s*path: "(?<path>[^"]*)"/m },
+      { pattern: /requestPaginated(?:Wrapped)?\(\s*OperationInfo\([^)]*\),\s*path: "(?<path>[^"]*)"/m, method: "GET" },
+    ],
+  },
+].freeze
+
+failures = []
+
+def die(failures)
+  warn "FAIL: cross-SDK operation assignment parity"
+  warn ""
+  failures.each { |f| warn "  - #{f}" }
+  warn ""
+  # NEUTRAL ON PURPOSE, the same way check-service-inventory-parity's footer is.
+  # This prints for every failure class — a missing input, an operation read out
+  # of only four SDKs, a duplicated key, a drifted Python async twin — and most
+  # of those are not a split-table disagreement. Naming a cause the gate cannot
+  # observe sends the reader to five generator configs when the thing to look at
+  # is one regex or one file.
+  warn "  This gate compares which service each operation is emitted on, SDK against"
+  warn "  SDK. It can report WHICH renderings disagree and about WHICH operation; it"
+  warn "  cannot see WHY, so read the specific failures above for the area to look at."
+  exit 1
+end
+
+# One universal rule, because all five generators name the class
+# `#{service}Service`. `sub` not `gsub`: exactly one suffix comes off, so a
+# service group whose own name ends in "Service" is spelled the same way by all
+# five rather than being taken apart by one of them.
+def canonical_service(class_name)
+  class_name.downcase.gsub(/[^a-z0-9]/, "").sub(/service\z/, "")
+end
+
+def normalize_path(raw)
+  raw
+    .sub(/\?.*\z/m, "")        # Ruby's two http_post_raw sites carry ?name=...
+    .gsub(/\$\{[^}]*\}/, "{}") # TypeScript, Kotlin
+    .gsub(/#\{[^}]*\}/, "{}")  # Ruby
+    .gsub(/\\\([^)]*\)/, "{}") # Swift
+    .gsub(/\{[^}]*\}/, "{}")   # Python f-strings, and openapi.json itself
+end
+
+def scan_calls(body, calls)
+  calls.flat_map do |spec|
+    body.to_enum(:scan, spec[:pattern]).map do
+      m = Regexp.last_match
+      [(spec[:method] || m[:method]).upcase, normalize_path(m[:path])]
+    end
+  end
+end
+
+# Each service class, and the body between its declaration and the next one. A
+# file with no matching class contributes nothing, which is safe: its operations
+# then go missing from the completeness check by name.
+def class_chunks(body, class_pattern)
+  starts = body.to_enum(:scan, class_pattern).map { [Regexp.last_match.begin(0), Regexp.last_match[1]] }
+  starts.each_with_index.map do |(offset, name), i|
+    finish = starts[i + 1]&.first || body.length
+    [name, body[offset...finish]]
+  end
+end
+
+# ------------------------------------------------------------------- the anchor
+
+spec_path = File.join(ROOT, "openapi.json")
+die(["openapi.json not found — it is the roster this gate holds each SDK against"]) \
+  unless File.file?(spec_path)
+
+spec = JSON.parse(File.read(spec_path, encoding: UTF8))
+unprefixed = (spec["paths"] || {}).keys.reject { |p| p.match?(ACCOUNT_PREFIX) }
+unless unprefixed.empty?
+  die(["openapi.json path #{unprefixed.first.inspect} is not account-scoped; this gate strips " \
+       "`/{accountId}` to compare against the SDKs, which put the account in the base URL. " \
+       "Either the path is wrong or the convention changed — until that is settled every " \
+       "operation would read as missing from every SDK"])
+end
+
+# key -> [operationId, path as openapi spells it]. The operationId is for the
+# failure message only; nothing downstream reads a service out of this.
+expected = {}
+(spec["paths"] || {}).each do |path, item|
+  next unless item.is_a?(Hash)
+  item.each do |verb, operation|
+    next unless %w[get put post delete patch].include?(verb)
+    next unless operation.is_a?(Hash)
+    sdk_path = path.sub(ACCOUNT_PREFIX, "")
+    key = [verb.upcase, normalize_path(sdk_path)]
+    if expected.key?(key)
+      die(["openapi.json declares #{verb.upcase} #{sdk_path} twice; the key this gate compares on " \
+           "would not identify an operation"])
+    end
+    expected[key] = [operation["operationId"] || "(no operationId)", sdk_path]
+  end
+end
+
+if expected.length < MIN_OPERATIONS
+  die(["only #{expected.length} operations read from openapi.json (floor #{MIN_OPERATIONS}) — " \
+       "the anchor collapsed, so nothing could be checked against it"])
+end
+
+def label(expected, key)
+  op_id, sdk_path = expected[key]
+  op_id ? "#{op_id} (#{key.first} #{sdk_path})" : "#{key.first} #{key.last}"
+end
+
+# ---------------------------------------------------------------- extraction
+
+# id -> { [method, path] => canonical service }
+assignments = {}
+
+SOURCES.each do |source|
+  dir = File.join(ROOT, source[:path])
+  unless File.directory?(dir)
+    die(["#{source[:path]} not found — this gate compares generated output, so a missing " \
+         "rendering is a build problem, not a parity verdict"])
+  end
+
+  # Both maps are per-SOURCE, not per-file, so there is exactly ONE duplicate
+  # check rather than one per scope. A per-file check beside this one would be
+  # unreachable: no generator emits two sync service classes into one file, so it
+  # would be a guard with no case that can pin it.
+  assignment = {}
+  mirrors = {}
+
+  Dir.children(dir).select { |f| f.end_with?(source[:ext]) }.sort.each do |file|
+    stem = File.basename(file, source[:ext])
+    next if Array(source[:drop]).include?(stem)
+
+    body = File.read(File.join(dir, file), encoding: UTF8)
+
+    class_chunks(body, source[:class_pattern]).each do |class_name, chunk|
+      prefix = source[:async_prefix]
+      mirror = prefix && class_name.start_with?(prefix)
+      bucket = mirror ? mirrors : assignment
+      service = canonical_service(mirror ? class_name.delete_prefix(prefix) : class_name)
+
+      scan_calls(chunk, source[:calls]).each do |key|
+        # A key claimed twice inside one SDK, which happens when two split
+        # entries both list the operation. Overwriting would hide an operation
+        # emitted on two services — a real surface bug, and one this gate is the
+        # only reader of, since the SDK is internally consistent with its own
+        # generator either way and the operationId set is unchanged.
+        if bucket.key?(key) && bucket[key] != service
+          failures << "#{source[:id]} emits #{key.first} #{key.last} on BOTH " \
+                      "`#{bucket[key]}` and `#{service}` (#{file}); an operation on two " \
+                      "services has no single assignment to compare"
+        end
+        bucket[key] = service
+      end
+    end
+  end
+
+  # Python's async twin: a second transcription of the same assignment by the
+  # same generator, and it must agree before the sync one is trusted. Reported as
+  # itself rather than folded into the cross-SDK diff, which would describe
+  # Python as disagreeing with the other four when it disagrees with itself.
+  if source[:async_prefix]
+    (assignment.keys | mirrors.keys).sort.each do |key|
+      next if assignment[key] == mirrors[key]
+      failures << "#{source[:id]}: #{key.first} #{key.last} is on " \
+                  "`#{assignment[key] || '(absent)'}` in the sync class but " \
+                  "`#{mirrors[key] || '(absent)'}` in the #{source[:async_prefix]} class"
+    end
+  end
+
+  assignments[source[:id]] = assignment
+end
+
+# --------------------------------------------------------------- completeness
+
+# Reported BEFORE the parity diff, and separately from it. An operation read out
+# of four SDKs and not the fifth is an extraction or emission problem; describing
+# it as an assignment disagreement would name a cause the gate has not observed.
+assignments.each do |id, assignment|
+  missing = (expected.keys - assignment.keys).sort
+  extra = (assignment.keys - expected.keys).sort
+
+  missing.each do |key|
+    failures << "#{id} never emits #{label(expected, key)} — openapi.json declares it, so either " \
+                "the SDK is short an operation or this gate's #{id} request-call patterns no " \
+                "longer match how the generator emits it. Nothing about assignment follows " \
+                "from this either way"
+  end
+  extra.each do |key|
+    failures << "#{id} emits #{key.first} #{key.last} on `#{assignment[key]}`, and openapi.json " \
+                "declares no such operation — the SDK is ahead of the spec, or the path was " \
+                "read wrong"
+  end
+end
+
+die(failures) unless failures.empty?
+
+# --------------------------------------------------------------------- parity
+
+expected.keys.sort.each do |key|
+  by_service = assignments.each_with_object({}) do |(id, assignment), acc|
+    (acc[assignment[key]] ||= []) << id
+  end
+  next if by_service.size == 1
+
+  spread = by_service.sort_by { |service, ids| [-ids.length, service.to_s] }
+                     .map { |service, ids| "`#{service}` in #{ids.sort.join(', ')}" }
+                     .join("; ")
+  failures << "#{label(expected, key)} is assigned to different services: #{spread}. " \
+              "Look at the SERVICE_SPLITS entry for this operation in the generator configs " \
+              "of the renderings that disagree"
+end
+
+die(failures) unless failures.empty?
+
+puts "OK: cross-SDK operation assignment parity — #{expected.length} operations each land on " \
+     "the same service in all #{assignments.size} generated SDKs " \
+     "(#{assignments.keys.join(', ')}); Go has no split table and is out of scope"

--- a/scripts/test-check-operation-assignment-parity.rb
+++ b/scripts/test-check-operation-assignment-parity.rb
@@ -1,0 +1,746 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+# Negative-case self-test for scripts/check-operation-assignment-parity.
+#
+# The gate's own `make check` run only ever exercises the PASSING case, so nothing
+# there proves it rejects anything. This repo treats an ungated gate as no gate,
+# and a parity gate that cannot fail is worse than none: it converts "nobody
+# compared them" into "the gate says they agree".
+#
+# Every case drives the real checker through its one env seam
+# (OPERATION_ASSIGNMENT_ROOT) against a synthetic repository tree in a tmpdir. The
+# tracked tree is never written to.
+#
+# THE SYNTHETIC TREE IS ITSELF UNDER TEST, the same way
+# test-check-service-inventory-parity.rb's is. It is built by INVERTING what the
+# checker reads: five class-declaration syntaxes, every request helper the checker
+# declares a pattern for, and all four path-interpolation spellings (`{p}`,
+# `${p}`, `#{p}`, `\(p)`). A builder that spelled anything differently from the
+# real generators would make every negative case below fail for a reason
+# unrelated to its mutation, so the synthetic positive control runs second and is
+# as load-bearing as the real one.
+#
+# THE ROSTER IS SCRAPED, NOT WRITTEN DOWN. operationId -> (method, path) comes
+# from openapi.json and operationId -> service from the real Swift service
+# filenames plus their `operation:` strings. A literal would be a sixth hand-copy
+# of the very table this gate exists because there are already five of. The scrape
+# is deliberately NOT the checker's own extraction: it keys on operationId, which
+# the checker never reads out of an SDK, so the builder and the thing it drives
+# do not share a reader.
+#
+# EXERCISING EVERY DECLARED HELPER IS THE POINT OF THE ROTATION below. The
+# checker declares 13 request-call patterns across the five sources; a pattern
+# that matches nothing is a dead rule, indistinguishable from a stale carve-out.
+# The builder rotates helper choice by the operation's index so each pattern is
+# hit, which makes the synthetic positive control fail if any of them is deleted
+# or misspelled.
+#
+# OPERATION_ASSIGNMENT_CHECKER names the checker under test (default
+# scripts/check-operation-assignment-parity), so a deliberately-mutated copy can
+# be driven through the same suite to prove the suite is not vacuous:
+#
+#   cp scripts/check-operation-assignment-parity /tmp/m       # mutate the COPY
+#   OPERATION_ASSIGNMENT_CHECKER=/tmp/m ruby scripts/test-check-operation-assignment-parity.rb
+#
+# The copy resolves its sources from OPERATION_ASSIGNMENT_ROOT, which every case
+# sets, so it needs nothing beside it. Never mutate the tracked file.
+#
+# Every guard in the checker is pinned by at least one case, and the mapping below
+# is MEASURED — mutate the guard in a copy, record which cases go red — rather
+# than reasoned about. Removing a guard from the copy must turn exactly this red:
+#
+#   guard mutated in the copy                       cases that go red
+#   ---------------------------------------------   -----------------------------
+#   the parity comparison                           1, 2, 3
+#   parity keyed on GROUPING, not on the name       3 (checker PASSES; see below)
+#   the completeness comparison (missing)           4, 5
+#   the completeness comparison (extra)             6
+#   the duplicate-key check                         7
+#   Python sync/async agreement check               8
+#   source-directory-exists check                   9
+#   openapi.json-exists check                       10
+#   account-prefix assertion                        11
+#   MIN_OPERATIONS floor on the anchor              12
+#   completeness reported BEFORE parity             4, 5
+#   the TypeScript baseUrl-concatenation pattern    both controls, 1, 2, 3, 13
+#   any other request-call pattern (10 measured)    both controls, 1, 2, 3, 13
+#   the `?`-suffix strip in normalize_path          both controls, 1, 2, 3, 13
+#   any of the four interpolation substitutions     both controls, 1, 2, 3, 13
+#   `sub` -> `gsub` on the service-suffix strip     NOTHING — see below
+#
+# THE BLUNT ROWS, AND WHY THEY ARE NOT THE PINS. Deleting any request-call pattern
+# turns both controls red plus 1, 2, 3 and 13, because a checker that cannot read
+# one SDK completely fails every case that expected some other verdict. Those
+# rows are smoke alarms, not pins. The pins are the sharp rows above them, and
+# they were MEASURED to be sharp: removing the parity comparison turns EXACTLY 1,
+# 2 and 3 red and nothing else; removing the duplicate-key check turns EXACTLY 7
+# red. What the blunt rows do buy is dead-rule detection — a pattern that matches
+# nothing is indistinguishable from a stale carve-out, and the rotation in the
+# builder is what makes all 13 of them load-bearing.
+#
+# ONE MUTATION SURVIVES ON PURPOSE, and it is recorded rather than papered over.
+# Changing the service-suffix strip from `sub` to `gsub` turns no case red, because
+# the strip is cosmetic: all five generators spell the class identically, so any
+# consistent rule leaves all five agreeing. No case is added for it, because a
+# case that cannot distinguish the two would be decoration. The checker's header
+# says the same thing at the code.
+#
+# TWO CASES PIN A MESSAGE RATHER THAN A VERDICT (4 and 5), which is deliberate. An
+# operation read out of four SDKs and not the fifth is an extraction or emission
+# problem, and describing it as an assignment disagreement would send the reader
+# to five generator configs when the thing to look at is one regex. Both are
+# pinned as ABSENCES (`expect_fail_without`), because the only way to hold a
+# diagnostic honest is to assert what it must NOT say. Case 13 is the mirror: it
+# expects a PASS, and pins that the gate answers ONE question — agreement — and
+# does not smuggle in a fixed service roster, which is
+# check-service-inventory-parity's question and not this one.
+#
+# Cases 1, 2 and 3 share the parity comparison and are not redundant: a
+# single-SDK reassignment, a two-SDK reassignment (which is what the reported
+# grouping has to render), and two classes whose contents were swapped wholesale.
+#
+# The third is the discriminator, and the grouping row above is its proof — read
+# with care, because all three go red under that mutation and only one of them is
+# the signal. Rekey the parity comparison on how operations are GROUPED rather
+# than on the service NAME (the cheaper instrument someone will propose) and 1 and
+# 2 go red on the MESSAGE — they still fail, the spread just no longer names the
+# services — while case 3 goes red because the mutated checker PASSES OUTRIGHT.
+# That is the only row in this file where a mutation makes the checker miss a real
+# defect, and case 3 is the only case that catches it. Both blocks and the
+# service-name set are unchanged in a wholesale swap, and
+# check-service-inventory-parity compares name SETS rather than names to contents,
+# so nothing else in `make` would see it.
+#
+# WHAT THIS SUITE IS NOT. The suite passing means these thirteen things are
+# checked. It has never meant the list is complete.
+#
+# Run directly (`ruby scripts/test-check-operation-assignment-parity.rb`) or via
+# `make test-check-operation-assignment-parity`.
+
+require "fileutils"
+require "json"
+require "open3"
+require "tmpdir"
+
+# Per-case lines go to stdout and the failure report to stderr. Unsynced, stdout
+# block-buffers when redirected to a file and the report lands ahead of the cases
+# it summarizes — which is exactly when someone is reading the log.
+$stdout.sync = true
+
+ROOT = File.expand_path("..", __dir__)
+CHECKER = File.expand_path(
+  ENV.fetch("OPERATION_ASSIGNMENT_CHECKER", "scripts/check-operation-assignment-parity"), ROOT
+)
+
+TS_DIR = "typescript/src/generated/services"
+RB_DIR = "ruby/lib/basecamp/generated/services"
+PY_DIR = "python/src/basecamp/generated/services"
+KT_DIR = "kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/services"
+SW_DIR = "swift/Sources/Basecamp/Generated/Services"
+SW_REAL = File.join(ROOT, SW_DIR)
+OPENAPI = "openapi.json"
+
+def read_utf8(path) = File.read(path, encoding: "UTF-8")
+
+def snake_case(name)
+  name.gsub(/([a-z0-9])([A-Z])/, '\1_\2').gsub(/([A-Z]+)([A-Z][a-z])/, '\1_\2').downcase
+end
+
+def lower_camel(name)
+  parts = snake_case(name).split("_")
+  ([parts.first] + parts.drop(1).map(&:capitalize)).join
+end
+
+# --- The scraped roster --------------------------------------------------------
+#
+# operationId -> { method:, path:, service: }. `service` is the Pascal service
+# name (`CardTables`), which is what every generator builds its class name from.
+
+spec = JSON.parse(read_utf8(File.join(ROOT, OPENAPI)))
+wire = {}
+spec.fetch("paths").each do |path, item|
+  item.each do |verb, operation|
+    next unless %w[get put post delete patch].include?(verb)
+    id = operation["operationId"]
+    raise "openapi.json has an operation with no operationId at #{verb} #{path}" if id.nil?
+    raise "openapi.json path #{path} is not account-scoped" unless path.start_with?("/{accountId}")
+    wire[id] = { method: verb.upcase, path: path.sub("/{accountId}", "") }
+  end
+end
+
+# Service assignment, read off the real Swift tree by operationId — a key the
+# checker never extracts from any SDK, so this scrape shares no reader with it.
+ROSTER = {}
+Dir.children(SW_REAL).select { |f| f.end_with?("Service.swift") }.sort.each do |file|
+  service = File.basename(file, "Service.swift")
+  read_utf8(File.join(SW_REAL, file)).scan(/operation: "(\w+)"/).flatten.uniq.each do |id|
+    raise "#{id} appears on two Swift services" if ROSTER.key?(id)
+    raise "#{id} is on a Swift service but not in openapi.json" unless wire.key?(id)
+    ROSTER[id] = wire.fetch(id).merge(service: service)
+  end
+end
+ROSTER.freeze
+
+raise "roster came back with #{ROSTER.length} operations; the real tree changed shape" \
+  if ROSTER.length < 200
+raise "roster is short of openapi.json (#{ROSTER.length} vs #{wire.length})" \
+  unless ROSTER.length == wire.length
+
+# The operations the cases below move around. Both services must survive the move
+# with at least one operation left, or the mutation would also delete a service —
+# a different failure, and one check-service-inventory-parity owns.
+MOVED = "GetCard"
+MOVED_TO = "CardTables"
+raise "case setup needs #{MOVED} to exist" unless ROSTER.key?(MOVED)
+FROM_SERVICE = ROSTER.fetch(MOVED).fetch(:service)
+raise "#{MOVED} is already on #{MOVED_TO}" if FROM_SERVICE == MOVED_TO
+raise "moving #{MOVED} would empty #{FROM_SERVICE}" \
+  unless ROSTER.count { |_, o| o[:service] == FROM_SERVICE } > 1
+
+def canonical(service) = service.downcase.gsub(/[^a-z0-9]/, "").sub(/service\z/, "")
+
+# --- Synthetic tree builder ----------------------------------------------------
+#
+# One emitter per source, each inverting what the checker reads out of that SDK.
+# `index` is the operation's position in the sorted roster and drives the helper
+# rotation described in the header.
+
+def interpolate(path, style)
+  path.gsub(/\{(\w+)\}/) do
+    param = Regexp.last_match(1)
+    case style
+    when :braces then "{#{param}}"
+    when :dollar then "${#{param}}"
+    when :hash   then "\#{#{snake_case(param)}}"
+    when :paren  then "\\(#{param})"
+    when :fstr   then "{#{snake_case(param)}}"
+    else raise "unknown interpolation style #{style.inspect}"
+    end
+  end
+end
+
+def write_file(root, rel, body)
+  path = File.join(root, rel)
+  FileUtils.mkdir_p(File.dirname(path))
+  File.write(path, body)
+end
+
+# The one generated TypeScript method that concatenates its URL instead of
+# handing a literal to openapi-fetch. Named here for the same reason the checker
+# names it: it is the only such site, and the pattern that reads it can only be
+# pinned by a case that emits it.
+TS_CONCAT_OPS = %w[UpdateAccountLogo].freeze
+
+def ts_method(id, op, index)
+  path = interpolate(op[:path], :braces)
+  name = lower_camel(id)
+  if TS_CONCAT_OPS.include?(id)
+    <<~TS
+        async #{name}(file: Blob): Promise<void> {
+          const url = `${this.baseUrl}` +
+            `#{path}`;
+          return this.requestMultipartUpload(
+            {
+              service: "#{op[:service]}",
+              operation: "#{id}",
+              isMutation: true,
+            },
+            url,
+            "#{op[:method]}",
+            file,
+          );
+        }
+    TS
+  else
+    <<~TS
+        async #{name}(): Promise<unknown> {
+          return this.request(
+            { service: "#{op[:service]}", operation: "#{id}", isMutation: #{index.even?} },
+            () => this.client.#{op[:method]}("#{path}", { params: {} })
+          );
+        }
+    TS
+  end
+end
+
+def rb_method(id, op, index)
+  path = interpolate(op[:path], :hash)
+  call =
+    case [op[:method], index % 4]
+    when ["GET", 0] then %(paginate("#{path}", operation: "#{id}"))
+    when ["GET", 1] then %(paginate_wrapped("#{path}", "events", operation: "#{id}"))
+    when ["POST", 0] then %(http_post_raw("#{path}?name=\#{URI.encode_www_form_component(name.to_s)}", body: nil))
+    when ["PUT", 0] then %(http_put_multipart("#{path}", io: io, field: "logo"))
+    else
+      case op[:method]
+      when "GET" then %(http_get("#{path}", operation: "#{id}"))
+      when "PUT" then %(http_put("#{path}", body: nil))
+      when "POST" then %(http_post("#{path}", body: nil))
+      when "DELETE" then %(http_delete("#{path}"))
+      when "PATCH" then %(http_patch("#{path}", body: nil))
+      else raise "unhandled method #{op[:method]}"
+      end
+    end
+  <<~RUBY
+        def #{snake_case(id)}
+          #{call}
+        end
+  RUBY
+end
+
+def py_body(id, op, index, indent)
+  path = interpolate(op[:path], :fstr)
+  info = %(OperationInfo(service="#{canonical(op[:service])}", operation="#{snake_case(id)}", is_mutation=#{index.even? ? 'True' : 'False'}))
+  call =
+    case [op[:method], index % 4]
+    when ["GET", 0] then %(_request_paginated(\n    #{info},\n    f"#{path}",\n    operation="#{id}",\n))
+    when ["GET", 1] then %(_request_paginated_wrapped(\n    #{info},\n    f"#{path}",\n    "events",\n    operation="#{id}",\n))
+    when ["GET", 2] then %(_request_list(\n    #{info},\n    "#{path}",\n    operation="#{id}",\n))
+    when ["POST", 0] then %(_request_raw(\n    #{info},\n    f"#{path}",\n    content=b"",\n    operation="#{id}",\n))
+    when ["PUT", 0] then %(_request_multipart_void(\n    #{info},\n    "PUT",\n    f"#{path}",\n    field="logo",\n))
+    when ["DELETE", 0], ["DELETE", 1], ["DELETE", 2], ["DELETE", 3]
+      %(_request_void(\n    #{info},\n    "DELETE",\n    f"#{path}",\n))
+    else
+      %(_request(\n    #{info},\n    "#{op[:method]}",\n    f"#{path}",\n    operation="#{id}",\n))
+    end
+  call.lines.map { |l| l == "\n" ? l : "#{indent}#{l}" }.join
+end
+
+def py_method(id, op, index, async:)
+  kw = async ? "async def" : "def"
+  await = async ? "await " : ""
+  <<~PY
+      #{kw} #{snake_case(id)}(self):
+          return #{await}self.#{py_body(id, op, index, '        ').lstrip}    )
+  PY
+end
+
+def kt_method(id, op, index)
+  path = interpolate(op[:path], :dollar)
+  call =
+    case [op[:method], index % 4]
+    when ["GET", 0] then %(httpGet("#{path}" + qs, operationName = info.operation))
+    when ["POST", 0] then %(httpPostBinary("#{path}", data, contentType))
+    when ["PUT", 0] then %(httpPutMultipart("#{path}", data, contentType))
+    else %(http#{op[:method].capitalize}("#{path}", operationName = info.operation))
+    end
+  <<~KT
+        suspend fun #{lower_camel(id)}(): JsonElement {
+            val info = OperationInfo(
+                service = "#{op[:service]}",
+                operation = "#{id}",
+                isMutation = #{index.even?},
+            )
+            return request(info, {
+                #{call}
+            }) { body -> json.parseToJsonElement(body) }
+        }
+  KT
+end
+
+def sw_method(id, op, index)
+  path = interpolate(op[:path], :paren)
+  info = %(OperationInfo(service: "#{op[:service]}", operation: "#{id}", isMutation: #{index.even?}))
+  call =
+    case [op[:method], index % 4]
+    when ["GET", 0]
+      %(requestPaginated(\n            #{info},\n            path: "#{path}"\n        ))
+    when ["GET", 1]
+      %(requestPaginatedWrapped(\n            #{info},\n            path: "#{path}",\n            key: "events"\n        ))
+    when ["DELETE", 0], ["DELETE", 1], ["DELETE", 2], ["DELETE", 3]
+      %(requestVoid(\n            #{info},\n            method: "#{op[:method]}",\n            path: "#{path}"\n        ))
+    else
+      %(request(\n            #{info},\n            method: "#{op[:method]}",\n            path: "#{path}"\n        ))
+    end
+  <<~SW
+        public func #{lower_camel(id)}() async throws -> Data {
+            return try await #{call}
+        }
+  SW
+end
+
+# `plan` is a list of [operationId, op, index] already resolved to its
+# (possibly reassigned) service, grouped by the class it must be emitted into.
+def group(plan)
+  plan.group_by { |_id, op, _i| op[:service] }.transform_values { |v| v.sort_by { |id, _, _| id } }
+       .sort.to_h
+end
+
+def build_root(dir, plan:, async_plan:, openapi:)
+  write_file(dir, OPENAPI, JSON.pretty_generate(openapi))
+
+  group(plan).each do |service, ops|
+    snake = snake_case(service)
+
+    write_file(dir, "#{TS_DIR}/#{snake.tr('_', '-')}.ts", <<~TS)
+      import { BaseService } from "../../services/base.js";
+
+      export class #{service}Service extends BaseService {
+      #{ops.map { |id, op, i| ts_method(id, op, i) }.join("\n")}
+      }
+    TS
+
+    write_file(dir, "#{RB_DIR}/#{snake}_service.rb", <<~RUBY)
+      # frozen_string_literal: true
+
+      module Basecamp
+        module Services
+          class #{service}Service < BaseService
+      #{ops.map { |id, op, i| rb_method(id, op, i) }.join("\n")}
+          end
+        end
+      end
+    RUBY
+
+    write_file(dir, "#{KT_DIR}/#{snake.tr('_', '-')}.kt", <<~KT)
+      package com.basecamp.sdk.generated.services
+
+      class #{service}Service(client: AccountClient) : BaseService(client) {
+      #{ops.map { |id, op, i| kt_method(id, op, i) }.join("\n")}
+      }
+    KT
+
+    write_file(dir, "#{SW_DIR}/#{service}Service.swift", <<~SW)
+      // @generated — do not edit
+      import Foundation
+
+      public final class #{service}Service: BaseService, @unchecked Sendable {
+      #{ops.map { |id, op, i| sw_method(id, op, i) }.join("\n")}
+      }
+    SW
+  end
+
+  # Python is emitted from its own plan so a case can drift the async twin alone.
+  sync = group(plan)
+  async_ = group(async_plan)
+  (sync.keys | async_.keys).sort.each do |service|
+    snake = snake_case(service)
+    body = +"# @generated — do not edit\n\nfrom basecamp.hooks import OperationInfo\n\n\n"
+    body << "class #{service}Service(BaseService):\n"
+    ops = sync.fetch(service, [])
+    body << (ops.empty? ? "    pass\n" : ops.map { |id, op, i| py_method(id, op, i, async: false) }.join("\n"))
+    body << "\n\nclass Async#{service}Service(AsyncBaseService):\n"
+    aops = async_.fetch(service, [])
+    body << (aops.empty? ? "    pass\n" : aops.map { |id, op, i| py_method(id, op, i, async: true) }.join("\n"))
+    write_file(dir, "#{PY_DIR}/#{snake}.py", body)
+  end
+
+  # The non-service files each source drops, present so the drop rules are
+  # exercised rather than merely declared.
+  write_file(dir, "#{TS_DIR}/index.ts", "export * from \"./account.js\";\n")
+  write_file(dir, "#{RB_DIR}/base_service.rb", <<~RUBY)
+    module Basecamp
+      module Services
+        class BaseService
+          # @!method http_get(path, params: {})
+          # @!method http_put(path, body: nil)
+          def paginate(...) = @client.paginate(...)
+        end
+      end
+    end
+  RUBY
+  write_file(dir, "#{PY_DIR}/__init__.py", "from basecamp.generated.services.account import AccountService\n")
+  write_file(dir, "#{PY_DIR}/_base.py", "class BaseService:\n    def _paginate(self, path, **kw):\n        return None\n")
+  write_file(dir, "#{PY_DIR}/_async_base.py", "class AsyncBaseService:\n    async def _paginate(self, path, **kw):\n        return None\n")
+  write_file(dir, "#{KT_DIR}/Types.kt", "package com.basecamp.sdk.generated.services\n")
+end
+
+# Builds the per-SDK plans. `reassign` moves an operation to another service in
+# the named SDKs only; `reassign_async` does it in Python's async classes only;
+# `duplicate` ALSO emits it on a second service; `omit` drops it entirely.
+def plans(reassign: {}, reassign_async: {}, duplicate: {}, omit: {}, extra: {})
+  base = ROSTER.keys.sort.each_with_index.map { |id, i| [id, ROSTER.fetch(id), i] }
+  sdk_plan = lambda do |sdk|
+    rows = base.reject { |id, _, _| Array(omit[sdk]).include?(id) }
+    rows = rows.map do |id, op, i|
+      moved = (reassign[sdk] || {})[id]
+      [id, moved ? op.merge(service: moved) : op, i]
+    end
+    (duplicate[sdk] || {}).each { |id, service| rows << [id, ROSTER.fetch(id).merge(service: service), 0] }
+    (extra[sdk] || []).each { |row| rows << row }
+    rows
+  end
+  {
+    plan: sdk_plan,
+    async: lambda do |sdk|
+      rows = sdk_plan.call(sdk)
+      rows.map do |id, op, i|
+        moved = (reassign_async[sdk] || {})[id]
+        [id, moved ? op.merge(service: moved) : op, i]
+      end
+    end,
+  }
+end
+
+# Every source is written from the SAME plan unless a case names an SDK, so the
+# builder writes one tree and the checker's five readers must agree on it. That
+# is what makes the synthetic positive control a round-trip proof.
+def with_root(reassign: {}, reassign_async: {}, duplicate: {}, omit: {}, extra: {}, openapi: nil)
+  built = plans(reassign: reassign, reassign_async: reassign_async, duplicate: duplicate,
+                omit: omit, extra: extra)
+  Dir.mktmpdir("operation-assignment-parity-test") do |dir|
+    spec_paths = {}
+    ROSTER.each do |id, op|
+      (spec_paths["/{accountId}#{op[:path]}"] ||= {})[op[:method].downcase] = { "operationId" => id }
+    end
+    doc = openapi || { "openapi" => "3.0.3", "paths" => spec_paths }
+
+    # The five sources are built one at a time so a case can name a single SDK.
+    # Each writer only touches its own directory, so writing five trees into one
+    # root and keeping the last of each is exactly the same as five roots.
+    build_root(dir, plan: built[:plan].call("typescript"), async_plan: built[:async].call("python"),
+                    openapi: doc)
+    %w[ruby kotlin swift python].each do |sdk|
+      rebuild_source(dir, sdk, built[:plan].call(sdk), built[:async].call(sdk))
+    end
+
+    yield dir if block_given?
+    run_checker(dir)
+  end
+end
+
+# Rewrites one SDK's directory from its own plan, after build_root laid down all
+# five from the TypeScript plan. Removing the directory first is what makes an
+# `omit` or a reassignment that empties a service actually disappear.
+def rebuild_source(dir, sdk, plan, async_plan)
+  target = { "ruby" => RB_DIR, "kotlin" => KT_DIR, "swift" => SW_DIR, "python" => PY_DIR }.fetch(sdk)
+  FileUtils.rm_rf(File.join(dir, target))
+  Dir.mktmpdir("operation-assignment-parity-one") do |scratch|
+    build_root(scratch, plan: plan, async_plan: async_plan, openapi: { "paths" => {} })
+    FileUtils.mkdir_p(File.dirname(File.join(dir, target)))
+    FileUtils.cp_r(File.join(scratch, target), File.join(dir, target))
+  end
+end
+
+def run_checker(root)
+  out, status = Open3.capture2e({ "OPERATION_ASSIGNMENT_ROOT" => root }, "ruby", CHECKER)
+  # Under LC_ALL=C the captured output comes back tagged US-ASCII, and expected
+  # fragments can contain UTF-8 punctuation — so `out.include?` would raise
+  # Encoding::CompatibilityError before comparing anything. The bytes are UTF-8
+  # either way; only the tag is wrong.
+  [out.dup.force_encoding("UTF-8"), status]
+end
+
+failures = []
+
+def expect_pass(failures, label, out, status)
+  if status.success?
+    puts "  PASS  #{label}"
+  else
+    puts "  FAIL  #{label}"
+    failures << "#{label}: expected PASS but checker failed:\n#{out}"
+  end
+end
+
+def expect_fail(failures, label, out, status, *fragments)
+  missing = fragments.reject { |f| out.include?(f) }
+  if status.success?
+    puts "  FAIL  #{label}"
+    failures << "#{label}: expected FAILURE but checker passed:\n#{out}"
+  elsif !missing.empty?
+    puts "  FAIL  #{label}"
+    failures << "#{label}: failed as expected but message missing #{missing.map(&:inspect).join(', ')}:\n#{out}"
+  else
+    puts "  PASS  #{label}"
+  end
+end
+
+# Fails, AND the message must NOT contain `forbidden`. For diagnostics: a gate
+# that fails for the right reason while telling the reader the wrong place to look
+# is still a defect, and only an absence assertion can pin that.
+def expect_fail_without(failures, label, out, status, fragment, forbidden)
+  if status.success?
+    puts "  FAIL  #{label}"
+    failures << "#{label}: expected FAILURE but checker passed:\n#{out}"
+  elsif !out.include?(fragment)
+    puts "  FAIL  #{label}"
+    failures << "#{label}: failed as expected but message missing #{fragment.inspect}:\n#{out}"
+  elsif out.include?(forbidden)
+    puts "  FAIL  #{label}"
+    failures << "#{label}: failed correctly but MISDIAGNOSED — output contains " \
+                "#{forbidden.inspect}, which names a cause this failure does not have:\n#{out}"
+  else
+    puts "  PASS  #{label}"
+  end
+end
+
+puts "==> operation assignment parity self-test (checker: #{CHECKER.sub("#{ROOT}/", '')})"
+
+# --- Positive controls ---------------------------------------------------------
+#
+# Both load-bearing. The first says the real tree agrees; the second says the
+# synthetic builder spells all five renderings — and every request helper, and
+# all four interpolation styles — the way the real generators do, without which
+# no negative case below means anything.
+
+out, status = run_checker(ROOT)
+expect_pass(failures, "positive control: the real tree passes", out, status)
+
+out, status = with_root
+expect_pass(failures,
+            "positive control: the synthetic tree passes (builder round-trips #{ROSTER.length} operations)",
+            out, status)
+
+# --- 1. THE #756 SCENARIO -------------------------------------------------------
+#
+# One generator routes an operation to a DIFFERENT BUT ALREADY-EXISTING service.
+# The service-name union is unchanged, so check-service-inventory-parity sees
+# nothing; the global operationId set is unchanged, so every per-SDK
+# check-*-service-drift sees nothing. This is the case the gate exists for.
+
+out, status = with_root(reassign: { "typescript" => { MOVED => MOVED_TO } })
+expect_fail(failures, "1. one SDK assigns an operation to a different existing service", out, status,
+            "#{MOVED} (#{ROSTER.fetch(MOVED)[:method]} #{ROSTER.fetch(MOVED)[:path]}) is assigned to different services",
+            "`#{canonical(MOVED_TO)}` in typescript",
+            "`#{canonical(FROM_SERVICE)}` in kotlin, python, ruby, swift")
+
+# --- 2. Two SDKs on the minority side -------------------------------------------
+#
+# The reported grouping has to render a split rather than a single odd-one-out,
+# and the majority has to come first so the reader sees which way the weight lies.
+
+out, status = with_root(reassign: { "typescript" => { MOVED => MOVED_TO },
+                                    "kotlin" => { MOVED => MOVED_TO } })
+expect_fail(failures, "2. two SDKs reassign the same operation", out, status,
+            "`#{canonical(FROM_SERVICE)}` in python, ruby, swift; `#{canonical(MOVED_TO)}` in kotlin, typescript")
+
+# --- 3. Two classes whose contents were swapped wholesale ------------------------
+#
+# THE CASE A PARTITION COMPARISON WOULD PASS. Every block is unchanged and the
+# service-name set is unchanged — and check-service-inventory-parity compares name
+# SETS, not names to contents — so nothing but a name-aware comparison of the
+# assignment can see it. Users reach the wrong methods on both services.
+
+swapped = ROSTER.select { |_, op| [FROM_SERVICE, MOVED_TO].include?(op[:service]) }
+                .transform_values { |op| op[:service] == FROM_SERVICE ? MOVED_TO : FROM_SERVICE }
+out, status = with_root(reassign: { "swift" => swapped })
+expect_fail(failures, "3. one SDK swaps two classes' contents wholesale", out, status,
+            "is assigned to different services",
+            "`#{canonical(MOVED_TO)}` in swift")
+
+# --- 4. An operation missing from one SDK ---------------------------------------
+#
+# An extraction or emission problem, NOT an assignment disagreement. Pinned as an
+# absence: the gate must report it against openapi.json and must not send the
+# reader to five generator configs. It is also why completeness is reported and
+# exits BEFORE the parity diff — a key one SDK never emits would otherwise show
+# up as a nil service in the spread.
+
+out, status = with_root(omit: { "ruby" => [MOVED] })
+expect_fail_without(failures, "4. an operation one SDK never emits is reported as such", out, status,
+                    "ruby never emits #{MOVED}",
+                    "is assigned to different services")
+
+# --- 5. A request-call pattern that stopped matching ----------------------------
+#
+# Specifically the TypeScript baseUrl-concatenation pattern, which is the one
+# recorded oddity in the generated tree — the sole `this.baseUrl` site, and the
+# only generated method that does not hand a literal path to openapi-fetch.
+# Recorded as an extra PATTERN rather than as an exemption precisely so this case
+# can exist: exempting the operation would mean the gate could never see it move.
+# Rewriting the emission shape must be LOUD and must name the operation.
+
+out, status = with_root do |dir|
+  path = File.join(dir, TS_DIR, "account.ts")
+  body = read_utf8(path)
+  raise "the synthetic TypeScript account service has no baseUrl concatenation" \
+    unless body.include?("${this.baseUrl}")
+  File.write(path, body.gsub("`${this.baseUrl}` +", "this.resolveUrl("))
+end
+expect_fail_without(failures, "5. the TypeScript URL-concatenation pattern going blind is loud",
+                    out, status,
+                    "typescript never emits #{TS_CONCAT_OPS.first}",
+                    "is assigned to different services")
+
+# --- 6. An operation openapi.json does not declare ------------------------------
+
+phantom = ["ListFanfares", { method: "GET", path: "/fanfares.json", service: MOVED_TO }, 0]
+out, status = with_root(extra: { "kotlin" => [phantom] })
+expect_fail(failures, "6. an SDK emitting an operation the spec does not declare", out, status,
+            "kotlin emits GET /fanfares.json on `#{canonical(MOVED_TO)}`, and openapi.json declares no such operation")
+
+# --- 7. One operation on two services inside a single SDK -----------------------
+#
+# Both split entries list it, so the SDK emits the method twice. Building the
+# assignment map by assignment alone would silently keep whichever came last, and
+# every other gate is blind: the SDK is internally consistent with its own
+# generator either way, and the operationId set is unchanged.
+
+out, status = with_root(duplicate: { "swift" => { MOVED => MOVED_TO } })
+expect_fail(failures, "7. one SDK emitting an operation on two services", out, status,
+            "swift emits #{ROSTER.fetch(MOVED)[:method]}", "on BOTH")
+
+# --- 8. Python's async twin drifting from its sync class ------------------------
+#
+# Every Python service is emitted twice. The async class is a second
+# transcription of the same assignment by the same generator, and a user who
+# reaches for the async client gets the drifted one. Reported as itself rather
+# than folded into the cross-SDK diff, which would describe it as Python
+# disagreeing with the other four when Python disagrees with itself.
+
+out, status = with_root(reassign_async: { "python" => { MOVED => MOVED_TO } })
+expect_fail(failures, "8. Python's async class assigning an operation elsewhere", out, status,
+            "python: #{ROSTER.fetch(MOVED)[:method]}",
+            "`#{canonical(FROM_SERVICE)}` in the sync class but `#{canonical(MOVED_TO)}` in the Async class")
+
+# --- 9. A rendering that is not there -------------------------------------------
+
+out, status = with_root { |dir| FileUtils.rm_rf(File.join(dir, KT_DIR)) }
+expect_fail(failures, "9. missing input is a build problem, not a parity verdict", out, status,
+            "#{KT_DIR} not found")
+
+# --- 10. The anchor missing ------------------------------------------------------
+
+out, status = with_root { |dir| FileUtils.rm(File.join(dir, OPENAPI)) }
+expect_fail(failures, "10. openapi.json missing is named for what it is", out, status,
+            "openapi.json not found")
+
+# --- 11. A path the account prefix no longer covers -----------------------------
+#
+# The SDKs put the account in the base URL, so the prefix is stripped before
+# comparing. A convention change would otherwise surface as all 250 operations
+# missing from all five SDKs — 1250 true statements describing the wrong problem.
+
+bare = { "openapi" => "3.0.3", "paths" => { "/fanfares.json" => { "get" => { "operationId" => "ListFanfares" } } } }
+out, status = with_root(openapi: bare)
+expect_fail(failures, "11. an openapi path that is not account-scoped", out, status,
+            "is not account-scoped")
+
+# --- 12. Anchor collapse ---------------------------------------------------------
+#
+# A regex or a walk that stops matching returns nothing rather than an error,
+# which reads as "all clear". Here the walk is over openapi.json, and the floor
+# turns a collapsed anchor into one legible failure instead of 1250 lines.
+
+first = ROSTER.first(3).to_h { |id, op| ["/{accountId}#{op[:path]}", { op[:method].downcase => { "operationId" => id } }] }
+out, status = with_root(openapi: { "openapi" => "3.0.3", "paths" => first })
+expect_fail(failures, "12. extraction floor catches a collapsed anchor", out, status,
+            "the anchor collapsed")
+
+# --- 13. A service this gate has never heard of ---------------------------------
+#
+# ALL FIVE move an operation onto a brand-new service. This gate's question is
+# agreement, and only agreement: which services exist is
+# check-service-inventory-parity's question, and answering both here is the
+# failure mode #755 documents. So a roster change every SDK made together must
+# PASS — a rule that exists to prevent a false positive can only be pinned by a
+# case that is supposed to pass.
+
+everywhere = %w[typescript ruby python kotlin swift].to_h { |sdk| [sdk, { MOVED => "Fanfares" }] }
+out, status = with_root(reassign: everywhere, reassign_async: everywhere)
+expect_pass(failures, "13. a new service all five SDKs agree on is not this gate's business",
+            out, status)
+
+# --- Report --------------------------------------------------------------------
+
+puts
+if failures.empty?
+  puts "==> operation assignment parity self-test: all cases passed"
+  exit 0
+else
+  warn "==> operation assignment parity self-test: #{failures.length} case(s) failed"
+  warn ""
+  failures.each { |f| warn "  #{f}\n\n" }
+  exit 1
+end


### PR DESCRIPTION
Closes #756.

`check-service-inventory-parity` answers *which services exist*. Nothing answered *which service each operation hangs off* — and if one generator routes an operation to a different but already-existing service, every existing gate stays green:

- the service-name union is unchanged, so the sibling gate sees nothing — both services still exist in every SDK;
- the global operationId set is unchanged, so every per-SDK `check-*-service-drift` sees nothing — each SDK still matches its own generator, and the operation is still emitted somewhere;
- the SDK compiles, and its tests exercise the method wherever it now lives.

Five SDKs then expose `account.cardTables.get`, one exposes `account.cards.get`, and both are "present".

## A new sibling gate, not a second question bolted onto the existing one

`scripts/check-operation-assignment-parity` + `scripts/test-check-operation-assignment-parity.rb`, modelled on the existing pair but sharing none of its table. Zero of the sibling gate's eight `SOURCES` entries are reusable here: different inputs (method bodies vs filenames), different key space (250 vs 53), different source count (5 vs 8). Its success line states exactly one quantity, its self-test case 15 pins an absence in its failure footer, and its own header forbids growing per-SDK rules into it. Bolting a second invariant on is the failure mode #755 documents.

What is reused is the *idioms*: normalization as data rather than branches, UTF-8-pinned reads, and a self-test that builds a full synthetic five-SDK repo in `Dir.mktmpdir` behind an env seam, with the canonical roster scraped from the real tree rather than written as a literal.

## Why Go is excluded, which is not an oversight

`grep -rn "SERVICE_SPLITS\|TAG_TO_SERVICE" go/` returns nothing. Go's service layer is hand-authored wrappers over one flat oapi-codegen client with no service grouping at all — **it has no split table that could disagree with the other five**, so it sits outside this failure mode entirely. The bug class is five hand-transcribed tables, and five sources cover it completely.

Go is also *deliberately* assigned differently, which is the second reason: it re-exposes `TrashRecording` on ten services (`cards.Trash()`, `documents.Trash()`, …), and `SetClientVisibility`, `ListLineupMarkers` and the progress reports all sit elsewhere by design — 27 operationIds a six-source gate would have to exempt. That table would be an order of magnitude larger than the sibling gate's `GO_CARVE_OUTS` and would encode intent, not drift. A gate whose exemption list is bigger than its signal is not a gate.

## The key is `(method, path)`, and it is a multiset

operationId would be the better key — three pairwise diffs (TS↔KT, TS↔SW, TS↔PY) come back empty on it — but **Ruby carries `operation:` on reads only** (`http_get`, `paginate`, `paginate_wrapped`); `http_put`, `http_post`, `http_delete` and `http_post_raw` never do, so it is available for 125 of 250. Every SDK states the method and the path for all 250, because it has to in order to make the request.

The method is part of the key, which is why this is not the `{service → path set}` the issue words it as: paths collide verb-agnostically inside one service — `boosts` has GET and DELETE on `/boosts/{}`, `campfires` has GET and POST on `…/integrations.json`. A set of paths per service silently merges those.

**TypeScript's `updateAccountLogo` is handled as an extra extraction pattern, not an exemption.** It is the sole generated method that builds its URL by concatenation (the only `this.baseUrl` site in the generated tree). Exempting `PUT /account/logo.json` from TypeScript would mean the gate could never see that operation move — a hole in exactly the invariant being built. Reading the concat keeps TS at 250/250, and self-test case 5 pins that breaking the pattern is loud.

## Two properties worth calling out

**The service name comes from the class declaration, not the filename.** Filenames diverge across all five SDKs; reading them would mean transcribing the sibling gate's per-source drop/strip/rename/spelling table a second time. The class is `#{service}Service` in all five, so one universal rule serves — squash to lowercase alphanumerics, strip a trailing `service` — and it lands on the same spelling Ruby and Python already emit in `OperationInfo`.

**Extraction completeness is checked exactly, so there is no `MIN_` floor on the per-SDK reads.** A regex that stops matching returns nothing rather than erroring, which reads as "all clear". Here openapi.json is the anchor (used *only* for the roster and for operationId labels — never for which service an operation belongs on), so an unrecognized request helper is reported by name — `typescript never emits PUT /account/logo.json` — rather than as a plausible-looking count. The one floor is on the anchor itself, to catch collapse rather than drift.

## Red proof — two triples, both including the regenerate step

A mutation that only edits a generator proves nothing where a drift gate exists; drift masks the result. Both mutations regenerate.

**Ruby** — `GetCard`: `Cards` → `CardTables` in `ruby/scripts/generate-services.rb`, then `make rb-generate-services` (53 services, 250 operations):

| leg | REAL_EXIT |
|---|---|
| `check-operation-assignment-parity` | **1 — RED** |
| `check-service-inventory-parity` | 0 — green |
| `check-ruby-service-drift.sh` | 0 — green |

> ``GetCard (GET /card_tables/cards/{cardId}) is assigned to different services: `cards` in kotlin, python, swift, typescript; `cardtables` in ruby``

**TypeScript** — the same move in `typescript/scripts/generate-services.ts`, then `make ts-generate-services`: new gate **1**, sibling **0**, `make ts-check-drift` **0**.

That triple is the whole claim: the new gate sees something nothing else can.

**The issue's literal scenario does not satisfy the triple, and that is worth knowing.** `GetCardTable` is the *sole* operation of `CardTables`, so moving it to `Cards` and regenerating drops TypeScript to 52 services — the generator creates services from operations, so `card-tables.ts` is deleted. The new gate goes red (naming `GetCardTable`), but `check-service-inventory-parity` goes red too. Isolating this gate's signal requires moving an operation *out of a multi-op service*.

## The self-test is not vacuous — measured

26 mutations driven through a copy of the checker via an env seam. Sharp pins: parity comparison → cases 1, 2, 3; completeness(missing) → 4, 5; completeness(extra) → 6; duplicate-key → 7; async agreement → 8; dir-exists → 9; openapi-exists → 10; prefix assertion → 11; floor → 12; completeness-before-parity ordering → 4, 5. Deleting any of the 13 request-call patterns, the `?`-strip, or any of the four interpolation substitutions turns both positive controls red — recorded honestly as smoke alarms rather than pins, their value being dead-rule detection.

One mutation earns case 3 its place: rekeying parity on *grouping* instead of the service *name* — the cheaper instrument someone will propose — leaves cases 1 and 2 red on the message only, and **case 3 (wholesale class-contents swap) is the only case the mutated checker passes outright.**

Two mutations initially survived, and both were acted on rather than papered over with new cases:

- a per-file duplicate check was **unreachable** (no generator emits two sync service classes in one file). Removed, with both maps made per-source so there is exactly one duplicate check — obviate rather than armor.
- `sub` → `gsub` on the suffix strip kills nothing, because all five SDKs spell the class identically. **Recorded as surviving on purpose** in the checker header and the mutation matrix, rather than inventing a case that cannot discriminate. Reading the class rather than the filename is what removes the hazard; the strip rule is cosmetic and the header says so.

## Wiring

Its own Makefile targets, into `check-targets`, **and two explicit CI steps** — `make check` membership is not CI coverage in this repo, since no job runs the full target. Both steps run under `LC_ALL: C`, which also keeps the UTF-8 pinning proven rather than asserted: the generated trees carry em dashes in their `@generated` banners, so an unpinned read raises `InvalidByteSequenceError` before anything is compared.

## Verification

All under `LC_ALL=C`, exit codes logged and read back: new gate 0 (250 operations, 5 SDKs) · self-test 0 (15/15) · `check-service-inventory-parity` 0 (53 services, 8 renderings — unchanged) · its self-test 0 · `ts-check-drift` 0 · `check-ruby-service-drift.sh` 0 · `lint-actions` 0 (zizmor: no findings).

Every mutation restored by `cp` + `diff -rq`, verified identical with `git status --porcelain` empty; committed bytes checked against the working tree with `git show HEAD:<path> | diff -q -` for all four files.

## Triaged, not filed

Ruby's generated mutations carry no `operation:` kwarg, which looked like it might mean Ruby's mutations resolve to retry defaults unseen. **It is not live, and there is nothing to file.** The kwarg does not exist on that path: `http.rb` routes non-GET straight to `single_request`, bypassing `request_with_retry` — the sole caller of `Http.operation_retry`. `post`/`put`/`delete`/`post_raw`/`put_raw` don't declare `operation:`, so adding it would raise `ArgumentError` rather than silently default. `with_operation`'s name feeds hooks only, and Ruby's `idempotent` metadata has no consumer at all. This is declared, intentional divergence — `SPEC.md` and `check-retry-metadata-parity.py` both state Ruby is GET-only. The real Ruby-vs-Python/Swift gap lives in `http.rb`'s non-GET routing, not at the generated call sites.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a new gate that fails when the five generated SDKs assign the same REST operation to different services. Previously we only checked service inventories and per-SDK drift, so cross-SDK misassignments (the gap in #756) could ship undetected.

- Keys on (method, path) from generated call sites and reads the service from class declarations; uses openapi.json only to anchor the operation roster and label failures.
- Covers `typescript`, `ruby`, `python` (sync and async must agree), `kotlin`, and `swift`; excludes Go because it has no service split table and many deliberate divergences.
- Handles TypeScript’s URL-concatenating `updateAccountLogo` via an explicit extraction pattern so the operation remains visible to the gate.
- Checks completeness exactly and reports missing/extra operations by SDK before diffing assignments; asserts account-scoped paths and floors the spec read to catch anchor collapse.
- Adds `check-operation-assignment-parity` and `test-check-operation-assignment-parity` Makefile targets and two CI steps in `.github/workflows/test.yml` (run under `LC_ALL=C`) to exercise both the live pass and synthetic negative cases.
- When red, fix the `SERVICE_SPLITS` for the named operation in the disagreeing generators so all five SDKs assign it to the same service.

<sup>Written for commit 0090a84dc127558432d307aecc35207562a73dcd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-sdk/pull/771?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

