### PR TITLE
Give a malformed response body one structural marker in all six SDKs

### DIFF
--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -265,7 +265,7 @@ hand. The one exception is called out below.
 | SDK | was | now |
 |---|---|---|
 | Kotlin | `kotlinx.serialization.SerializationException` (incl. `MissingFieldException`) | `BasecampException.Api` with `httpStatus == null`, `retryable == false`, and the `SerializationException` as `cause` |
-| Swift | `DecodingError` — and, on the wrapped-list path, a raw `NSError` from `JSONSerialization` for a body that is not JSON at all | `BasecampError.api(message:httpStatus:hint:requestId:decodeFailure:)` with `httpStatus == nil` (so `isRetryable == false`), the underlying error's description interpolated into `message` and the error itself in `decodeFailure` (see below) |
+| Swift | `DecodingError` — and, on the wrapped-list path, a raw `NSError` from `JSONSerialization` for a body that is not JSON at all | `BasecampError.api(message:httpStatus:hint:requestId:decodeFailure:)` with `httpStatus == nil` (so `isRetryable == false`), the underlying error's description interpolated into `message` and the error itself in `decodeFailure` (see above) |
 | Go, TypeScript, Ruby, Python | unchanged | unchanged |
 
 **Wrong behaviour you get if you ignore it:** a `catch (e: SerializationException)`

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -13,6 +13,70 @@ what wrong behaviour you get if you ignore one. This file is that half.
 
 # Unreleased
 
+### `BasecampError.api` gained a fifth associated value (#750)
+
+**Swift only, and it is a compile error** — the one shape of break you cannot
+miss.
+
+```swift
+case .api(let message, let status, _, _, _):      // one more `_`
+    print("API error (\(status ?? 0)): \(message)")
+
+// …or better, stop matching the case:
+if let decodeFailure = error.decodeFailure {
+    print("Basecamp sent a body this SDK could not decode: \(decodeFailure)")
+}
+```
+
+The case is now
+`api(message: String, httpStatus: Int?, hint: String?, requestId: String?, decodeFailure: (any Error & Sendable)?)`.
+Add one more `_` to every match and `decodeFailure: nil` to every construction —
+or better, stop matching the case and read the new `error.decodeFailure`
+property, defined on every `BasecampError` (nil for all other shapes), which will
+not move again when a case gains a sixth value. A bare `case .api` match, and a
+`switch` with a `default`, keep compiling untouched.
+
+**What the slot means.** It is the response decoder's own refusal, and it is set
+on exactly two things: the SPEC §6 statusless `api_error` raised for a 2xx body
+the model would not decode, and the merge-safe composites' restatement of that
+same failure with their escape hatch attached. It is nil everywhere else —
+including the *other* statusless `.api`, the pagination same-origin guard, which
+is a deliberate refusal and not a bad body. The value is a `DecodingError` for a
+typed decode and a `CocoaError` for a body that is not JSON at all, so match the
+concrete type if you need to tell those apart.
+
+**Why the break was worth taking.** Swift used to answer "is this a malformed
+response body?" by looking for the phrase `"returned a body that does not
+decode"` inside the message, through an `@_spi(Conformance)` helper whose own
+docstring named the reason: `.api` had no slot to answer it structurally, and
+statuslessness alone would also match the pagination guard. That made the
+*wording of a sentence* the contract — rewording the message moved the answer,
+and a caller composing their own `.api` around the phrase produced one. Kotlin
+has answered the same question structurally since #730. The helper, the phrase
+constant and the SPI are gone.
+
+**Wrong behaviour you get if you ignore it:** you cannot ignore it — it does not
+build. Once it does, nothing else changed: the message still carries the
+decoder's account of the failure, and the classification (`api_error`, statusless,
+non-retryable) is unchanged.
+
+**Related, non-breaking, in the other five SDKs.** The same question now has the
+same structural answer everywhere, and none of it needs anything from you:
+Kotlin's `BasecampException.Api.decodeFailure` became a public read-only property
+(it was `internal`, invisible to a separate Gradle module); Go's two composite
+decode refusals set `Cause`, so `errors.As` reaches `*json.UnmarshalTypeError`
+and `*json.SyntaxError` through `Unwrap`; Ruby's paginated-page parse failure
+carries the `JSON::ParserError` in `cause`; Python's `BasecampError` grew a
+`cause` property over `__cause__`, which its refusal sites already set.
+
+**TypeScript has one behaviour change.** A followed pagination page whose body is
+not JSON used to escape as a bare `SyntaxError` — no code, no hint,
+indistinguishable from a bug in your own code. It is now the same statusless,
+non-retryable `api_error` Ruby and Python already raised there, with the
+`SyntaxError` in `cause` and the page number in the message. A `catch` for
+`SyntaxError` around a paginated call stops matching; a `catch` on
+`BasecampError` starts.
+
 ### Go: typed operations now honour `WithMaxRetries`, and `0` is a legal cap (#718)
 
 Two changes to the same knob, one of them a bug fix you may feel in production.
@@ -201,7 +265,7 @@ hand. The one exception is called out below.
 | SDK | was | now |
 |---|---|---|
 | Kotlin | `kotlinx.serialization.SerializationException` (incl. `MissingFieldException`) | `BasecampException.Api` with `httpStatus == null`, `retryable == false`, and the `SerializationException` as `cause` |
-| Swift | `DecodingError` — and, on the wrapped-list path, a raw `NSError` from `JSONSerialization` for a body that is not JSON at all | `BasecampError.api(message:httpStatus:hint:requestId:)` with `httpStatus == nil` (so `isRetryable == false`); the underlying error's description is interpolated into `message` |
+| Swift | `DecodingError` — and, on the wrapped-list path, a raw `NSError` from `JSONSerialization` for a body that is not JSON at all | `BasecampError.api(message:httpStatus:hint:requestId:decodeFailure:)` with `httpStatus == nil` (so `isRetryable == false`), the underlying error's description interpolated into `message` and the error itself in `decodeFailure` (see below) |
 | Go, TypeScript, Ruby, Python | unchanged | unchanged |
 
 **Wrong behaviour you get if you ignore it:** a `catch (e: SerializationException)`
@@ -215,9 +279,9 @@ What did **not** move: an auth-strategy throw, a transport failure and a
 that distinction is load-bearing — the request body is serialized inside the
 same `try`, and throws the same `SerializationException` type the decoder does.
 
-`BasecampError.api` gained no `cause` slot: adding an associated value would
-break every `switch` over the case. Swift carries the underlying error in the
-message, as its composites already did.
+`BasecampError.api` did gain a slot in the end, and it is a compile break — see
+[`BasecampError.api` gained a fifth associated value](#basecamperrorapi-gained-a-fifth-associated-value-750)
+above. It ships in this same release, so there is one migration to do, not two.
 
 **One operation is exempt, and it is `GetPersonProgress`.** Its wrapper is
 decoded by generated code that runs *after* the request primitive returns — the

--- a/conformance/runner/swift/Sources/ConformanceRunner/Runner.swift
+++ b/conformance/runner/swift/Sources/ConformanceRunner/Runner.swift
@@ -1,4 +1,4 @@
-@_spi(Conformance) import Basecamp
+import Basecamp
 import ConformanceSupport
 import Foundation
 
@@ -325,9 +325,11 @@ struct Runner {
                 // The SDK is asked which shape this is rather than told: a
                 // statusless `.api` is also what the pagination same-origin
                 // guard throws, and `security.json` asserts on that refusal.
-                // `malformedBodyMessage` is `@_spi(Conformance)` precisely so
-                // this seam cannot hold a second, drifting copy of the phrase.
-                if let decodeFailure = BaseService.malformedBodyMessage(error) {
+                // `decodeFailure` is set by the SDK's decode wrapper and by the
+                // §18 composites restating that same failure, and by nothing
+                // else — so this seam holds no copy of a message to drift from
+                // (#750, replacing a `@_spi(Conformance)` substring test).
+                if let decodeFailure = error.decodeFailure {
                     guard expectsFailure else {
                         return .fail("Mock body lacks required Swift model fields: \(decodeFailure)")
                     }

--- a/go/pkg/basecamp/documents.go
+++ b/go/pkg/basecamp/documents.go
@@ -144,6 +144,13 @@ func (f *DocumentFields) fullBody() (generated.ReplaceDocumentJSONRequestBody, e
 // AuthStrategy may each return any sentinel they like. So DocumentsService.Get
 // splits the request from the decode and calls this on the decode step only,
 // where the origin is known by construction rather than guessed.
+//
+// The decoder's error is kept as Cause, not just interpolated into Message
+// (#750). Every SDK renders it into the message; only the ones that keep it let
+// a caller act on it, and Go's is the errors.As/errors.Is chain — a caller who
+// wants to know whether the field was the wrong type or the body was not JSON
+// at all reaches *json.UnmarshalTypeError or *json.SyntaxError through Unwrap
+// instead of pattern-matching a sentence.
 func documentDecodeError(err error) error {
 	return &Error{
 		Code:    CodeAPI,
@@ -151,6 +158,7 @@ func documentDecodeError(err error) error {
 		Hint: "The merge-safe Update/Edit resend this record's fields verbatim, so a malformed " +
 			"response cannot be written back safely. Use Replace to write the record deliberately.",
 		Retryable: false,
+		Cause:     err,
 	}
 }
 

--- a/go/pkg/basecamp/documents_test.go
+++ b/go/pkg/basecamp/documents_test.go
@@ -704,6 +704,39 @@ func TestDocumentsService_UpdateWrapsADecodeFailureAsStatuslessAPIError(t *testi
 	}
 }
 
+// The decoder's own error stays REACHABLE, not just quoted (#750).
+//
+// documentDecodeError interpolates it into Message, which tells a human what
+// happened and leaves a caller nothing to act on: deciding "was the field the
+// wrong type, or was the body not JSON at all" from a sentence means matching
+// substrings, which is the mechanism #750 removed from Swift. Cause + Unwrap put
+// the decoder's own error back in reach of errors.As, so the classification and
+// the detail are both available and neither is parsed out of prose.
+func TestDocumentsService_UpdateKeepsTheDecoderErrorReachable(t *testing.T) {
+	fixture := loadDocumentsFixture(t, "get.json")
+	getBody := patchDocumentFixture(t, fixture, map[string]any{"title": 42})
+	svc, _ := testDocumentsCaptureServer(t, getBody, fixture, nil)
+
+	_, err := svc.Update(context.Background(), 1069479300, &UpdateDocumentRequest{Title: "Q3 Plan"})
+	if err == nil {
+		t.Fatal("expected the call to fail, but it succeeded")
+	}
+
+	var typeErr *json.UnmarshalTypeError
+	if !errors.As(err, &typeErr) {
+		t.Fatalf("expected the decoder's error to be reachable through Unwrap, got %v", err)
+	}
+	if typeErr.Field != "title" {
+		t.Errorf("expected the decoder to name the offending field, got %q", typeErr.Field)
+	}
+	// The classification must survive alongside it: a chain that only reports
+	// the decoder error would have replaced the SPEC §6 shape, not enriched it.
+	var apiErr *Error
+	if !errors.As(err, &apiErr) || apiErr.Code != CodeAPI {
+		t.Fatalf("expected a statusless api_error over the decoder error, got %T: %v", err, err)
+	}
+}
+
 // A transport or HTTP error must pass through untouched — the wrapper is for
 // decode failures only, and swallowing everything would hide a 404 behind a
 // "does not decode" message.

--- a/go/pkg/basecamp/schedules.go
+++ b/go/pkg/basecamp/schedules.go
@@ -479,6 +479,11 @@ func nonNilIDs(ids []int64) []int64 {
 // are the errors that precede a response. So getEntryWithBody splits the
 // request from the decode and calls this on the decode step only, where the
 // origin is known by construction rather than guessed.
+//
+// The decoder's error is kept as Cause the way documentDecodeError keeps it
+// (#750): interpolating it into Message tells a human what happened and leaves
+// a caller nothing to switch on, where Unwrap puts *json.UnmarshalTypeError and
+// *json.SyntaxError back within reach of errors.As.
 func scheduleEntryDecodeError(err error) error {
 	return &Error{
 		Code:    CodeAPI,
@@ -486,6 +491,7 @@ func scheduleEntryDecodeError(err error) error {
 		Hint: "The merge-safe UpdateEntry/EditEntry resend this record's fields verbatim, so a malformed " +
 			"response cannot be written back safely. Use ReplaceEntry to write the record deliberately.",
 		Retryable: false,
+		Cause:     err,
 	}
 }
 

--- a/go/pkg/basecamp/schedules_test.go
+++ b/go/pkg/basecamp/schedules_test.go
@@ -1579,6 +1579,35 @@ func TestSchedulesService_UpdateEntryWrapsADecodeFailureAsStatuslessAPIError(t *
 	}
 }
 
+// The decoder's own error stays REACHABLE, not just quoted (#750) — the same
+// assertion documents_test.go makes for the document read, at the second site
+// that renders this shape. One helper per record means one Cause per record to
+// forget.
+func TestSchedulesService_UpdateEntryKeepsTheDecoderErrorReachable(t *testing.T) {
+	base := scheduleEntryReadBack(t)
+	get := patchScheduleEntryFixture(t, base, map[string]any{"summary": 42})
+	svc, _ := testSchedulesCaptureServer(t, get, base, nil)
+
+	_, err := svc.UpdateEntry(context.Background(), 1069479400, &UpdateScheduleEntryRequest{
+		Summary: strPtr("Q3 Kickoff"),
+	})
+	if err == nil {
+		t.Fatal("expected the call to fail, but it succeeded")
+	}
+
+	var typeErr *json.UnmarshalTypeError
+	if !errors.As(err, &typeErr) {
+		t.Fatalf("expected the decoder's error to be reachable through Unwrap, got %v", err)
+	}
+	if typeErr.Field != "summary" {
+		t.Errorf("expected the decoder to name the offending field, got %q", typeErr.Field)
+	}
+	var apiErr *Error
+	if !errors.As(err, &apiErr) || apiErr.Code != CodeAPI {
+		t.Fatalf("expected a statusless api_error over the decoder error, got %T: %v", err, err)
+	}
+}
+
 // A transport or HTTP error must pass through untouched — the wrapper is for
 // decode failures only, and swallowing everything would hide a 404 behind a
 // "does not decode" message.

--- a/kotlin/conformance/src/main/kotlin/com/basecamp/sdk/conformance/Main.kt
+++ b/kotlin/conformance/src/main/kotlin/com/basecamp/sdk/conformance/Main.kt
@@ -551,7 +551,11 @@ private fun runTest(tc: TestCase): TestResult {
             // failure and let a fixture pinning `errorCode: api_error` be
             // satisfied by a decoder rejection, which is exactly what
             // `caughtException` is withheld to prevent.
-            val decodeFailure = (e as? BasecampException.Api)?.cause as? SerializationException
+            //
+            // The SDK is asked which shape this is rather than told: see
+            // malformedBodyFailure (MalformedBody.kt) for why inspecting `cause`
+            // is not the same question, and for why the branch lives there.
+            val decodeFailure = malformedBodyFailure(e)
             if (decodeFailure != null) {
                 if (!expectsFailure) {
                     client.close()

--- a/kotlin/conformance/src/main/kotlin/com/basecamp/sdk/conformance/MalformedBody.kt
+++ b/kotlin/conformance/src/main/kotlin/com/basecamp/sdk/conformance/MalformedBody.kt
@@ -1,0 +1,34 @@
+package com.basecamp.sdk.conformance
+
+import com.basecamp.sdk.BasecampException
+import kotlinx.serialization.SerializationException
+
+/**
+ * The response decoder's own refusal carried by [e], or null when [e] is any
+ * other failure.
+ *
+ * Since #604 a body the model refuses arrives here as a `BasecampException.Api`
+ * rather than a raw `SerializationException`, so the runner has to ask which
+ * shape it is holding: a decoder rejection means "repair the fixture body"
+ * (#555), and every other `api_error` is a result the assertions get to see.
+ *
+ * **Ask the SDK, do not re-derive.** The test this replaces was
+ * `(e as? BasecampException.Api)?.cause as? SerializationException`, which is
+ * the #730 bug: `BasecampHttpClient` propagates an already-classified
+ * `BasecampException` from the auth strategy untouched, so an `AuthStrategy`
+ * that classifies its own JSON failure as `Api(cause = SerializationException(…))`
+ * — through the public constructor, which leaves `decodeFailure` null — matched
+ * it and was reported as a malformed mock body for a request that was never
+ * sent. #730 fixed the three §18 composites by giving the SDK a structural slot
+ * and left this module reading the old signal; the two agreed only because the
+ * decoder's own refusal fills both, and diverged on exactly the case the slot
+ * exists for. `decodeFailure` is public for this caller: `:conformance` is a
+ * separate Gradle module and cannot see `internal`.
+ *
+ * Split out of the runner so both directions are unit-testable
+ * (MalformedBodyTest). Only the positive one is reachable from
+ * `conformance/tests/`: no fixture can supply a custom `AuthStrategy`, so
+ * nothing committed would have failed while the misread was live.
+ */
+fun malformedBodyFailure(e: BasecampException): SerializationException? =
+    (e as? BasecampException.Api)?.decodeFailure

--- a/kotlin/conformance/src/test/kotlin/com/basecamp/sdk/conformance/MalformedBodyTest.kt
+++ b/kotlin/conformance/src/test/kotlin/com/basecamp/sdk/conformance/MalformedBodyTest.kt
@@ -1,0 +1,130 @@
+package com.basecamp.sdk.conformance
+
+import com.basecamp.sdk.AuthStrategy
+import com.basecamp.sdk.BasecampClient
+import com.basecamp.sdk.BasecampException
+import com.basecamp.sdk.generated.projects
+import io.ktor.client.engine.mock.MockEngine
+import io.ktor.client.engine.mock.respond
+import io.ktor.http.ContentType
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.headersOf
+import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.SerializationException
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertSame
+
+/**
+ * Both directions of the runner's malformed-body test (#750, the tail of #730).
+ *
+ * The runner's `BasecampException` arm decides between "the mock body is wrong,
+ * fail loudly so the fixture gets repaired" (#555) and "this is a result the
+ * assertions get to judge". Getting that wrong in the first direction reports a
+ * fixture bug that does not exist and hides the real error; in the second it
+ * lets a case pinning `errorCode: api_error` be satisfied by a decoder
+ * rejection.
+ *
+ * Only the first direction is reachable from `conformance/tests/`: a fixture
+ * cannot install an `AuthStrategy`, so the misread this file pins was live in
+ * the runner with every committed fixture green.
+ */
+class MalformedBodyTest {
+    private fun clientReturning(body: String): BasecampClient =
+        BasecampClient {
+            accessToken("conformance-test-token")
+            baseUrl = "http://localhost:3000"
+            enableRetry = false
+            engine = MockEngine {
+                respond(
+                    content = body,
+                    status = HttpStatusCode.OK,
+                    headers = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString()),
+                )
+            }
+        }
+
+    /**
+     * The positive direction, produced the only way it can be: by the SDK's own
+     * response decoder, since the factory that fills the slot is internal to
+     * `:basecamp-sdk`. A body the `Project` model refuses arrives as the SPEC §6
+     * statusless `api_error` (#604), and the decoder's exception is what the
+     * runner reports to the fixture author.
+     */
+    @Test
+    fun `a decoder refusal carries the decode failure`() {
+        val client = clientReturning("""{"id": "not-a-number"}""")
+
+        val error = assertFailsWith<BasecampException.Api> {
+            runBlocking { client.forAccount("999").projects.get(1) }
+        }
+
+        val failure = malformedBodyFailure(error)
+        assertNotNull(failure, "a body the model refuses must be recognized as a malformed body")
+        assertSame(
+            error.cause, failure,
+            "the runner reports the decoder's own account of what was wrong",
+        )
+        client.close()
+    }
+
+    /**
+     * The #730 case, one module over. `BasecampHttpClient` propagates an
+     * already-classified `BasecampException` from the auth strategy untouched,
+     * so a token provider that classifies its own JSON failure as
+     * `Api(cause = SerializationException(…))` reaches the runner's
+     * `BasecampException` arm. Through the public constructor `decodeFailure`
+     * stays null, which is the whole point: the strategy did not decode a
+     * Basecamp response body, and no request was ever sent.
+     *
+     * While the runner read `cause as? SerializationException`, this matched —
+     * and the case was failed as "Mock body does not decode into the Kotlin
+     * model" naming a fixture that is fine, or silently absorbed as the expected
+     * failure of a case that declares `errorRaised`.
+     */
+    @Test
+    fun `an auth strategy failure carrying a serialization cause is not a malformed body`() {
+        val thrown = BasecampException.Api(
+            message = "the token endpoint returned a body that does not decode",
+            cause = SerializationException("Unexpected JSON token at offset 0"),
+        )
+        val client = BasecampClient {
+            auth(AuthStrategy { throw thrown })
+            baseUrl = "http://localhost:3000"
+            enableRetry = false
+            engine = MockEngine { respond(content = "{}", status = HttpStatusCode.OK) }
+        }
+
+        val error = assertFailsWith<BasecampException.Api> {
+            runBlocking { client.forAccount("999").projects.get(1) }
+        }
+
+        assertSame(thrown, error, "the strategy's own exception must reach the runner unchanged")
+        assertNull(
+            malformedBodyFailure(error),
+            "an auth failure is not a malformed response body — no request was sent",
+        )
+        client.close()
+    }
+
+    /**
+     * The other statusless `api_error` a runner sees, and the reason
+     * statuslessness alone cannot be the test: the pagination same-origin
+     * refusal is a deliberate guard, `security.json` asserts on it, and routing
+     * it to "repair the fixture body" would both lose the assertion and mislabel
+     * the refusal.
+     */
+    @Test
+    fun `a guard refusal with no decode failure is not a malformed body`() {
+        val refusal = BasecampException.Api(
+            message = "Pagination Link header points to a different origin: https://evil.example.com/",
+        )
+
+        assertNull(malformedBodyFailure(refusal))
+        assertEquals(null, refusal.decodeFailure)
+    }
+}

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/BasecampException.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/BasecampException.kt
@@ -102,9 +102,11 @@ sealed class BasecampException(
         requestId: String?,
         cause: Throwable?,
         /**
-         * The response decoder's own refusal, set on the exception
-         * [com.basecamp.sdk.services.BaseService] raises for a malformed 2xx
-         * body and on nothing else.
+         * The response decoder's own refusal, set on exactly two things: the
+         * exception [com.basecamp.sdk.services.BaseService] raises for a
+         * malformed 2xx body, and the SPEC §18 composites' restatement of that
+         * same failure with their own escape hatch attached. Null on every
+         * other [Api].
          *
          * The SPEC §18 composites re-hint a decode failure of the GET they
          * issue, so what they have to answer is "did this come out of the

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/BasecampException.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/BasecampException.kt
@@ -125,13 +125,26 @@ sealed class BasecampException(
          * That is an accident guarantee and not an unforgeable one — see
          * [Companion.malformedBody] for what it does and does not stop.
          *
-         * [cause] still carries the same exception it always did — callers and
-         * the **Kotlin** conformance runner read it (Swift's has no `cause` to
-         * read: `BasecampError.api` carries none, which is the whole premise of
-         * #750), and a [kotlinx.serialization.MissingFieldException] there still
-         * reports its `missingFields`.
+         * **Readable everywhere, settable in one place.** The guarantee above is
+         * a property of the *producer*, not of who can look: the constructor
+         * that fills this slot is private and the factory that reaches it is
+         * internal, so widening the getter takes nothing away. It has to be
+         * public. The Kotlin conformance runner asks this same question and
+         * `:conformance` is a separate Gradle module, so `internal` is invisible
+         * to it — it read `cause is SerializationException` instead and carried
+         * the #730 misread one module over until #750. `@PublishedApi internal`
+         * does not help: it lifts an internal declaration into the ABI for
+         * public inline functions *of the same module* and still cannot be
+         * named from another module's source. Swift's `BasecampError`
+         * `decodeFailure` is public for the same reason and answers the same
+         * question (#750).
+         *
+         * [cause] still carries the same exception it always did, and a
+         * [kotlinx.serialization.MissingFieldException] there still reports its
+         * `missingFields`. It is not the discriminator: reading it as one is
+         * exactly the #730 bug.
          */
-        internal val decodeFailure: SerializationException?,
+        val decodeFailure: SerializationException?,
     ) : BasecampException(message, CODE_API, hint, httpStatus, retryable, requestId, cause) {
 
         constructor(

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/BasecampException.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/BasecampException.kt
@@ -165,6 +165,15 @@ sealed class BasecampException(
              * caller's to vary, which is why they are fixed here rather than
              * passed.
              *
+             * [hint] is passed, because the §18 composites restate this failure
+             * with their own escape hatch attached and the restatement is still
+             * the same malformed body. Restating it through the public
+             * constructor would have dropped the marker, which reads as "this
+             * was not a decode failure after all" to everything downstream —
+             * the conformance runner included, where it means "a mock body that
+             * needs repairing" is reported as an ordinary `api_error` instead
+             * (#750).
+             *
              * A factory and not a constructor, because `internal` does not
              * survive the JVM boundary for `<init>`: constructors cannot be
              * name-mangled, so an internal *constructor* is emitted public and
@@ -192,11 +201,12 @@ sealed class BasecampException(
              */
             internal fun malformedBody(
                 message: String,
+                hint: String? = null,
                 decodeFailure: SerializationException,
             ): Api = Api(
                 message,
                 httpStatus = null,
-                hint = null,
+                hint = hint,
                 retryable = false,
                 requestId = null,
                 cause = decodeFailure,

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/BasecampException.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/BasecampException.kt
@@ -120,9 +120,11 @@ sealed class BasecampException(
          *
          * Presence is the discriminator. The only constructor that sets this
          * slot is private, reached through the internal [Companion.malformedBody]
-         * factory the decoder wrapper alone calls, so no caller reaches it by
-         * writing the natural thing. The value is the decoder's own message,
-         * which is what the composites were reaching into [cause] for.
+         * factory — which the decoder wrapper and those composites are the only
+         * callers of — so no caller outside this module reaches it by writing
+         * the natural thing. The value is the [SerializationException] the
+         * decoder threw, which is what the composites were reaching into [cause]
+         * for.
          *
          * That is an accident guarantee and not an unforgeable one — see
          * [Companion.malformedBody] for what it does and does not stop.

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/services/BaseService.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/services/BaseService.kt
@@ -561,9 +561,10 @@ abstract class BaseService(
         }
 
     /**
-     * The one place a decode failure is rendered — and, through the internal
-     * factory it calls, the only producer of
-     * [BasecampException.Api.decodeFailure]. That slot is how the §18
+     * The one place a decode failure is first rendered — and, through the
+     * internal factory it calls, one of the two producers of
+     * [BasecampException.Api.decodeFailure]; the §18 composites are the other,
+     * restating this exception through the same factory. That slot is how the §18
      * composites and the conformance runner tell this exception from any other
      * `api_error` that happens to carry a [SerializationException] as its
      * `cause`, which an auth strategy's already-classified failure can (#730).

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/services/BaseService.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/services/BaseService.kt
@@ -525,11 +525,11 @@ abstract class BaseService(
      *
      * **One mapped type, deliberately.** [SerializationException] is the type
      * kotlinx uses to say "this body is not what the model expects", and the
-     * `cause` it becomes here is a contract other code reads: the conformance
-     * runner tells a decoder rejection from a real `api_error` that way, and
-     * the §18 composites read the same exception through
-     * [BasecampException.Api.decodeFailure], the internal slot [malformedBody]
-     * alone fills. A second mapped type would be a second cause type they would
+     * `cause` it becomes here is a contract other code reads: the §18
+     * composites and the conformance runner both tell a decoder rejection from a
+     * real `api_error` through [BasecampException.Api.decodeFailure], the slot
+     * [malformedBody] alone fills, and read the exception itself back out of
+     * it. A second mapped type would be a second cause type they would
      * each have to learn, so anything that is a decode failure is made to speak
      * this one *where it is raised* instead — see
      * [com.basecamp.sdk.serialization.FlexibleLongSerializer], whose numeric
@@ -564,9 +564,9 @@ abstract class BaseService(
      * The one place a decode failure is rendered — and, through the internal
      * factory it calls, the only producer of
      * [BasecampException.Api.decodeFailure]. That slot is how the §18
-     * composites tell this exception from any other `api_error` that happens to
-     * carry a [SerializationException] as its `cause`, which an auth strategy's
-     * already-classified failure can (#730).
+     * composites and the conformance runner tell this exception from any other
+     * `api_error` that happens to carry a [SerializationException] as its
+     * `cause`, which an auth strategy's already-classified failure can (#730).
      */
     private fun malformedBody(operation: String, cause: SerializationException): BasecampException.Api =
         BasecampException.Api.malformedBody(

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/services/DocumentsService.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/services/DocumentsService.kt
@@ -98,8 +98,12 @@ class DocumentsService(client: AccountClient) :
      * hatch for writing it deliberately. That is what is restated here.
      *
      * The restatement is keyed off [BasecampException.Api.decodeFailure], the
-     * internal slot the base layer's decoder wrapper alone fills, so any other
-     * [BasecampException.Api] passes through untouched. Reading `cause is
+     * slot the base layer's decoder wrapper alone fills, so any other
+     * [BasecampException.Api] passes through untouched — and it carries that
+     * slot forward through the internal factory, because a restatement of a
+     * malformed body is still a malformed body. Rebuilding through the public
+     * constructor would drop the marker and tell everything downstream this was
+     * not a decode failure (#750). Reading `cause is
      * SerializationException` instead would catch more than this GET's decode:
      * an auth strategy that classifies its own JSON failure that way has its
      * exception propagated untouched by `BasecampHttpClient`, and would arrive
@@ -115,14 +119,13 @@ class DocumentsService(client: AccountClient) :
             get(documentId)
         } catch (e: BasecampException.Api) {
             val decodeFailure = e.decodeFailure ?: throw e
-            throw BasecampException.Api(
+            throw BasecampException.Api.malformedBody(
                 message = "GetDocument returned a body that does not decode as a document: " +
                     "${decodeFailure.message}",
                 hint = "The merge-safe update/edit resend this record's fields verbatim, so a " +
                     "malformed response cannot be written back safely. Use replace to write the " +
                     "record deliberately.",
-                retryable = false,
-                cause = decodeFailure,
+                decodeFailure = decodeFailure,
             )
         }
 

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/services/SchedulesService.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/services/SchedulesService.kt
@@ -280,8 +280,12 @@ class SchedulesService(client: AccountClient) :
      * writing it deliberately. That is what is restated here.
      *
      * The restatement is keyed off [BasecampException.Api.decodeFailure], the
-     * internal slot the base layer's decoder wrapper alone fills, so any other
-     * [BasecampException.Api] passes through untouched. Reading `cause is
+     * slot the base layer's decoder wrapper alone fills, so any other
+     * [BasecampException.Api] passes through untouched — and it carries that
+     * slot forward through the internal factory, because a restatement of a
+     * malformed body is still a malformed body. Rebuilding through the public
+     * constructor would drop the marker and tell everything downstream this was
+     * not a decode failure (#750). Reading `cause is
      * SerializationException` instead would catch more than this GET's decode:
      * an auth strategy that classifies its own JSON failure that way has its
      * exception propagated untouched by `BasecampHttpClient`, and would arrive
@@ -297,12 +301,11 @@ class SchedulesService(client: AccountClient) :
             getEntry(entryId)
         } catch (e: BasecampException.Api) {
             val decodeFailure = e.decodeFailure ?: throw e
-            throw BasecampException.Api(
+            throw BasecampException.Api.malformedBody(
                 message = "GetScheduleEntry returned a body that does not decode as a schedule " +
                     "entry: ${decodeFailure.message}",
                 hint = MALFORMED_HINT,
-                retryable = false,
-                cause = decodeFailure,
+                decodeFailure = decodeFailure,
             )
         }
 

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/services/TodolistsService.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/services/TodolistsService.kt
@@ -103,8 +103,12 @@ class TodolistsService(client: AccountClient) :
      * restated here.
      *
      * The restatement is keyed off [BasecampException.Api.decodeFailure], the
-     * internal slot the base layer's decoder wrapper alone fills, so any other
-     * [BasecampException.Api] passes through untouched. Reading `cause is
+     * slot the base layer's decoder wrapper alone fills, so any other
+     * [BasecampException.Api] passes through untouched — and it carries that
+     * slot forward through the internal factory, because a restatement of a
+     * malformed body is still a malformed body. Rebuilding through the public
+     * constructor would drop the marker and tell everything downstream this was
+     * not a decode failure (#750). Reading `cause is
      * SerializationException` instead would catch more than this GET's decode:
      * an auth strategy that classifies its own JSON failure that way has its
      * exception propagated untouched by `BasecampHttpClient`, and would arrive
@@ -120,14 +124,13 @@ class TodolistsService(client: AccountClient) :
             get(id)
         } catch (e: BasecampException.Api) {
             val decodeFailure = e.decodeFailure ?: throw e
-            throw BasecampException.Api(
+            throw BasecampException.Api.malformedBody(
                 message = "GetTodolistOrGroup returned a body that does not decode as a " +
                     "todolist: ${decodeFailure.message}",
                 hint = "The merge-safe update/edit resend this record's fields verbatim, so a " +
                     "malformed response cannot be written back safely. Use replace to write the " +
                     "record deliberately.",
-                retryable = false,
-                cause = decodeFailure,
+                decodeFailure = decodeFailure,
             )
         }
 

--- a/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/DocumentsServiceTest.kt
+++ b/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/DocumentsServiceTest.kt
@@ -13,6 +13,7 @@ import kotlinx.serialization.json.jsonPrimitive
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertSame
 import kotlin.test.assertTrue
@@ -118,6 +119,11 @@ class DocumentsServiceTest {
             error.message!!.contains("GetDocument returned a body that does not decode as a document"),
             "expected the composite's message, got: ${error.message}",
         )
+        // The restatement is still a malformed body, so it carries the marker
+        // forward: rebuilding through the public constructor would drop it and
+        // tell a caller — and the conformance runner — that this was not a
+        // decode failure (#750).
+        assertNotNull(error.decodeFailure, "the restatement must keep the decode-failure marker")
         assertTrue(
             error.hint?.contains("Use replace to write the record deliberately") == true,
             "expected a hint naming the escape hatch, got: ${error.hint}",

--- a/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/SchedulesServiceTest.kt
+++ b/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/SchedulesServiceTest.kt
@@ -15,6 +15,7 @@ import kotlinx.serialization.json.long
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertNotNull
 import kotlin.test.assertNull
 import kotlin.test.assertSame
 import kotlin.test.assertTrue
@@ -494,6 +495,11 @@ class SchedulesServiceTest {
             ),
             "expected the composite's message, got: ${error.message}",
         )
+        // The restatement is still a malformed body, so it carries the marker
+        // forward: rebuilding through the public constructor would drop it and
+        // tell a caller — and the conformance runner — that this was not a
+        // decode failure (#750).
+        assertNotNull(error.decodeFailure, "the restatement must keep the decode-failure marker")
         assertTrue(
             error.hint?.contains("Use replaceEntry to write the record deliberately") == true,
             "expected a hint naming the escape hatch, got: ${error.hint}",

--- a/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/TodolistsServiceTest.kt
+++ b/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/TodolistsServiceTest.kt
@@ -348,6 +348,10 @@ class TodolistsServiceTest {
                 ),
                 "expected the composite's message, got: ${error.message}",
             )
+            assertNotNull(
+                error.decodeFailure,
+                "the restatement must keep the decode-failure marker (#750)",
+            )
             assertTrue(
                 error.hint?.contains("Use replace to write the record deliberately") == true,
                 "expected a hint naming the escape hatch, got: ${error.hint}",

--- a/python/src/basecamp/errors.py
+++ b/python/src/basecamp/errors.py
@@ -69,6 +69,27 @@ class BasecampError(Exception):
         self.request_id = request_id
 
     @property
+    def cause(self) -> BaseException | None:
+        """The failure this error was raised from, or ``None``.
+
+        The slot the other five SDKs spell ``Cause``/``cause``/``decodeFailure``,
+        and the reason it is a property rather than a constructor keyword: the
+        refusal sites that have an underlying failure — the page-body decode in
+        ``_base``/``_async_base`` — are all inside an ``except`` block and all
+        ``raise ... from e``, which is Python's own way of recording it. A
+        keyword would be a second place to set the same fact, free to disagree
+        with ``__cause__`` and easy to forget at the next site. What was missing
+        was the NAME: a caller reading a malformed-body refusal had to know to
+        reach for a dunder to get what every other SDK hands over (#750).
+
+        Reading the decoder's own error, rather than the message it was
+        interpolated into, is the point. The message says which page failed; the
+        exception says whether the body was truncated mid-object or was never
+        JSON, and it is not parsed back out of a sentence.
+        """
+        return self.__cause__
+
+    @property
     def exit_code(self) -> int:
         try:
             return _EXIT_CODE_MAP.get(ErrorCode(self.code), ExitCode.API)

--- a/python/tests/test_malformed_body.py
+++ b/python/tests/test_malformed_body.py
@@ -1,0 +1,78 @@
+"""The decode failure behind a malformed-body refusal stays reachable (#750).
+
+A page body that is not JSON is Python's "the server sent something I could not
+decode" refusal, and ``_base``/``_async_base`` classify it as a statusless
+``api_error`` with ``raise ... from e``. What #750 adds is the NAME the other
+five SDKs use for that slot, so a caller does not have to know to reach for
+``__cause__`` to get what Go hands over through ``errors.As`` and Kotlin and
+Swift through ``decodeFailure``.
+
+Both paginators are exercised, sync and async: they are four separate ``except``
+arms, and an arm that dropped its ``from e`` would leave the slot empty while
+every other one stayed green.
+"""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+import respx
+
+from basecamp import AsyncClient, Client
+from basecamp.errors import ApiError
+
+_ACCOUNT_URL = "https://3.basecampapi.com/12345"
+_TRUNCATED_BODY = '[{"id": 1'
+
+
+def _link_to(url: str) -> dict[str, str]:
+    return {"Link": f'<{url}>; rel="next"'}
+
+
+def _mount_bad_second_page(url: str) -> None:
+    respx.get(url, params={"page": "2"}).mock(
+        return_value=httpx.Response(200, content=_TRUNCATED_BODY, headers={"Content-Type": "application/json"})
+    )
+    respx.get(url).mock(
+        return_value=httpx.Response(200, json=[{"id": 1, "title": "Item 1"}], headers=_link_to(f"{url}?page=2"))
+    )
+
+
+class TestPaginatedDecodeFailure:
+    @respx.mock
+    def test_bare_array_page_keeps_the_decoder_error(self):
+        url = f"{_ACCOUNT_URL}/projects.json"
+        _mount_bad_second_page(url)
+
+        account = Client(access_token="test-token").for_account("12345")
+        with pytest.raises(ApiError) as excinfo:
+            account.projects._paginate("/projects.json")
+
+        assert "page 2" in str(excinfo.value)
+        assert isinstance(excinfo.value.cause, json.JSONDecodeError)
+
+    @pytest.mark.asyncio
+    @respx.mock
+    async def test_async_bare_array_page_keeps_the_decoder_error(self):
+        url = f"{_ACCOUNT_URL}/projects.json"
+        _mount_bad_second_page(url)
+
+        client = AsyncClient(access_token="test-token")
+        account = client.for_account("12345")
+        with pytest.raises(ApiError) as excinfo:
+            await account.projects._paginate("/projects.json")
+        await client.close()
+
+        assert "page 2" in str(excinfo.value)
+        assert isinstance(excinfo.value.cause, json.JSONDecodeError)
+
+
+class TestCauseSlot:
+    def test_cause_is_none_for_a_refusal_with_nothing_behind_it(self):
+        """The malformed-*field* guards refuse a decodable body on their own
+        terms, so there is no underlying failure and the slot is empty. That is
+        the honest answer, and the same one Swift's ``decodeFailure`` gives for
+        the pagination same-origin refusal."""
+        assert ApiError("Basecamp returned a document with no title").cause is None

--- a/ruby/lib/basecamp/http.rb
+++ b/ruby/lib/basecamp/http.rb
@@ -342,7 +342,16 @@ module Basecamp
       Http.normalize_person_ids(data)
       data
     rescue JSON::ParserError => e
-      raise Basecamp::ApiError.new("Failed to parse paginated response (page #{page}): #{Security.truncate(e.message)}")
+      # +cause+ carries the parser's own error, not just its message (#750). The
+      # message says what happened; the slot is what a caller can act on, and it
+      # is the same answer Go reaches through errors.As and Kotlin and Swift
+      # through their decodeFailure slot. Passed explicitly rather than left to
+      # Ruby's implicit +$!+ chaining because Basecamp::Error defines its own
+      # +cause+ reader.
+      raise Basecamp::ApiError.new(
+        "Failed to parse paginated response (page #{page}): #{Security.truncate(e.message)}",
+        cause: e
+      )
     end
 
     # Extracts the item array from a parsed page body: the body itself for

--- a/ruby/test/basecamp/http_test.rb
+++ b/ruby/test/basecamp/http_test.rb
@@ -647,4 +647,26 @@ class HTTPPaginationTest < Minitest::Test
     assert_equal 1, items.length
     assert_requested(:get, "https://3.basecampapi.com/items.json", times: 1)
   end
+
+  # A page body that is not JSON at all is the "the server sent something I
+  # could not decode" refusal, and the parser's own error must stay REACHABLE
+  # rather than only quoted into the message (#750). Reading which page failed,
+  # or whether the body was truncated mid-object, out of a sentence is the
+  # substring mechanism this SDK family is getting rid of.
+  def test_paginate_parse_failure_keeps_the_parser_error
+    stub_request(:get, "https://3.basecampapi.com/items.json")
+      .to_return(
+        status: 200,
+        body: '[{"id": 1}]',
+        headers: { "Link" => '<https://3.basecampapi.com/items.json?page=2>; rel="next"' }
+      )
+
+    stub_request(:get, "https://3.basecampapi.com/items.json?page=2")
+      .to_return(status: 200, body: '[{"id": 2')
+
+    error = assert_raises(Basecamp::ApiError) { @http.paginate("/items.json").to_a }
+
+    assert_kind_of JSON::ParserError, error.cause
+    assert_match(/page 2/, error.message)
+  end
 end

--- a/swift/README.md
+++ b/swift/README.md
@@ -354,7 +354,7 @@ do {
         }
     case .network(let message, _):
         print("Network error: \(message)")
-    case .api(let message, let status, _, _):
+    case .api(let message, let status, _, _, _):
         print("API error (\(status ?? 0)): \(message)")
     case .validation(let message, _, _, _, let fieldErrors):
         print("Validation: \(message)")
@@ -373,6 +373,15 @@ do {
     // Common properties available on all cases
     print("Hint: \(error.hint ?? "none")")
     print("Retryable: \(error.isRetryable)")
+
+    // A 2xx body this SDK could not decode. Set on that refusal and on the
+    // merge-safe composites' restatement of it, nil on everything else —
+    // including the other statusless `.api`, the pagination same-origin guard.
+    // Prefer this property over matching the case: it does not move when a case
+    // gains another associated value.
+    if let decodeFailure = error.decodeFailure {
+        print("Basecamp sent a body this SDK could not decode: \(decodeFailure)")
+    }
 
     // CLI exit codes (matches Go/TS/Ruby SDKs)
     Foundation.exit(Int32(error.exitCode))

--- a/swift/Sources/Basecamp/BasecampError.swift
+++ b/swift/Sources/Basecamp/BasecampError.swift
@@ -38,7 +38,20 @@ public enum BasecampError: Error, Sendable, LocalizedError {
     case network(message: String, cause: (any Error & Sendable)?)
 
     /// Server or API error (typically 5xx).
-    case api(message: String, httpStatus: Int?, hint: String?, requestId: String?)
+    ///
+    /// `decodeFailure` is the response decoder's own refusal, and it is set on
+    /// exactly one thing: the SPEC §6 statusless `api_error` raised for a 2xx
+    /// body the model would not decode, plus the §18 composites' restatement of
+    /// that same failure with their escape hatch attached. Nil on every other
+    /// `.api`, including the *other* statusless one — the pagination
+    /// same-origin refusal, which is a deliberate guard and not a bad body.
+    ///
+    /// Read it through ``decodeFailure``, not by matching this case: that
+    /// property is nil for every other error shape, and it will not move again
+    /// when this case gains a sixth value.
+    case api(
+        message: String, httpStatus: Int?, hint: String?, requestId: String?,
+        decodeFailure: (any Error & Sendable)?)
 
     /// Validation error (HTTP 400, 422).
     ///
@@ -70,7 +83,7 @@ public enum BasecampError: Error, Sendable, LocalizedError {
         switch self {
         case .rateLimit: true
         case .network: true
-        case .api(_, let status, _, _): status.map { $0 >= 500 } ?? false
+        case .api(_, let status, _, _, _): status.map { $0 >= 500 } ?? false
         case .limitExceeded: false
         case .ambiguous: false
         default: false
@@ -85,7 +98,7 @@ public enum BasecampError: Error, Sendable, LocalizedError {
         case .notFound: 404
         case .rateLimit: 429
         case .validation(_, let status, _, _, _): status
-        case .api(_, let status, _, _): status
+        case .api(_, let status, _, _, _): status
         case .limitExceeded: 507
         case .ambiguous: nil
         case .network: nil
@@ -117,7 +130,7 @@ public enum BasecampError: Error, Sendable, LocalizedError {
         case .notFound(_, let hint, _): hint
         case .rateLimit(_, _, let hint, _): hint
         case .network: "Check your network connection"
-        case .api(_, _, let hint, _): hint
+        case .api(_, _, let hint, _, _): hint
         case .limitExceeded(_, let hint, _): hint
         case .ambiguous(_, _, let hint): hint
         case .validation(_, _, let hint, _, _): hint
@@ -133,7 +146,7 @@ public enum BasecampError: Error, Sendable, LocalizedError {
         case .notFound(let msg, _, _): msg
         case .rateLimit(let msg, _, _, _): msg
         case .network(let msg, _): msg
-        case .api(let msg, _, _, _): msg
+        case .api(let msg, _, _, _, _): msg
         case .limitExceeded(let msg, _, _): msg
         case .ambiguous(let resource, _, _): "Ambiguous \(resource)"
         case .validation(let msg, _, _, _, _): msg
@@ -148,7 +161,7 @@ public enum BasecampError: Error, Sendable, LocalizedError {
         case .forbidden(_, _, let id): id
         case .notFound(_, _, let id): id
         case .rateLimit(_, _, _, let id): id
-        case .api(_, _, _, let id): id
+        case .api(_, _, _, let id, _): id
         case .limitExceeded(_, _, let id): id
         case .ambiguous: nil
         case .validation(_, _, _, let id, _): id
@@ -165,6 +178,35 @@ public enum BasecampError: Error, Sendable, LocalizedError {
     public var fieldErrors: [String: [String]]? {
         switch self {
         case .validation(_, _, _, _, let fieldErrors): fieldErrors
+        default: nil
+        }
+    }
+
+    /// The response decoder's own refusal, for a 2xx body this SDK would not
+    /// decode; nil for every other error shape.
+    ///
+    /// Presence is the answer to "is this a malformed response body". Statuslessness
+    /// is not: the pagination same-origin guard throws a statusless `.api` too,
+    /// and the message is not either — it used to be, through a
+    /// `@_spi(Conformance)` substring test whose contract was the wording of a
+    /// sentence, so a reworded message moved the answer and a caller composing
+    /// their own `.api` containing the phrase forged one (#750).
+    ///
+    /// The value is a `DecodingError` for a typed decode and a `CocoaError` for
+    /// a body that is not JSON at all (the wrapped-list path reaches
+    /// `JSONSerialization`, which reports that instead) — so match on the
+    /// concrete type when the distinction matters rather than assuming one.
+    ///
+    /// This is a marker against an *accident*, not a forgery: `.api` is a public
+    /// case with no private payload, so a caller can construct one carrying
+    /// anything. That is unchanged from the phrase it replaces, and there is
+    /// nothing to gain — the same caller can already throw an `.api` carrying a
+    /// composite's message and hint verbatim. What it buys is that the SDK's own
+    /// two producers are the only *plausible* ones, and that nobody has to know
+    /// how this SDK words a sentence to tell the shapes apart.
+    public var decodeFailure: (any Error & Sendable)? {
+        switch self {
+        case .api(_, _, _, _, let decodeFailure): decodeFailure
         default: nil
         }
     }
@@ -230,7 +272,7 @@ public enum BasecampError: Error, Sendable, LocalizedError {
         default:
             return .api(
                 message: message, httpStatus: status,
-                hint: hint, requestId: requestId
+                hint: hint, requestId: requestId, decodeFailure: nil
             )
         }
     }

--- a/swift/Sources/Basecamp/DocumentsServiceExtensions.swift
+++ b/swift/Sources/Basecamp/DocumentsServiceExtensions.swift
@@ -46,7 +46,8 @@ public struct DocumentFields: Sendable {
                 hint: "The merge-safe update/edit resend this field verbatim, so a blank value "
                     + "would blank the current one. Use replace(documentId:req:) to write the "
                     + "record deliberately.",
-                requestId: nil
+                requestId: nil,
+                decodeFailure: nil
             )
         }
         title = document.title
@@ -127,20 +128,24 @@ extension DocumentsService {
         // malformed-2xx-body shape for every operation (#604) — statusless,
         // non-retryable `api_error` — so what is left to add here is the part
         // the base layer cannot know: the composite's escape hatch.
-        // `BaseService.malformedBodyMessage` is what recognizes that one
-        // failure — statuslessness alone would also match the pagination
-        // same-origin guard — so every other error passes through untouched.
+        // `BasecampError.decodeFailure` is what recognizes that one failure —
+        // statuslessness alone would also match the pagination same-origin
+        // guard — so every other error passes through untouched. The restatement
+        // carries the marker forward: it is the same malformed body with a
+        // better hint, and dropping it would tell the conformance runner (and
+        // any caller) this was not a decode failure (#750).
         do {
             return try await get(documentId: documentId)
         } catch let error as BasecampError {
-            guard let message = BaseService.malformedBodyMessage(error) else { throw error }
+            guard let decodeFailure = error.decodeFailure else { throw error }
             throw BasecampError.api(
-                message: message,
+                message: error.message,
                 httpStatus: nil,
                 hint: "The merge-safe update/edit resend this record's fields verbatim, so a "
                     + "malformed response cannot be written back safely. Use "
                     + "replace(documentId:req:) to write the record deliberately.",
-                requestId: nil
+                requestId: nil,
+                decodeFailure: decodeFailure
             )
         }
     }

--- a/swift/Sources/Basecamp/Download.swift
+++ b/swift/Sources/Basecamp/Download.swift
@@ -101,7 +101,7 @@ extension AccountClient {
                       !location.isEmpty else {
                     throw BasecampError.api(
                         message: "redirect \(statusCode) with no Location header",
-                        httpStatus: statusCode, hint: nil, requestId: nil
+                        httpStatus: statusCode, hint: nil, requestId: nil, decodeFailure: nil
                     )
                 }
 
@@ -114,7 +114,7 @@ extension AccountClient {
                 guard signedResponse.statusCode >= 200 && signedResponse.statusCode < 300 else {
                     throw BasecampError.api(
                         message: "download failed with status \(signedResponse.statusCode)",
-                        httpStatus: signedResponse.statusCode, hint: nil, requestId: nil
+                        httpStatus: signedResponse.statusCode, hint: nil, requestId: nil, decodeFailure: nil
                     )
                 }
 

--- a/swift/Sources/Basecamp/SchedulesServiceExtensions.swift
+++ b/swift/Sources/Basecamp/SchedulesServiceExtensions.swift
@@ -161,7 +161,8 @@ public struct ScheduleEntryFields: Sendable {
                 hint: "The merge-safe updateEntry/editEntry resend this field verbatim, so a "
                     + "blank value would overwrite the current one. Use "
                     + "replaceEntry(entryId:req:) to write the record deliberately.",
-                requestId: nil
+                requestId: nil,
+                decodeFailure: nil
             )
         }
         return value
@@ -284,21 +285,25 @@ extension SchedulesService {
         // renders that as the SPEC §6 malformed-2xx-body shape for every
         // operation (#604) — statusless, non-retryable `api_error` — so what is
         // left to add here is the part the base layer cannot know: the
-        // composite's escape hatch. `BaseService.malformedBodyMessage` is what
+        // composite's escape hatch. `BasecampError.decodeFailure` is what
         // recognizes that one failure — statuslessness alone would also match
         // the pagination same-origin guard — so every other error passes
-        // through untouched.
+        // through untouched. The restatement carries the marker forward: it is
+        // the same malformed body with a better hint, and dropping it would tell
+        // the conformance runner (and any caller) this was not a decode failure
+        // (#750).
         do {
             return try await getEntry(entryId: entryId)
         } catch let error as BasecampError {
-            guard let message = BaseService.malformedBodyMessage(error) else { throw error }
+            guard let decodeFailure = error.decodeFailure else { throw error }
             throw BasecampError.api(
-                message: message,
+                message: error.message,
                 httpStatus: nil,
                 hint: "The merge-safe updateEntry/editEntry resend this record's fields verbatim, "
                     + "so a malformed response cannot be written back safely. Use "
                     + "replaceEntry(entryId:req:) to write the record deliberately.",
-                requestId: nil
+                requestId: nil,
+                decodeFailure: decodeFailure
             )
         }
     }

--- a/swift/Sources/Basecamp/Services/BaseService.swift
+++ b/swift/Sources/Basecamp/Services/BaseService.swift
@@ -354,7 +354,7 @@ open class BaseService: @unchecked Sendable {
             guard isSameOrigin(nextURL, initialURL) else {
                 throw BasecampError.api(
                     message: "Pagination Link header points to different origin: \(nextURL)",
-                    httpStatus: nil, hint: nil, requestId: nil
+                    httpStatus: nil, hint: nil, requestId: nil, decodeFailure: nil
                 )
             }
 
@@ -412,7 +412,7 @@ open class BaseService: @unchecked Sendable {
             guard isSameOrigin(nextURL, initialURL) else {
                 throw BasecampError.api(
                     message: "Pagination Link header points to different origin: \(nextURL)",
-                    httpStatus: nil, hint: nil, requestId: nil
+                    httpStatus: nil, hint: nil, requestId: nil, decodeFailure: nil
                 )
             }
 
@@ -470,10 +470,11 @@ open class BaseService: @unchecked Sendable {
     /// Statusless because the request succeeded, so no HTTP status describes the
     /// failure; non-retryable because re-requesting cannot repair a malformed
     /// body (`isRetryable` reads `false` off the nil status). The underlying
-    /// error's own account of what was wrong is interpolated into the message,
-    /// which is where `BasecampError.api` can carry it: unlike `.network`, that
-    /// case has no `cause` slot, and adding one would break every `switch` over
-    /// it. This matches what the §18 composites already did by hand.
+    /// error goes in two places: interpolated into the message, for a human
+    /// reading a log, and structurally into ``BasecampError/decodeFailure``, for
+    /// code that has to tell this failure from any other statusless `.api`
+    /// (#750). This is the one producer of that slot besides the §18 composites'
+    /// restatement of the same failure.
     ///
     /// **Wrap the decode expression, never the block.** Each primitive above
     /// runs encode → URL build → auth → transport → status check → decode inside
@@ -498,43 +499,25 @@ open class BaseService: @unchecked Sendable {
         }
     }
 
-    /// The phrase that identifies a malformed-body error, since `.api` carries
-    /// no `cause` to identify one structurally and statuslessness alone will not
-    /// do it: the pagination same-origin guard above throws a statusless `.api`
-    /// too. Written once, read back by ``malformedBodyMessage(_:)``.
-    private static let malformedBodyPhrase = "returned a body that does not decode"
-
     /// The one place a decode failure is rendered.
-    private static func malformedBody(_ operation: String, _ error: any Error) -> BasecampError {
+    ///
+    /// The message still says "returned a body that does not decode", but that
+    /// wording is no longer a contract: it used to be read back by a
+    /// `malformedBodyMessage(_:)` substring test that the composites and the
+    /// conformance runner asked "is this a malformed body?", so rewording it
+    /// moved the answer and a caller composing their own `.api` around the
+    /// phrase forged one. The answer is ``BasecampError/decodeFailure`` now
+    /// (#750), which is also what Kotlin's `BasecampException.Api.decodeFailure`
+    /// has answered since #730.
+    private static func malformedBody(_ operation: String, _ error: any Error & Sendable) -> BasecampError {
         .api(
             message: BasecampError.truncate(
-                "\(operation) \(malformedBodyPhrase): \(error)"),
+                "\(operation) returned a body that does not decode: \(error)"),
             httpStatus: nil,
             hint: nil,
-            requestId: nil
+            requestId: nil,
+            decodeFailure: error
         )
-    }
-
-    /// The message of a malformed-body error, or nil for any other
-    /// ``BasecampError`` — including the *other* statusless `.api`, the
-    /// pagination same-origin refusal, which is a deliberate guard rather than a
-    /// bad body.
-    ///
-    /// The composites ask this to add their own hint to that failure and only
-    /// that one. The conformance runner asks it to decide whether a fixture body
-    /// needs repairing (its #555 policy), and reaches it through
-    /// `@_spi(Conformance) import Basecamp`: it links the SDK as a product, and
-    /// the alternative — a second copy of ``malformedBodyPhrase`` in the runner —
-    /// is a constant nothing checks, which is what this SPI exists to avoid. SPI
-    /// rather than `public` because the answer is only meaningful to a caller
-    /// that already knows how this SDK renders the failure.
-    @_spi(Conformance) public static func malformedBodyMessage(_ error: BasecampError) -> String? {
-        guard case .api(let message, let httpStatus, _, _) = error, httpStatus == nil,
-            message.contains(malformedBodyPhrase)
-        else {
-            return nil
-        }
-        return message
     }
 
     // MARK: - Shared Coders

--- a/swift/Sources/Basecamp/TodolistsServiceExtensions.swift
+++ b/swift/Sources/Basecamp/TodolistsServiceExtensions.swift
@@ -124,21 +124,25 @@ extension TodolistsService {
         // malformed-2xx-body shape for every operation (#604) — statusless,
         // non-retryable `api_error` — so what is left to add here is the part
         // the base layer cannot know: the composite's escape hatch.
-        // `BaseService.malformedBodyMessage` is what recognizes that one
-        // failure — statuslessness alone would also match the pagination
-        // same-origin guard — so every other error passes through untouched.
+        // `BasecampError.decodeFailure` is what recognizes that one failure —
+        // statuslessness alone would also match the pagination same-origin
+        // guard — so every other error passes through untouched. The restatement
+        // carries the marker forward: it is the same malformed body with a
+        // better hint, and dropping it would tell the conformance runner (and
+        // any caller) this was not a decode failure (#750).
         let todolist: Todolist
         do {
             todolist = try await get(id: id)
         } catch let error as BasecampError {
-            guard let message = BaseService.malformedBodyMessage(error) else { throw error }
+            guard let decodeFailure = error.decodeFailure else { throw error }
             throw BasecampError.api(
-                message: message,
+                message: error.message,
                 httpStatus: nil,
                 hint: "The merge-safe update/edit resend this record's fields verbatim, so a "
                     + "malformed response cannot be written back safely. Use replace(id:req:) "
                     + "to write the record deliberately.",
-                requestId: nil
+                requestId: nil,
+                decodeFailure: decodeFailure
             )
         }
 
@@ -156,7 +160,8 @@ extension TodolistsService {
                 httpStatus: nil,
                 hint: "The name is presence-validated server-side, so an empty one is a "
                     + "malformed response. The caller did not ask to clear it.",
-                requestId: nil
+                requestId: nil,
+                decodeFailure: nil
             )
         }
         return todolist

--- a/swift/Tests/BasecampTests/DecodeIsolationTests.swift
+++ b/swift/Tests/BasecampTests/DecodeIsolationTests.swift
@@ -43,7 +43,7 @@ final class DecodeIsolationTests: XCTestCase {
             _ = try await account.projects.get(projectId: 1)
             XCTFail("expected a malformed body to fail")
         } catch let error as BasecampError {
-            guard case .api(let message, let httpStatus, _, _) = error else {
+            guard case .api(let message, let httpStatus, _, _, _) = error else {
                 return XCTFail("expected .api for a malformed body, got \(error)")
             }
             XCTAssertNil(httpStatus, "the transport succeeded, so no status describes this")
@@ -68,7 +68,7 @@ final class DecodeIsolationTests: XCTestCase {
             _ = try await account.projects.list()
             XCTFail("expected a malformed page to fail")
         } catch let error as BasecampError {
-            guard case .api(let message, let httpStatus, _, _) = error else {
+            guard case .api(let message, let httpStatus, _, _, _) = error else {
                 return XCTFail("expected .api, got \(error)")
             }
             XCTAssertNil(httpStatus)
@@ -112,7 +112,7 @@ final class DecodeIsolationTests: XCTestCase {
             _ = try await account.projects.list()
             XCTFail("expected the malformed second page to fail")
         } catch let error as BasecampError {
-            guard case .api(_, let httpStatus, _, _) = error else {
+            guard case .api(_, let httpStatus, _, _, _) = error else {
                 return XCTFail("expected .api, got \(error)")
             }
             XCTAssertEqual(pages.count, 2, "the second page must actually have been fetched")
@@ -133,7 +133,7 @@ final class DecodeIsolationTests: XCTestCase {
             _ = try await account.reports.personProgress(personId: 7)
             XCTFail("expected a body that is not JSON to fail")
         } catch let error as BasecampError {
-            guard case .api(let message, let httpStatus, _, _) = error else {
+            guard case .api(let message, let httpStatus, _, _, _) = error else {
                 return XCTFail("expected .api, got \(error)")
             }
             XCTAssertNil(httpStatus)
@@ -143,6 +143,101 @@ final class DecodeIsolationTests: XCTestCase {
         } catch {
             XCTFail("expected BasecampError, got a raw \(type(of: error)): \(error)")
         }
+    }
+
+    // MARK: - The marker: which statusless api_error is this?
+
+    /// The two statusless `.api`s the SDK produces, told apart structurally
+    /// (#750).
+    ///
+    /// This is one test and not two on purpose: the question is not "does a
+    /// decode failure carry the marker" but "does the marker SEPARATE the two
+    /// shapes", and the pagination same-origin refusal is the other one. Both
+    /// carry a nil `httpStatus` and both are `.api`, so before the marker the
+    /// only thing distinguishing them was a phrase inside the message — read
+    /// back through a `@_spi(Conformance)` substring test whose contract was
+    /// therefore the wording of a sentence.
+    func testTheMarkerSeparatesADecodeFailureFromThePaginationRefusal() async throws {
+        // Shape 1: a body the model refuses.
+        let decodeAccount = makeTestAccountClient(transport: transport(body: "{}"))
+        var decodeError: BasecampError?
+        do {
+            _ = try await decodeAccount.projects.get(projectId: 1)
+            XCTFail("expected a malformed body to fail")
+        } catch let error as BasecampError {
+            decodeError = error
+        }
+
+        // Shape 2: a Link header pointing off-origin. A deliberate guard, not a
+        // bad body — and `security.json` asserts on this refusal, so mislabelling
+        // it as a fixture-repair job would lose the assertion.
+        let page1 = Data("[]".utf8)
+        let refusalTransport = MockTransport { request in
+            (
+                page1,
+                makeHTTPResponse(
+                    url: request.url!.absoluteString, statusCode: 200,
+                    headers: [
+                        "Content-Type": "application/json",
+                        "Link": "<https://evil.example.com/steal?page=2>; rel=\"next\"",
+                    ])
+            )
+        }
+        let refusalAccount = makeTestAccountClient(transport: refusalTransport)
+        var refusalError: BasecampError?
+        do {
+            _ = try await refusalAccount.projects.list()
+            XCTFail("expected the off-origin Link header to be refused")
+        } catch let error as BasecampError {
+            refusalError = error
+        }
+
+        // Both are statusless `.api`, which is what makes the message the only
+        // thing that used to separate them.
+        XCTAssertNil(decodeError?.httpStatusCode)
+        XCTAssertNil(refusalError?.httpStatusCode)
+
+        // The marker separates them, and no substring is consulted to do it.
+        XCTAssertTrue(
+            decodeError?.decodeFailure is DecodingError,
+            "the decoder's own refusal must be the marker's value, got: "
+                + String(describing: decodeError?.decodeFailure))
+        XCTAssertNil(
+            refusalError?.decodeFailure,
+            "a deliberate guard is not a malformed body")
+    }
+
+    /// A body that is not JSON at all is refused by `JSONSerialization` on the
+    /// wrapped-list path, which reports a `CocoaError` rather than a
+    /// `DecodingError`. The marker carries whichever one refused, so a caller
+    /// telling those apart matches the concrete type instead of a message.
+    func testTheMarkerCarriesACocoaErrorForABodyThatIsNotJSON() async throws {
+        let account = makeTestAccountClient(transport: transport(body: "not json at all"))
+
+        do {
+            _ = try await account.reports.personProgress(personId: 7)
+            XCTFail("expected a body that is not JSON to fail")
+        } catch let error as BasecampError {
+            XCTAssertNotNil(error.decodeFailure, "this is still a malformed body")
+            XCTAssertFalse(
+                error.decodeFailure is DecodingError,
+                "JSONSerialization refused it, so the marker is not a DecodingError")
+        }
+    }
+
+    /// `decodeFailure` is nil for every error shape that is not `.api`, the way
+    /// `fieldErrors` is nil for everything that is not `.validation`. The
+    /// property is what callers are steered to read, so its behaviour off the
+    /// case it belongs to is part of the contract.
+    func testTheMarkerIsNilForEveryOtherErrorShape() {
+        XCTAssertNil(BasecampError.usage(message: "bad argument", hint: nil).decodeFailure)
+        XCTAssertNil(
+            BasecampError.network(message: "socket dropped", cause: nil).decodeFailure)
+        XCTAssertNil(
+            BasecampError.validation(
+                message: "invalid", httpStatus: 422, hint: nil, requestId: nil,
+                fieldErrors: ["title": ["is required"]]
+            ).decodeFailure)
     }
 
     // MARK: - Negative: everything else in the block keeps its own identity

--- a/swift/Tests/BasecampTests/DocumentsServiceExtensionsTests.swift
+++ b/swift/Tests/BasecampTests/DocumentsServiceExtensionsTests.swift
@@ -141,7 +141,7 @@ final class DocumentsServiceExtensionsTests: XCTestCase {
                 documentId: 42, req: UpdateDocumentRequest(content: "<p>New body.</p>"))
             XCTFail("expected the call to fail, but it succeeded")
         } catch let error as BasecampError {
-            guard case .api(_, let httpStatus, let hint, _) = error else {
+            guard case .api(_, let httpStatus, let hint, _, _) = error else {
                 return XCTFail("expected .api, got \(error)")
             }
             XCTAssertNil(httpStatus, "a malformed 2xx body carries no status")
@@ -151,6 +151,78 @@ final class DocumentsServiceExtensionsTests: XCTestCase {
         XCTAssertEqual(log.methods, ["GET"], "the guard must fire before the PUT")
     }
 
+    /// The composite restates the base layer's decode failure with its own
+    /// escape hatch, and the restatement is still that decode failure: it
+    /// carries `decodeFailure` forward (#750).
+    ///
+    /// Dropping it would say "this was not a malformed body after all" to
+    /// everything downstream — the conformance runner included, where the answer
+    /// decides between "repair the fixture body" and "hand this to the
+    /// assertions". Read through the property, not by matching the case, which is
+    /// what the migration entry steers callers to do.
+    ///
+    /// The blank-title refusal above is the control: it is a hand-written guard
+    /// on a body that decoded fine, so its marker is nil.
+    func testUpdate_restatementKeepsTheDecodeFailureMarker() async throws {
+        let log = DocumentRequestLog()
+        var wrongType = fullDocumentJSON()
+        wrongType["title"] = 42
+        let wrongTypeData = try JSONSerialization.data(withJSONObject: wrongType)
+        let transport = MockTransport { request in
+            log.record(request)
+            return (
+                wrongTypeData,
+                makeHTTPResponse(
+                    url: request.url!.absoluteString,
+                    statusCode: 200,
+                    headers: ["Content-Type": "application/json"]
+                )
+            )
+        }
+        let account = makeTestAccountClient(transport: transport)
+
+        do {
+            _ = try await account.documents.update(
+                documentId: 42, req: UpdateDocumentRequest(content: "<p>New body.</p>"))
+            XCTFail("expected the call to fail, but it succeeded")
+        } catch let error as BasecampError {
+            XCTAssertNotNil(
+                error.decodeFailure,
+                "the composite's restatement must keep the marker")
+            XCTAssertNotNil(error.hint, "and must add its own escape hatch")
+        }
+
+        XCTAssertEqual(log.methods, ["GET"], "the guard must fire before the PUT")
+    }
+
+    func testUpdate_blankTitleRefusalCarriesNoDecodeFailureMarker() async throws {
+        let log = DocumentRequestLog()
+        var blank = fullDocumentJSON()
+        blank["title"] = "   "
+        let blankData = try JSONSerialization.data(withJSONObject: blank)
+        let transport = MockTransport { request in
+            log.record(request)
+            return (
+                blankData,
+                makeHTTPResponse(
+                    url: request.url!.absoluteString,
+                    statusCode: 200,
+                    headers: ["Content-Type": "application/json"]
+                )
+            )
+        }
+        let account = makeTestAccountClient(transport: transport)
+
+        do {
+            _ = try await account.documents.update(
+                documentId: 42, req: UpdateDocumentRequest(content: "<p>New body.</p>"))
+            XCTFail("expected the call to fail, but it succeeded")
+        } catch let error as BasecampError {
+            XCTAssertNil(
+                error.decodeFailure,
+                "a hand-written guard on a body that decoded is not a decode failure")
+        }
+    }
 
     func testUpdate_mergesUnsetFields() async throws {
         let log = DocumentRequestLog()

--- a/swift/Tests/BasecampTests/ErrorTests.swift
+++ b/swift/Tests/BasecampTests/ErrorTests.swift
@@ -48,14 +48,14 @@ final class ErrorTests: XCTestCase {
     }
 
     func testApiErrorProperties() {
-        let error = BasecampError.api(message: "Server error", httpStatus: 500, hint: nil, requestId: nil)
+        let error = BasecampError.api(message: "Server error", httpStatus: 500, hint: nil, requestId: nil, decodeFailure: nil)
         XCTAssertEqual(error.httpStatusCode, 500)
         XCTAssertEqual(error.exitCode, 7)
         XCTAssertTrue(error.isRetryable)
     }
 
     func testApiError4xxNotRetryable() {
-        let error = BasecampError.api(message: "Bad", httpStatus: 418, hint: nil, requestId: nil)
+        let error = BasecampError.api(message: "Bad", httpStatus: 418, hint: nil, requestId: nil, decodeFailure: nil)
         XCTAssertFalse(error.isRetryable)
     }
 
@@ -270,7 +270,7 @@ final class ErrorTests: XCTestCase {
 
     func testFromHTTPResponse500() {
         let error = BasecampError.fromHTTPResponse(status: 500, data: nil, headers: [:], requestId: nil)
-        if case .api(_, let status, _, _) = error {
+        if case .api(_, let status, _, _, _) = error {
             XCTAssertEqual(status, 500)
         } else {
             XCTFail("Expected .api")

--- a/swift/Tests/BasecampTests/PaginationTests.swift
+++ b/swift/Tests/BasecampTests/PaginationTests.swift
@@ -355,7 +355,7 @@ final class PaginationTests: XCTestCase {
             let _: ListResult<Project> = try await account.projects.list()
             XCTFail("Expected SSRF error for different-origin Link header")
         } catch let error as BasecampError {
-            if case .api(let message, _, _, _) = error {
+            if case .api(let message, _, _, _, _) = error {
                 XCTAssertTrue(message.contains("different origin"),
                               "Error should mention different origin, got: \(message)")
             } else {

--- a/swift/Tests/BasecampTests/SchedulesServiceExtensionsTests.swift
+++ b/swift/Tests/BasecampTests/SchedulesServiceExtensionsTests.swift
@@ -296,6 +296,43 @@ final class SchedulesServiceExtensionsTests: XCTestCase {
         try await assertMalformedReadAborts(body: wrongType)
     }
 
+    /// The composite restates the base layer's decode failure with its own
+    /// escape hatch, and the restatement is still that decode failure: it
+    /// carries `decodeFailure` forward (#750). Dropping it would tell the
+    /// conformance runner — and any caller reading the property — that this was
+    /// not a malformed body.
+    ///
+    /// The blank-summary case is the control: a hand-written guard on a body that
+    /// decoded fine, so its marker is nil.
+    func testUpdateEntry_restatementKeepsTheDecodeFailureMarker() async throws {
+        var wrongType = fullScheduleEntryJSON()
+        wrongType["description"] = 42
+        let decodeError = try await malformedReadError(body: wrongType)
+        XCTAssertNotNil(
+            decodeError?.decodeFailure, "the restatement must keep the marker")
+        XCTAssertNotNil(decodeError?.hint, "and must add its own escape hatch")
+
+        var blank = fullScheduleEntryJSON()
+        blank["summary"] = "   "
+        let guardError = try await malformedReadError(body: blank)
+        XCTAssertNil(
+            guardError?.decodeFailure,
+            "a hand-written guard on a body that decoded is not a decode failure")
+    }
+
+    private func malformedReadError(body: [String: Any]) async throws -> BasecampError? {
+        let log = ScheduleEntryRequestLog()
+        let account = try makeSchedulesClient(log: log, body: body)
+        do {
+            _ = try await account.schedules.updateEntry(
+                entryId: 1069479523, req: UpdateScheduleEntryRequest(summary: "never written"))
+            XCTFail("expected the call to fail, but it succeeded")
+            return nil
+        } catch let error as BasecampError {
+            return error
+        }
+    }
+
     /// Every malformed read must abort BEFORE the PUT with the SDK's statusless,
     /// non-retryable `api_error`.
     private func assertMalformedReadAborts(
@@ -309,7 +346,7 @@ final class SchedulesServiceExtensionsTests: XCTestCase {
                 entryId: 1069479523, req: UpdateScheduleEntryRequest(summary: "never written"))
             XCTFail("expected the call to fail, but it succeeded", file: file, line: line)
         } catch let error as BasecampError {
-            guard case .api(_, let httpStatus, let hint, _) = error else {
+            guard case .api(_, let httpStatus, let hint, _, _) = error else {
                 return XCTFail("expected .api, got \(error)", file: file, line: line)
             }
             XCTAssertNil(httpStatus, "a malformed 2xx body carries no status", file: file, line: line)

--- a/swift/Tests/BasecampTests/TodolistsServiceExtensionsTests.swift
+++ b/swift/Tests/BasecampTests/TodolistsServiceExtensionsTests.swift
@@ -485,10 +485,11 @@ final class TodolistsServiceExtensionsTests: XCTestCase {
             XCTFail("expected a decoding error, got \(todolist)")
         } catch let error as BasecampError {
             // Since #604 the decoder's refusal wears the SPEC §6
-            // malformed-2xx-body shape. `BasecampError.api` has no `cause` slot
-            // — adding one would break every `switch` over the case — so the
-            // `DecodingError`'s own description, coding path included, is
-            // carried in the message and asserted there.
+            // malformed-2xx-body shape, and since #750 it carries the
+            // `DecodingError` itself in `decodeFailure` (asserted by the helper
+            // below). Its own description, coding path included, is still
+            // interpolated into the message, which is what these assertions
+            // read — the message is where a human looks.
             let message = assertStatuslessDecodeFailure(error)
             XCTAssertTrue(message.contains("typeMismatch"), message)
             // camelCase because BaseService.decoder applies .convertFromSnakeCase.
@@ -581,7 +582,7 @@ final class TodolistsServiceExtensionsTests: XCTestCase {
                 id: 2, req: UpdateTodolistRequest(description: "<p>New</p>"))
             XCTFail("expected an empty name from the wire to be refused")
         } catch let error as BasecampError {
-            guard case .api(let message, _, _, _) = error else {
+            guard case .api(let message, _, _, _, _) = error else {
                 return XCTFail("expected .api for a malformed response, got \(error)")
             }
             XCTAssertTrue(
@@ -608,13 +609,18 @@ final class TodolistsServiceExtensionsTests: XCTestCase {
                 id: 2, req: UpdateTodolistRequest(name: "Renamed"))
             XCTFail("expected a decode failure to surface as a BasecampError")
         } catch let error as BasecampError {
-            guard case .api(let message, let httpStatus, let hint, _) = error else {
+            guard case .api(let message, let httpStatus, let hint, _, _) = error else {
                 return XCTFail("expected .api for a malformed body, got \(error)")
             }
             XCTAssertNil(httpStatus, "the transport succeeded, so there is no status to report")
             XCTAssertNotNil(hint)
             XCTAssertLessThanOrEqual(message.count, 500, "SPEC section 9 caps the message")
             XCTAssertTrue(message.contains("does not decode"), message)
+            // The restatement is still that decode failure, so it carries the
+            // marker forward (#750). The message assertion above is a
+            // convenience for a human reading a failure; this is the contract.
+            XCTAssertNotNil(
+                error.decodeFailure, "the composite's restatement must keep the marker")
         } catch {
             XCTFail("expected BasecampError, got a raw \(type(of: error)): \(error)")
         }
@@ -653,7 +659,7 @@ extension XCTestCase {
     func assertStatuslessDecodeFailure(
         _ error: BasecampError, file: StaticString = #filePath, line: UInt = #line
     ) -> String {
-        guard case .api(let message, let httpStatus, _, _) = error else {
+        guard case .api(let message, let httpStatus, _, _, _) = error else {
             XCTFail("expected .api for a malformed body, got \(error)", file: file, line: line)
             return ""
         }
@@ -662,6 +668,9 @@ extension XCTestCase {
             line: line)
         XCTAssertFalse(
             error.isRetryable, "re-requesting cannot repair a malformed body", file: file,
+            line: line)
+        XCTAssertNotNil(
+            error.decodeFailure, "the base layer's producer sets the #750 marker", file: file,
             line: line)
         return message
     }

--- a/swift/Tests/BasecampTests/TransportNetworkErrorRetryTests.swift
+++ b/swift/Tests/BasecampTests/TransportNetworkErrorRetryTests.swift
@@ -165,7 +165,7 @@ final class TransportNetworkErrorRetryTests: XCTestCase {
         for error in [
             BasecampError.auth(message: "nope", hint: nil, requestId: nil),
             BasecampError.usage(message: "bad config", hint: nil),
-            BasecampError.api(message: "boom", httpStatus: 500, hint: nil, requestId: nil),
+            BasecampError.api(message: "boom", httpStatus: 500, hint: nil, requestId: nil, decodeFailure: nil),
         ] {
             let counter = AttemptCounter()
             let transport = BasecampErrorTransport(

--- a/swift/Tests/BasecampTests/UpcomingScheduleDecodeTests.swift
+++ b/swift/Tests/BasecampTests/UpcomingScheduleDecodeTests.swift
@@ -139,7 +139,8 @@ final class UpcomingScheduleDecodeTests: XCTestCase {
         } catch let error as BasecampError {
             // Since #604 the decoder's refusal wears the SPEC §6
             // malformed-2xx-body shape; the `DecodingError`'s own description
-            // rides in the message, which is where `.api` can carry it.
+            // rides in the message, and since #750 the exception itself rides in
+            // `decodeFailure`.
             let message = assertStatuslessDecodeFailure(error)
             XCTAssertTrue(message.contains("keyNotFound"), message)
             XCTAssertTrue(message.contains("assignables"), message)

--- a/typescript/src/services/base.ts
+++ b/typescript/src/services/base.ts
@@ -125,6 +125,30 @@ function normalizePersonIds(obj: unknown): void {
   }
 }
 
+/**
+ * Whether a rejection denotes invalid JSON rather than a failed read.
+ *
+ * `response.json()` rejects for two unrelated reasons, and only one of them is
+ * a malformed body: the bytes arrived and would not parse (SyntaxError), or the
+ * bytes never finished arriving — a socket reset or a decompression failure
+ * (TypeError), an aborted read (AbortError). Those are transport failures and
+ * keep their own semantics.
+ *
+ * Matched on `name`, not `instanceof`, and the engines force that rather than
+ * merely permitting it: Node/undici rejects with a real `SyntaxError`, but
+ * WebKit rejects with a **DOMException** named "SyntaxError", which
+ * `instanceof SyntaxError` answers `false` for. Narrowing by constructor would
+ * classify nothing in Safari and let every malformed body escape there — and
+ * excluding DOMException, to keep a DOMException named "SyntaxError" from
+ * matching, would break exactly the engine that produces one. A cross-realm
+ * error is the third case the name survives and `instanceof` does not, which is
+ * why the OAuth device flow matches AbortError the same way. Nothing else
+ * `response.json()` can reject with is named "SyntaxError".
+ */
+function isJsonSyntaxError(err: unknown): err is SyntaxError {
+  return typeof err === "object" && err !== null && (err as { name?: unknown }).name === "SyntaxError";
+}
+
 export abstract class BaseService {
   /** The underlying openapi-fetch client */
   protected readonly client: RawClient;
@@ -563,17 +587,23 @@ export abstract class BaseService {
    * mid-object or was never JSON, and neither answer is parsed back out of the
    * other. Statusless per SPEC §6 — the transport returned 2xx — and
    * non-retryable, because re-requesting cannot repair a malformed body.
+   *
+   * Only a syntax failure is classified. A read that dies partway through — a
+   * reset socket, a corrupt gzip stream, an aborted request — rejects here too,
+   * and it is transient: relabelling it non-retryable would be a worse answer
+   * than the bare error this replaced. It propagates with its own type.
    */
   private async parsePage<T>(response: Response, page: number): Promise<T> {
     try {
       return (await response.json()) as T;
     } catch (err) {
-      const detail = err instanceof Error ? err.message : String(err);
-      throw new BasecampError(
-        "api_error",
-        truncateErrorMessage(`Failed to parse paginated response (page ${page}): ${detail}`),
-        { retryable: false, cause: err instanceof Error ? err : undefined },
-      );
+      throw isJsonSyntaxError(err)
+        ? new BasecampError(
+            "api_error",
+            truncateErrorMessage(`Failed to parse paginated response (page ${page}): ${err.message}`),
+            { retryable: false, cause: err },
+          )
+        : err;
     }
   }
 

--- a/typescript/src/services/base.ts
+++ b/typescript/src/services/base.ts
@@ -23,7 +23,7 @@
  */
 
 import type { BasecampHooks, OperationInfo, OperationResult } from "../hooks.js";
-import { BasecampError, errorFromParsedBody, errorFromResponse } from "../errors.js";
+import { BasecampError, errorFromParsedBody, errorFromResponse, truncateErrorMessage } from "../errors.js";
 import metadata from "../generated/metadata.js";
 import { ListResult, parseTotalCount, type PaginationOptions } from "../pagination.js";
 import { parseNextLink, resolveURL, isSameOrigin, DEFAULT_MAX_PAGES, assertValidMaxPages } from "../pagination-utils.js";
@@ -549,6 +549,35 @@ export abstract class BaseService {
   }
 
   /**
+   * Decodes a followed page's body, refusing one that is not JSON.
+   *
+   * The raw-fetch pagination path is the only place this SDK decodes a body
+   * itself — every other response comes back through `openapi-fetch` — and an
+   * unwrapped `await response.json()` let a `SyntaxError` escape with no code,
+   * no hint and nothing to distinguish "the server sent garbage on page 4" from
+   * a bug in the caller's own code. Ruby and Python already classify this exact
+   * failure with this exact message; TypeScript was the outlier.
+   *
+   * `cause` carries the decoder's own error, which is the #750 contract: the
+   * message says which page failed, the slot says whether the body was truncated
+   * mid-object or was never JSON, and neither answer is parsed back out of the
+   * other. Statusless per SPEC §6 — the transport returned 2xx — and
+   * non-retryable, because re-requesting cannot repair a malformed body.
+   */
+  private async parsePage<T>(response: Response, page: number): Promise<T> {
+    try {
+      return (await response.json()) as T;
+    } catch (err) {
+      const detail = err instanceof Error ? err.message : String(err);
+      throw new BasecampError(
+        "api_error",
+        truncateErrorMessage(`Failed to parse paginated response (page ${page}): ${detail}`),
+        { retryable: false, cause: err instanceof Error ? err : undefined },
+      );
+    }
+  }
+
+  /**
    * Follows Link header pagination, accumulating items across pages.
    * Returns items and whether results were truncated: true only when items
    * beyond maxItems were dropped, or a next-page link was left unfetched
@@ -583,7 +612,7 @@ export abstract class BaseService {
         throw await errorFromResponse(response, response.headers.get("X-Request-Id") ?? undefined);
       }
 
-      const pageItems: T[] = (await response.json()) as T[];
+      const pageItems: T[] = await this.parsePage<T[]>(response, page + 1);
       normalizePersonIds(pageItems);
       allItems.push(...pageItems);
 
@@ -635,7 +664,7 @@ export abstract class BaseService {
         throw await errorFromResponse(response, response.headers.get("X-Request-Id") ?? undefined);
       }
 
-      const pageData = (await response.json()) as Record<string, unknown>;
+      const pageData = await this.parsePage<Record<string, unknown>>(response, page + 1);
       normalizePersonIds(pageData);
       const pageItems: T[] = (pageData[key] as T[]) ?? [];
       allItems.push(...pageItems);

--- a/typescript/tests/services/base.test.ts
+++ b/typescript/tests/services/base.test.ts
@@ -375,6 +375,100 @@ describe("BaseService", () => {
       expect(basecampError.cause).toBeInstanceOf(SyntaxError);
     });
 
+    // Vitest runs on Node, where a JSON syntax failure is a real SyntaxError, so
+    // nothing above would notice the discriminator being "simplified" back to
+    // `instanceof SyntaxError`. WebKit rejects the same malformed body with a
+    // DOMException *named* SyntaxError, which that test answers false for — the
+    // whole class would escape unclassified in Safari, and no Node test can see
+    // it. This case is that engine's shape, pinned where it can fail.
+    it("should classify a syntax failure the engine reports as a DOMException", async () => {
+      server.use(
+        http.get(`${BASE_URL}/test-list`, () => {
+          return HttpResponse.json([{ id: 1 }, { id: 2 }], {
+            headers: { Link: `<${BASE_URL}/test-list?page=2>; rel="next"` },
+          });
+        })
+      );
+
+      const thrown = new DOMException("JSON Parse error: Unexpected EOF", "SyntaxError");
+      expect(thrown).not.toBeInstanceOf(SyntaxError);
+
+      const client = createBasecampClient({ accountId: "12345", accessToken: "test-token" });
+      const paginatedService = new TestService(client.raw, undefined, async () => {
+        const body = new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.error(thrown);
+          },
+        });
+        return new Response(body, {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      });
+
+      const error = await paginatedService
+        .testPaginatedGet<{ id: number }>("/test-list", listInfo)
+        .then(() => null, (err: unknown) => err);
+
+      expect(error).toBeInstanceOf(BasecampError);
+      const basecampError = error as BasecampError;
+      expect(basecampError.code).toBe("api_error");
+      expect(basecampError.retryable).toBe(false);
+      expect(basecampError.cause).toBe(thrown);
+    });
+
+    // `response.json()` rejects for two unrelated reasons: the bytes arrived and
+    // were not JSON, or the bytes never finished arriving. Only the first is a
+    // malformed body. A socket reset surfaces as TypeError, an aborted read as
+    // AbortError, and both are transient — classifying either as a statusless
+    // non-retryable api_error would tell a caller reading `retryable` that a
+    // failure it should retry is permanent. They propagate untouched, with the
+    // type the runtime gave them, so the SDK's own retry layer still sees them
+    // for what they are.
+    for (const { label, failure, expectedName } of [
+      { label: "a socket reset", failure: () => new TypeError("terminated"), expectedName: "TypeError" },
+      {
+        label: "an aborted read",
+        failure: () => new DOMException("The operation was aborted", "AbortError"),
+        expectedName: "AbortError",
+      },
+    ]) {
+      it(`should propagate ${label} during a followed page's body read`, async () => {
+        server.use(
+          http.get(`${BASE_URL}/test-list`, () => {
+            return HttpResponse.json([{ id: 1 }, { id: 2 }], {
+              headers: { Link: `<${BASE_URL}/test-list?page=2>; rel="next"` },
+            });
+          })
+        );
+
+        const thrown = failure();
+        const client = createBasecampClient({ accountId: "12345", accessToken: "test-token" });
+        // The page arrives with a 200 and a body stream that fails partway
+        // through, which is what the transport failure looks like from here.
+        const paginatedService = new TestService(client.raw, undefined, async () => {
+          const body = new ReadableStream<Uint8Array>({
+            start(controller) {
+              controller.enqueue(new TextEncoder().encode('[{"id": 3}'));
+              controller.error(thrown);
+            },
+          });
+          return new Response(body, {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          });
+        });
+
+        const error = await paginatedService
+          .testPaginatedGet<{ id: number }>("/test-list", listInfo)
+          .then(() => null, (err: unknown) => err);
+
+        expect(error).not.toBeInstanceOf(BasecampError);
+        expect(error).toBe(thrown);
+        expect((error as Error).name).toBe(expectedName);
+      });
+    }
+
     it("should throw BasecampError on cross-origin Link header", async () => {
       server.use(
         http.get(`${BASE_URL}/test-list`, () => {

--- a/typescript/tests/services/base.test.ts
+++ b/typescript/tests/services/base.test.ts
@@ -334,6 +334,47 @@ describe("BaseService", () => {
       expect(pageRequests).toBe(2);
     });
 
+    // A followed page whose body is not JSON is "the server sent something I
+    // could not decode", and it used to escape as a bare SyntaxError: no code, no
+    // hint, indistinguishable from a bug in the caller's own code. Ruby and
+    // Python already classified it with this message; #750 gives all six the same
+    // shape and the same reachable cause.
+    it("should classify an unparseable followed page and keep the decoder error", async () => {
+      server.use(
+        http.get(`${BASE_URL}/test-list`, ({ request }) => {
+          const url = new URL(request.url);
+          if (url.searchParams.get("page") === "2") {
+            return new HttpResponse('[{"id": 3', {
+              headers: { "Content-Type": "application/json" },
+            });
+          }
+          return HttpResponse.json([{ id: 1 }, { id: 2 }], {
+            headers: { Link: `<${BASE_URL}/test-list?page=2>; rel="next"` },
+          });
+        })
+      );
+
+      const client = createBasecampClient({ accountId: "12345", accessToken: "test-token" });
+      const paginatedService = new TestService(client.raw, undefined, async (url: string) => {
+        return fetch(url, { headers: { Accept: "application/json" } });
+      });
+
+      const error = await paginatedService
+        .testPaginatedGet<{ id: number }>("/test-list", listInfo)
+        .then(() => null, (err: unknown) => err);
+
+      expect(error).toBeInstanceOf(BasecampError);
+      const basecampError = error as BasecampError;
+      expect(basecampError.code).toBe("api_error");
+      // Statusless per SPEC §6 — the transport returned 2xx — and re-requesting
+      // cannot repair a malformed body.
+      expect(basecampError.httpStatus).toBeUndefined();
+      expect(basecampError.retryable).toBe(false);
+      expect(basecampError.message).toContain("page 2");
+      // The marker: the decoder's own error, not a phrase to match on.
+      expect(basecampError.cause).toBeInstanceOf(SyntaxError);
+    });
+
     it("should throw BasecampError on cross-origin Link header", async () => {
       server.use(
         http.get(`${BASE_URL}/test-list`, () => {
@@ -755,6 +796,45 @@ describe("BaseService", () => {
       const events = result.events;
       expect(events.length).toBe(3);
       expect(events.meta.truncated).toBe(false);
+    });
+
+    // The wrapped loop decodes its pages at its own call site, so it is a second
+    // case rather than a second assertion about the first: routing both through
+    // one helper is not what makes them both classified.
+    it("should classify an unparseable followed page and keep the decoder error", async () => {
+      server.use(
+        http.get(`${BASE_URL}/test-wrapped`, ({ request }) => {
+          const url = new URL(request.url);
+          if (url.searchParams.get("page") === "2") {
+            return new HttpResponse("not json at all", {
+              headers: { "Content-Type": "application/json" },
+            });
+          }
+          return HttpResponse.json({
+            person: { id: 456, name: "Jane Doe" },
+            events: [{ id: 1, action: "created" }],
+          }, {
+            headers: { Link: `<${BASE_URL}/test-wrapped?page=2>; rel="next"` },
+          });
+        })
+      );
+
+      const client = createBasecampClient({ accountId: "12345", accessToken: "test-token" });
+      const wrappedService = new TestService(client.raw, undefined, async (url: string) => {
+        return fetch(url, { headers: { Accept: "application/json" } });
+      });
+
+      const error = await wrappedService
+        .testPaginatedWrappedGet<"events", { id: number; action: string }>("/test-wrapped", listInfo, "events")
+        .then(() => null, (err: unknown) => err);
+
+      expect(error).toBeInstanceOf(BasecampError);
+      const basecampError = error as BasecampError;
+      expect(basecampError.code).toBe("api_error");
+      expect(basecampError.httpStatus).toBeUndefined();
+      expect(basecampError.retryable).toBe(false);
+      expect(basecampError.message).toContain("page 2");
+      expect(basecampError.cause).toBeInstanceOf(SyntaxError);
     });
   });
 


### PR DESCRIPTION
Closes #750.

"Did the server send a body I could not decode?" had six different answers, one of them a substring test. This gives it one structural answer everywhere — and on the way, finishes #730, which is **still live** one module over.

## It contains a live bug fix, and that is the first commit

#730 added `BasecampException.Api.decodeFailure` and migrated the three Kotlin composites to it. **The Kotlin conformance runner was never migrated** — it still read `(e as? BasecampException.Api)?.cause as? SerializationException`.

The two agree only because `Api.malformedBody` sets both slots to the same exception. They diverge for exactly the case #730 exists to fix: an `AuthStrategy` throwing `Api(message, cause = SerializationException(...))` through the *public* constructor gets `decodeFailure = null`, so the composites pass it through correctly while the runner calls it a malformed mock body. #730's defect outlived #730.

**Red proof.** Reverting `malformedBodyFailure` to the verbatim pre-fix expression and running `make conformance-runner-tests-kotlin` → exit 2, `39 tests completed, 1 failed`:

> FAIL `an auth strategy failure carrying a serialization cause is not a malformed body` — expected `<null>` but was `<kotlinx.serialization.SerializationException: Unexpected JSON token at offset 0>`

…while `a decoder refusal carries the decode failure` passed, so the test is not vacuous. After restore: exit 0, 3/3 new tests executed per the JUnit XML.

## The Kotlin visibility problem: public read-only `val`

`:conformance` is a separate Gradle module and cannot see `internal`, which is *why* the runner was reading `cause`. `@PublishedApi internal` does not solve it — it lifts an internal declaration into the ABI for public inline functions **of the same module** and still cannot be named from another module's source. Reflection would work and would be a mechanism the compiler cannot check.

The public getter costs nothing, because the guarantee is a property of the **producer**: the constructor that fills the slot is private, the factory that reaches it is internal and name-mangled, and both are pinned by `ApiConstructorSurfaceTest` (unchanged, still passing). It also matches Swift's `decodeFailure`, which is public in this same PR for the same reason.

## One commit beyond the plan, and it is load-bearing

The three Kotlin composites **restate** the base layer's malformed-body refusal through the *public* constructor, which leaves `decodeFailure` null — so the restatement of a malformed body claimed not to be one. That was invisible while the composites were the slot's only readers. Once the runner reads it, a mock body refused by a Documents/Todolists/Schedules composite would reach the assertions instead of triggering "repair the fixture" (#555).

Worse for Swift: `malformedBodyMessage` *did* recognise those restatements, because the message contained the phrase. Retiring the phrase without preserving the marker would have been a runner regression. So the internal Kotlin factory now takes the composites' hint, and Swift's three composites pass `decodeFailure` forward.

**No committed fixture reaches those three paths, which is exactly why it would have shipped unnoticed.**

## The four dynamic SDKs: nearly free, none of it breaking

Go, TypeScript and Ruby all had a `cause` slot and simply weren't setting it at the refusal sites. Go's `documentDecodeError` interpolated the decoder error into the message and then dropped it, so `errors.As`/`errors.Is` could not reach it.

- **Go** — both composite decode refusals set `Cause`, so `errors.As` reaches `*json.UnmarshalTypeError` and `*json.SyntaxError` through `Unwrap`.
- **Ruby** — the paginated-page parse failure carries its `JSON::ParserError` in `cause`.
- **Python** — `BasecampError` grew a `cause` property over `__cause__`, which the refusal sites already set. Purely additive; it was the only SDK of the six with nowhere to put it.
- **TypeScript** — one **behaviour change**, documented: a followed pagination page whose body is not JSON used to escape as a bare `SyntaxError` — no code, no hint, indistinguishable from a bug in the caller's own code. It is now the same statusless, non-retryable `api_error` Ruby and Python already raised there, with the `SyntaxError` in `cause`.

  **Review caught this catching too much**, and it was a real regression: `response.json()` also rejects when the body *stream* fails — a reset socket or corrupt gzip surfaces as `TypeError`, an aborted read as `AbortError` — so transient failures were being stamped non-retryable. Only a syntax failure is classified now; the rest propagate with their own type.

  The discriminator is `name === "SyntaxError"`, not `instanceof`, and the engines forced that rather than merely permitting it:

  | case | Node 22 / undici | WebKit (Safari 26.5) |
  |---|---|---|
  | body arrived, invalid JSON | `SyntaxError`, `instanceof` true | **DOMException named `"SyntaxError"`**, `instanceof` **false** |
  | socket reset mid-body | `TypeError: terminated` | `TypeError` |
  | aborted read | DOMException `AbortError` | DOMException `AbortError` |
  | cross-realm syntax error | `instanceof SyntaxError` false, `instanceof Error` **false**, `name` true | identical |

  So the obvious narrowing would have classified **nothing in Safari**, and excluding `DOMException` defensively would have broken exactly the engine that produces one. Matching on `name` is also the house convention — `oauth/device.ts` matches `AbortError` that way, its comment citing the same reason. A dedicated test covers Safari's shape, which no Node run can reach, and mutating the check back to `instanceof` kills it.

Each site red-proved individually: Go documents / Go schedules (exit 1 each, the other passing), Ruby `cause:` (exit 1), Python sync / async `from e` (exit 1 each), TS bare-array / wrapped paginator (exit 1 each, with the failing `describe` verified to be the mutated one).

## Swift: a compile break, taken deliberately

`BasecampError.api` gains a fifth associated value carrying the decode failure, and a `decodeFailure` computed property alongside it — nil for every other shape, modelled on `fieldErrors` from #549 so callers can stop matching the case entirely.

**`malformedBodyMessage` and the repo's only `@_spi` are gone.** The helper's own docstring named the reason it existed: `.api` had no slot to answer the question structurally. This PR removes that reason. It also deletes the Swift runner's dependence on message text — the contract was the *wording of a sentence*, so rewording the message moved the answer, and a caller composing their own `.api` around the phrase forged one.

**Precedent, since this is a source break.** `MIGRATING.md`'s Class A/Class B plus a `breaking` label is the whole process here — no CHANGELOG, no semver gate, no API-surface snapshot — and the same move has shipped twice in the last two releases: `BasecampError.validation` gained a fifth associated value in v0.13.0 (#549), and `BasecampError` gained `case limitExceeded` in v0.14.0. #725 declined this on scope, not policy.

**Blast radius, all migrated:** 17 binding matches (6 `Sources/`, 11 `Tests/`) and 15 constructions (12 `Sources/`, 3 `Tests/`), plus the `swift/README.md` example, which now also demonstrates the property. **The 5 bare `case .api` matches survive untouched**, verified by name rather than assumed: `BasecampError.swift:118`, `conformance/.../Assertions.swift:35` (the runner's exhaustive switch), `RetryTests.swift:637`, `DownloadTests.swift:221` and `:296`.

**Red proof.** `testTheMarkerSeparatesADecodeFailureFromThePaginationRefusal` asserts both errors are statusless `.api`, that the decode failure's marker `is DecodingError`, and that the same-origin refusal's marker is nil — the distinction the substring test could only make by reading English. Mutating the producer (`decodeFailure: nil` in `BaseService.malformedBody`) → exit 1, 16 failures including that test. Each of the three composite restatements, mutated on its own, failed exactly its own test and nothing else.

## MIGRATING.md

The entry is modelled line-for-line on #549's, down to steering callers at the property so a sixth associated value will not move them again.

It also **corrects the #604 entry in the same unreleased section**, which states outright that `.api` gained no slot *because* adding an associated value would break every `switch`. That was true when written and is the decision this release reverses; leaving it would have shipped a release note contradicting itself.

## Verification

`make check` at final HEAD → **exit 0** — it includes `go-check ts-check rb-check kt-check swift-check py-check`, every drift gate, the doc gates, `conformance` and `conformance-runner-tests`. Individually: `kt-check` 0 · `go-check` 0 · `rb-check` 0 · `py-check` 0 · `ts-check` 0 · `swift-check` 0 (431 tests) · `conformance` 0 (197 passed, 1 skipped, 198 declared). Post-rebase onto the current `main`: `doc-constants-check` 0 and the new `check-operation-assignment-parity` 0.

**One pre-existing environment caveat, not introduced here.** `LC_ALL=C make conformance` fails in `conformance/runner/ruby/runner.rb` with `Encoding::InvalidByteSequenceError` reading `conformance/tests/*.json` — the known unpinned-encoding trap. This branch touches neither `conformance/tests/` nor the Ruby runner (0 files). The green runs above used `LC_ALL=C.UTF-8`. Worth its own gate-hardening issue; not fixed here.

## Reported, not fixed here

**Go has the same over-wide refusal shape**, at `vaults.go:508` and `schedules.go:814`. Go streams the body and `io.ReadAll` runs *inside* the generated parse, so `unexpected EOF`, a reset or a deadline lands in `decodeErr` and is stamped `CodeAPI`, statusless, `Retryable: false`. It predates this PR — only `Cause: err` is new — and the fix is an `errors.As` gate at two call sites plus tests, not a one-line narrowing, so it wants its own issue rather than widening this one. The other four SDKs are safe: Ruby, Kotlin, Swift and Python all buffer the body before decoding.

## Deliberately not done

The marker is **not** added to `SPEC.md` §6. Doing so would make it a normative obligation on all six SDKs, which is a larger call than this PR's remit — flagged rather than decided.
