### PR TITLE
API compatibility: check the whole module, and fail on an incompatible change

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1149,7 +1149,23 @@ jobs:
           command -v apidiff || go install golang.org/x/exp/cmd/apidiff@v0.0.0-20241217172543-b2144cdd0a67
 
       - name: Check for breaking API changes
+        env:
+          # An intentional break is declared by labelling the PR `breaking`
+          # ("Breaking change to public API"). The gate still runs and still
+          # prints everything it found — the label suppresses the failure, not
+          # the report, so the break stays visible in the log and in the
+          # label itself rather than being argued in a thread nobody reads
+          # later. Without a hatch this gate could not block at all: the SDK is
+          # pre-1.0 and removes surface on purpose (#504 withdrew
+          # GetEverythingBoosts), so a hard fail with no override would just be
+          # switched off the first time it was right.
+          BREAKING_ACKNOWLEDGED: ${{ contains(github.event.pull_request.labels.*.name, 'breaking') }}
         run: |
+          # A failed export must abort rather than leave a missing .api file
+          # for the comparison to read as "nothing changed" — the whole gate
+          # would then pass for the wrong reason.
+          set -eu
+
           # Store the checked-out commit — the PR-on-base merge, not the branch
           # head. Restoring head.sha instead left go/ dirty (and failed the
           # manifest guard) on any PR whose base had since touched go/, which a
@@ -1158,8 +1174,27 @@ jobs:
           ORIG_SHA="$(git rev-parse HEAD)"
           BASE_REF="${GITHUB_BASE_REF}"
 
-          # Export the current (PR) API
-          apidiff -w pr.api ./pkg/basecamp
+          WORK="${RUNNER_TEMP}/apidiff"
+          mkdir -p "$WORK"
+
+          # apidiff compares one package at a time, so the set of packages IS
+          # the scope of this gate. It used to be the single literal
+          # `./pkg/basecamp`, which exempted every other importable package in
+          # the module — pkg/basecamp/oauth, pkg/basecamp/otel,
+          # pkg/basecamp/prometheus, pkg/types and pkg/generated were never
+          # checked, and pkg/basecamp/eventfeed was about to enter the module
+          # the same way. Enumerating instead of listing means a package added
+          # later is covered on the day it appears rather than on the day
+          # someone remembers to widen this line.
+          export_apis() {
+            local prefix="$1" list="$2"
+            go list ./... > "$list"
+            while read -r pkg; do
+              apidiff -w "${WORK}/${prefix}.$(printf '%s' "$pkg" | tr / _).api" "$pkg"
+            done < "$list"
+          }
+
+          export_apis pr "${WORK}/pr.pkgs"
 
           # Find files added in PR that don't exist on base branch
           # These need to be removed after checkout since git checkout doesn't remove them
@@ -1175,9 +1210,13 @@ jobs:
             echo "$ADDED_FILES"
             echo "$ADDED_FILES" | xargs rm -f
           fi
+          # A PR that adds a whole package leaves its directory behind, empty.
+          # `go list ./...` fails on a directory with no buildable Go files, so
+          # the base enumeration would abort on exactly the PRs this widening
+          # exists to cover.
+          find . -type d -empty -delete
 
-          # Export the base API
-          apidiff -w base.api ./pkg/basecamp
+          export_apis base "${WORK}/base.pkgs"
 
           # Restore what was checked out, using the stored SHA
           git checkout "${ORIG_SHA}" -- .
@@ -1186,22 +1225,37 @@ jobs:
           echo "## API Compatibility Check"
           echo ""
 
-          if apidiff -incompatible base.api pr.api > breaking.txt 2>&1; then
-            if [ -s breaking.txt ]; then
-              echo "### Breaking Changes Detected"
+          breaking=0
+          while read -r pkg; do
+            slug="$(printf '%s' "$pkg" | tr / _)"
+            # A package present on base and absent from the PR is itself an
+            # incompatible change, and apidiff cannot see it: it compares two
+            # exports, and there is no second export to compare.
+            if ! grep -Fxq "$pkg" "${WORK}/pr.pkgs"; then
+              echo "### Package removed: \`${pkg}\`"
               echo ""
-              echo "The following incompatible API changes were found:"
-              echo ""
-              echo '```'
-              cat breaking.txt
-              echo '```'
-              echo ""
-              echo "If these changes are intentional, ensure they are documented in the changelog."
-              # Don't fail the build, just warn
-            else
-              echo "No breaking changes detected."
+              breaking=1
+              continue
             fi
-          else
+            if apidiff -incompatible "${WORK}/base.${slug}.api" "${WORK}/pr.${slug}.api" > "${WORK}/breaking.${slug}.txt" 2>&1 \
+              && [ -s "${WORK}/breaking.${slug}.txt" ]; then
+              echo "### Breaking changes in \`${pkg}\`"
+              echo ""
+              echo '```'
+              cat "${WORK}/breaking.${slug}.txt"
+              echo '```'
+              echo ""
+              breaking=1
+            fi
+          done < "${WORK}/base.pkgs"
+
+          # A package the PR adds is additive by construction: nothing outside
+          # the PR could have imported it, so there is nothing it can break.
+          while read -r pkg; do
+            grep -Fxq "$pkg" "${WORK}/base.pkgs" || echo "New package (additive, not compared): \`${pkg}\`"
+          done < "${WORK}/pr.pkgs"
+
+          if [ "$breaking" -eq 0 ]; then
             echo "No breaking changes detected."
           fi
 
@@ -1209,12 +1263,32 @@ jobs:
           echo ""
           echo "### All API Changes"
           echo ""
-          if apidiff base.api pr.api > changes.txt 2>&1 && [ -s changes.txt ]; then
-            echo '```'
-            cat changes.txt
-            echo '```'
-          else
+          changed=0
+          while read -r pkg; do
+            grep -Fxq "$pkg" "${WORK}/pr.pkgs" || continue
+            slug="$(printf '%s' "$pkg" | tr / _)"
+            if apidiff "${WORK}/base.${slug}.api" "${WORK}/pr.${slug}.api" > "${WORK}/changes.${slug}.txt" 2>&1 \
+              && [ -s "${WORK}/changes.${slug}.txt" ]; then
+              echo "#### \`${pkg}\`"
+              echo '```'
+              cat "${WORK}/changes.${slug}.txt"
+              echo '```'
+              changed=1
+            fi
+          done < "${WORK}/base.pkgs"
+          if [ "$changed" -eq 0 ]; then
             echo "No API changes detected."
+          fi
+
+          if [ "$breaking" -eq 1 ]; then
+            echo ""
+            if [ "$BREAKING_ACKNOWLEDGED" = "true" ]; then
+              echo "Incompatible changes are present and the PR carries the \`breaking\` label — not failing."
+              echo "Document them in the changelog."
+            else
+              echo "::error::Incompatible public API changes. If they are intentional, label this PR \`breaking\` and document them in the changelog."
+              exit 1
+            fi
           fi
 
       # Ground truth, and the authoritative check: the static parser predicts

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1162,188 +1162,158 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          # A failed export must abort rather than leave a missing .api file
-          # for the comparison to read as "nothing changed" — the whole gate
-          # would then pass for the wrong reason.
+          # An export that cannot run must abort rather than leave a missing
+          # .api file for the comparison to read as "nothing changed" — the
+          # whole gate would then pass for the wrong reason.
           set -eu
-
-          # Store the checked-out commit — the PR-on-base merge, not the branch
-          # head. Restoring head.sha instead left go/ dirty (and failed the
-          # manifest guard) on any PR whose base had since touched go/, which a
-          # dependabot batch makes routine: the first sibling to merge changes
-          # go/go.sum under every other open PR in the group.
-          ORIG_SHA="$(git rev-parse HEAD)"
-          BASE_REF="${GITHUB_BASE_REF}"
 
           WORK="${RUNNER_TEMP}/apidiff"
           mkdir -p "$WORK"
 
-          # apidiff compares one package at a time, so the set of packages IS
-          # the scope of this gate. It used to be the single literal
-          # `./pkg/basecamp`, which exempted every other importable package in
-          # the module — pkg/basecamp/oauth, pkg/basecamp/otel,
-          # pkg/basecamp/prometheus, pkg/types and pkg/generated were never
-          # checked, and pkg/basecamp/eventfeed was about to enter the module
-          # the same way. Enumerating instead of listing means a package added
-          # later is covered on the day it appears rather than on the day
-          # someone remembers to widen this line.
+          # Both sides of the comparison have to be taken from one fixed point.
+          # The PR side is whatever `actions/checkout` left here, which for a
+          # `pull_request` event is `refs/pull/N/merge`: this PR merged onto the
+          # base. The base side used to be `origin/${GITHUB_BASE_REF}`, a moving
+          # ref that `fetch-depth: 0` refreshes at job start, so the two sides
+          # could straddle a base that had advanced in between — and then a
+          # package the BASE gained is reported as one this PR REMOVED, failing
+          # a PR that changed nothing. `main` takes several commits on an
+          # ordinary day. Reading the `breaking` label live (below) widened the
+          # window further, by making "label it and re-run" a normal flow that
+          # can happen long after the merge commit was cut.
           #
-          # `internal/...` is excluded for the same reason a newly added package
-          # is reported but not compared: it has no external consumer to break,
-          # since nothing outside this module subtree can import it. Excluding
-          # it is not just tidiness. apidiff refuses to compare an internal
-          # package and says so on stderr ("Ignoring internal package ..."),
-          # exiting 0; the comparisons below fold stderr into the report file
-          # and read any non-empty report as a finding, so the first internal
-          # package to exist in both revisions would be announced as a breaking
-          # change and fail this gate. A gate that fails on something that
-          # cannot break anyone is how a `breaking` label gets applied to a
-          # non-break — or how the gate gets switched off.
-          #
-          # `all` is assigned on its own line, not filtered through a pipeline,
-          # so a failing `go list` still aborts the step under `set -e` —
-          # inside a pipeline only the last command's status would survive, and
-          # enumeration silently returning nothing is how this gate would pass
-          # while checking no packages at all. awk rather than grep because it
-          # exits 0 whether or not it matched, and its `NF` drops the empty
-          # line `printf` would otherwise produce from an empty list.
-          export_apis() {
-            local prefix="$1" list="$2" all
-            all="$(go list ./...)"
-            printf '%s\n' "$all" | awk 'NF && !/\/internal\// && !/\/internal$/' > "$list"
-            while read -r pkg; do
-              apidiff -w "${WORK}/${prefix}.$(printf '%s' "$pkg" | tr / _).api" "$pkg"
-            done < "$list"
-          }
-
-          export_apis pr "${WORK}/pr.pkgs"
-
-          # Find files added in PR that don't exist on base branch
-          # These need to be removed after checkout since git checkout doesn't remove them
-          # Strip 'go/' prefix since we're running from go/ directory
-          ADDED_FILES=$(git diff --name-only --diff-filter=A "origin/${BASE_REF}" -- . 2>/dev/null | sed 's|^go/||' || true)
-
-          # Check out the base branch to compare against
-          git checkout "origin/${BASE_REF}" -- .
-
-          # Remove files that were added in PR (they don't exist on base)
-          if [ -n "$ADDED_FILES" ]; then
-            echo "Removing files added in PR:"
-            echo "$ADDED_FILES"
-            echo "$ADDED_FILES" | xargs rm -f
+          # The merge commit's own first parent is that fixed point: it is the
+          # base commit this tree was merged onto. It cannot drift, and it needs
+          # no second ref to look up.
+          ORIG_SHA="$(git rev-parse HEAD)"
+          if ! git rev-parse --verify --quiet "${ORIG_SHA}^2" > /dev/null; then
+            echo "::error::HEAD (${ORIG_SHA}) is not a merge commit, so its first parent is not this PR's base. The baseline here is derived from the checked-out refs/pull/N/merge commit; if the checkout step above is ever changed to fetch the branch head instead, this gate would silently narrow to 'did the last commit break the API'."
+            exit 1
           fi
-          # A PR that adds a whole package leaves its directory behind, empty.
-          # `go list ./...` fails on a directory with no buildable Go files, so
-          # the base enumeration would abort on exactly the PRs this widening
-          # exists to cover.
-          find . -type d -empty -delete
+          BASE_SHA="$(git rev-parse --verify "${ORIG_SHA}^1")"
+          echo "Comparing ${ORIG_SHA} (this PR merged onto its base) against ${BASE_SHA} (that base)."
 
-          export_apis base "${WORK}/base.pkgs"
+          # The base revision is exported from its own worktree rather than by
+          # checking it out over this one. Checking out meant deleting the files
+          # the PR added, deleting the directories that left empty, and checking
+          # the original tree back out — three steps whose only job was to undo
+          # the first, each able to leave `go/` dirty and fail the manifest
+          # guard that runs after this step. A worktree under RUNNER_TEMP is
+          # outside the repository and touches neither. It is not removed
+          # afterwards: the runner is ephemeral, and a removal on the success
+          # path alone would be skipped by every path that exits early.
+          BASE_TREE="${WORK}/base"
+          git worktree add --detach "$BASE_TREE" "$BASE_SHA"
 
-          # Restore what was checked out, using the stored SHA
-          git checkout "${ORIG_SHA}" -- .
-
-          # apidiff has three outcomes, and only two of them are verdicts about
-          # the API: a clean comparison exits 0 and writes nothing, a
-          # comparison that found differences exits 0 and writes them to
-          # stdout, and a comparison that could not run at all exits non-zero
-          # with its reason on stderr. Both call sites below used to test
-          # `apidiff ... && [ -s report ]`, which folds the third outcome into
-          # the first — `set -e` does not fire for a command used as an `if`
-          # condition, so a non-zero apidiff simply short-circuited the `&&`,
-          # left `breaking` at 0, and the gate printed "No breaking changes
-          # detected" and passed. That is this gate failing open, and it is the
-          # exact failure the comment at the top of this step already rules out
-          # for the export phase: a report that cannot be produced must not be
-          # read as "nothing changed".
+          # apidiff's module mode answers the whole scope question. `-m`
+          # compares every package in the module, classifies an added package as
+          # compatible and a removed one as incompatible, and drops `internal/`
+          # before comparing. This step used to hand-roll all of that around
+          # per-package exports: a `go list ./...` enumeration, an internal
+          # filter, underscore-slugged filenames (two import paths can slug to
+          # the same name), a removed-package check the per-package comparison
+          # structurally cannot make, and two comparison loops. Three review
+          # rounds found three defects and every one of them was in that
+          # machinery — none in the policy around it. Module mode is in the
+          # pinned build, so none of it needs owning here.
           #
-          # It was also silent. The comparator's stderr went into the report
-          # file, and that file is only ever printed on the differences path,
-          # so the reason was written down and then discarded. This prints it.
+          # GOWORK=off, for two reasons. The repository root carries a `go.work`
+          # covering three modules, so a bare `go list -m` prints all three and
+          # `apidiff -m` would be handed a "module path" three lines long — it
+          # fails, but only after the workspace has been read, and the failure
+          # names all three. And the module a consumer resolves is this one
+          # alone, from its own go.mod and go.sum, not one wired to sibling
+          # directories that are never published; measuring the published shape
+          # is the whole point of the gate. Both spellings export byte-identical
+          # data today, since nothing here depends on a workspace sibling.
+          export GOWORK=off
+          MODULE_PATH="$(go list -m)"
+          BASE_MODULE_PATH="$(cd "$BASE_TREE/go" && go list -m)"
+
+          apidiff -m -w "${WORK}/pr.api" "$MODULE_PATH"
+          ( cd "$BASE_TREE/go" && apidiff -m -w "${WORK}/base.api" "$BASE_MODULE_PATH" )
+
+          # apidiff has three outcomes and only two of them are verdicts about
+          # the API: a clean comparison exits 0 and writes nothing to stdout, a
+          # comparison that found differences exits 0 and writes them to stdout,
+          # and a comparison that could not run exits non-zero with its reason
+          # on stderr. Both call sites used to be written `apidiff ... && [ -s
+          # report ]`, which folds the third outcome into the first — `set -e`
+          # does not fire for a command used as an `if` condition, so a failed
+          # comparison simply skipped the branch, left `breaking` at 0, and the
+          # gate printed "No breaking changes detected" and passed.
           #
-          # Both sites go through one helper rather than repeating the check,
-          # because the way this reappears is the two drifting apart.
+          # The two streams are kept apart rather than merged with `2>&1`.
+          # Module mode writes one benign line per internal package to stderr
+          # ("Ignoring internal package ...") on every comparison; merging that
+          # into the report would announce it as a finding, which is how the
+          # previous shape turned excluding `internal/` from a nicety into a
+          # requirement. On exit 0 stdout is the entire verdict; on non-zero
+          # stderr is the entire reason, and this prints it — a reason captured
+          # to a file nothing ever prints is how the fail-open survived review.
           run_apidiff() {
             local out="$1"; shift
             local status=0
-            apidiff "$@" > "$out" 2>&1 || status=$?
+            apidiff "$@" > "$out" 2> "${out}.err" || status=$?
             if [ "$status" -ne 0 ]; then
               echo "::error::apidiff exited ${status} comparing ${*} — the comparison could not be run. This is a tool failure, not a verdict on the API, so it is not something the \`breaking\` label should be used to wave through."
               echo '```'
-              cat "$out"
+              cat "${out}.err"
               echo '```'
               exit 1
             fi
           }
 
-          # Compare APIs and report breaking changes
           echo "## API Compatibility Check"
           echo ""
 
           breaking=0
-          while read -r pkg; do
-            slug="$(printf '%s' "$pkg" | tr / _)"
-            # A package present on base and absent from the PR is itself an
-            # incompatible change, and apidiff cannot see it: it compares two
-            # exports, and there is no second export to compare.
-            if ! grep -Fxq "$pkg" "${WORK}/pr.pkgs"; then
-              echo "### Package removed: \`${pkg}\`"
-              echo ""
-              breaking=1
-              continue
-            fi
-            run_apidiff "${WORK}/breaking.${slug}.txt" -incompatible \
-              "${WORK}/base.${slug}.api" "${WORK}/pr.${slug}.api"
-            if [ -s "${WORK}/breaking.${slug}.txt" ]; then
-              echo "### Breaking changes in \`${pkg}\`"
-              echo ""
-              echo '```'
-              cat "${WORK}/breaking.${slug}.txt"
-              echo '```'
-              echo ""
-              breaking=1
-            fi
-          done < "${WORK}/base.pkgs"
 
-          # A package the PR adds is additive by construction: nothing outside
-          # the PR could have imported it, so there is nothing it can break.
-          while read -r pkg; do
-            grep -Fxq "$pkg" "${WORK}/base.pkgs" || echo "New package (additive, not compared): \`${pkg}\`"
-          done < "${WORK}/pr.pkgs"
+          # `apidiff -m` keys packages by their path relative to the module, so
+          # a module whose path changed compares as though nothing moved and
+          # reports nothing at all. That is the one break module mode cannot
+          # see, and it is the break that invalidates every import at once.
+          if [ "$MODULE_PATH" != "$BASE_MODULE_PATH" ]; then
+            echo "### Module path changed: \`${BASE_MODULE_PATH}\` → \`${MODULE_PATH}\`"
+            echo ""
+            echo "Every existing import of the old path stops resolving."
+            echo ""
+            breaking=1
+          fi
+
+          run_apidiff "${WORK}/breaking.txt" -m -incompatible "${WORK}/base.api" "${WORK}/pr.api"
+          if [ -s "${WORK}/breaking.txt" ]; then
+            echo "### Breaking Changes Detected"
+            echo ""
+            echo "The following incompatible API changes were found:"
+            echo ""
+            echo '```'
+            cat "${WORK}/breaking.txt"
+            echo '```'
+            echo ""
+            breaking=1
+          fi
 
           if [ "$breaking" -eq 0 ]; then
             echo "No breaking changes detected."
           fi
 
-          # Also show all changes for reference
+          # Unqualified, and true: a module comparison covers the package set as
+          # well as each package's surface, so an added or removed package is a
+          # change this report has already named. The per-package shape could
+          # not say that — it walked one package list and skipped anything the
+          # other revision lacked, so "no API changes" could contradict a
+          # package removal reported four lines above it.
           echo ""
           echo "### All API Changes"
           echo ""
-          changed=0
-          while read -r pkg; do
-            grep -Fxq "$pkg" "${WORK}/pr.pkgs" || continue
-            slug="$(printf '%s' "$pkg" | tr / _)"
-            run_apidiff "${WORK}/changes.${slug}.txt" \
-              "${WORK}/base.${slug}.api" "${WORK}/pr.${slug}.api"
-            if [ -s "${WORK}/changes.${slug}.txt" ]; then
-              echo "#### \`${pkg}\`"
-              echo '```'
-              cat "${WORK}/changes.${slug}.txt"
-              echo '```'
-              changed=1
-            fi
-          done < "${WORK}/base.pkgs"
-          # Qualified to what the loop above actually measured. It walks the
-          # base package list and skips anything the PR does not also have, so
-          # a package that was only added or only removed never reaches it —
-          # yet both are already reported further up, one of them as a break.
-          # An unqualified "no API changes" would therefore contradict the
-          # report it is part of, and on a removal it would do so in the same
-          # log as the failure that removal just caused. Folding the package
-          # set into `changed` would silence the line instead, which leaves the
-          # section empty and says less than naming its scope does.
-          if [ "$changed" -eq 0 ]; then
-            echo "No API changes detected in packages present in both revisions."
+          run_apidiff "${WORK}/changes.txt" -m "${WORK}/base.api" "${WORK}/pr.api"
+          if [ -s "${WORK}/changes.txt" ]; then
+            echo '```'
+            cat "${WORK}/changes.txt"
+            echo '```'
+          else
+            echo "No API changes detected."
           fi
 
           # An intentional break is declared by labelling the PR `breaking`
@@ -1351,22 +1321,50 @@ jobs:
           # prints everything it found — the label suppresses the failure, not
           # the report, so the break stays visible in the log and in the label
           # itself rather than being argued in a thread nobody reads later.
-          # Without a hatch this gate could not block at all: the SDK is
-          # pre-1.0 and removes surface on purpose (#504 withdrew
-          # GetEverythingBoosts), so a hard fail with no override would just be
-          # switched off the first time it was right.
+          # Without a hatch this gate could not block at all: the SDK is pre-1.0
+          # and removes surface on purpose (#504 withdrew GetEverythingBoosts),
+          # so a hard fail with no override would just be switched off the first
+          # time it was right.
           #
           # The label is read from the API here rather than out of the event
-          # payload, because the payload is a snapshot of the event that
-          # started the run and this workflow's `pull_request:` trigger does
-          # not fire on `labeled`. A payload read can therefore only ever see
-          # labels that predate the run: applying `breaking` after a failure
-          # starts no new run, and re-running replays the same payload, so the
-          # very remedy printed below — label it, re-run — was the one thing
-          # that could not work. Reading it live is what makes that instruction
-          # true. Subscribing to `labeled`/`unlabeled` would close it too, but
-          # this file is the whole Test workflow, so it would re-run every
-          # check in it on every label edit on every PR.
+          # payload, because the payload is a snapshot of the event that started
+          # the run and this workflow's `pull_request:` trigger does not fire on
+          # `labeled`. A payload read can therefore only ever see labels that
+          # predate the run: applying `breaking` after a failure starts no new
+          # run, and re-running replays the same payload, so the very remedy
+          # printed below — label it, re-run — was the one thing that could not
+          # work. Reading it live is what makes that instruction true.
+          #
+          # The reverse case is left open on purpose: removing `breaking` after
+          # a green run leaves that run green, because nothing re-runs to notice.
+          # Closing it needs a trigger that fires on label events, and both
+          # shapes cost more than the hole. Adding `labeled`/`unlabeled` here
+          # re-runs all 23 jobs in this workflow on every label event on every
+          # PR — and `labeler.yml` runs `actions/labeler` with `sync-labels:
+          # true` on every push, so label events are emitted automatically
+          # whenever a push moves the changed-path set across one of its 9
+          # globs. That is amplification on the ordinary path, not an occasional
+          # extra run. Splitting this job into its own workflow file would make
+          # the extra run one job rather than 23, but it renames the required
+          # check, so it cannot land without an admin changing branch protection
+          # in the same breath — and between the two, every PR blocks on a check
+          # that no longer reports.
+          #
+          # What is left open is narrow. `breaking` is not in
+          # `.github/labeler.yml`, so `sync-labels: true` cannot remove it: only
+          # a person can, deliberately. Doing so buys them nothing they did not
+          # already have, because the label acknowledges a break rather than
+          # approving a merge — anyone who can remove it can equally leave it on
+          # and merge. And it is not free elsewhere: `.github/release.yml` files
+          # `breaking` PRs under "Breaking Changes", so removing the label drops
+          # the break from the release notes, which is the consequence this gate
+          # could not have prevented in any case. The acknowledged-pass message
+          # below says out loud that the run is only as good as the label at the
+          # moment it read it.
+          #
+          # Revisit if `breaking` ever becomes automated, or if a merge queue
+          # lands: a queue re-runs required checks against the merge result,
+          # which closes this for free.
           breaking_acknowledged() {
             # Events with no pull request (a push to main, a manual dispatch)
             # have nothing to carry a label, so say that rather than letting an
@@ -1397,7 +1395,7 @@ jobs:
             echo ""
             if breaking_acknowledged; then
               echo "Incompatible changes are present and the PR carries the \`breaking\` label — not failing."
-              echo "Document them in the changelog."
+              echo "Document them in the changelog. This run passed on the label as it stood when this step read it; removing the label later does not re-run this gate, so re-run it if the acknowledgement changes."
             else
               echo "::error::Incompatible public API changes. If they are intentional, label this PR \`breaking\` and re-run this job, and document them in the changelog."
               exit 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1121,6 +1121,10 @@ jobs:
     if: github.event_name == 'pull_request'
     permissions:
       contents: read
+      # Reads this PR's labels back from the API when the gate is failing, to
+      # see the `breaking` acknowledgement as it stands now rather than as the
+      # event payload froze it. See breaking_acknowledged() below.
+      pull-requests: read
     defaults:
       run:
         working-directory: go
@@ -1150,16 +1154,13 @@ jobs:
 
       - name: Check for breaking API changes
         env:
-          # An intentional break is declared by labelling the PR `breaking`
-          # ("Breaking change to public API"). The gate still runs and still
-          # prints everything it found — the label suppresses the failure, not
-          # the report, so the break stays visible in the log and in the
-          # label itself rather than being argued in a thread nobody reads
-          # later. Without a hatch this gate could not block at all: the SDK is
-          # pre-1.0 and removes surface on purpose (#504 withdrew
-          # GetEverythingBoosts), so a hard fail with no override would just be
-          # switched off the first time it was right.
-          BREAKING_ACKNOWLEDGED: ${{ contains(github.event.pull_request.labels.*.name, 'breaking') }}
+          # The `breaking` acknowledgement is not passed in here as a
+          # pre-computed boolean; it is read from the API at the point of use,
+          # for the reasons on breaking_acknowledged() below. These two are the
+          # ingredients for that read, and PR_NUMBER is empty on any event that
+          # has no pull request.
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           # A failed export must abort rather than leave a missing .api file
           # for the comparison to read as "nothing changed" — the whole gate
@@ -1276,17 +1277,73 @@ jobs:
               changed=1
             fi
           done < "${WORK}/base.pkgs"
+          # Qualified to what the loop above actually measured. It walks the
+          # base package list and skips anything the PR does not also have, so
+          # a package that was only added or only removed never reaches it —
+          # yet both are already reported further up, one of them as a break.
+          # An unqualified "no API changes" would therefore contradict the
+          # report it is part of, and on a removal it would do so in the same
+          # log as the failure that removal just caused. Folding the package
+          # set into `changed` would silence the line instead, which leaves the
+          # section empty and says less than naming its scope does.
           if [ "$changed" -eq 0 ]; then
-            echo "No API changes detected."
+            echo "No API changes detected in packages present in both revisions."
           fi
+
+          # An intentional break is declared by labelling the PR `breaking`
+          # ("Breaking change to public API"). The gate still runs and still
+          # prints everything it found — the label suppresses the failure, not
+          # the report, so the break stays visible in the log and in the label
+          # itself rather than being argued in a thread nobody reads later.
+          # Without a hatch this gate could not block at all: the SDK is
+          # pre-1.0 and removes surface on purpose (#504 withdrew
+          # GetEverythingBoosts), so a hard fail with no override would just be
+          # switched off the first time it was right.
+          #
+          # The label is read from the API here rather than out of the event
+          # payload, because the payload is a snapshot of the event that
+          # started the run and this workflow's `pull_request:` trigger does
+          # not fire on `labeled`. A payload read can therefore only ever see
+          # labels that predate the run: applying `breaking` after a failure
+          # starts no new run, and re-running replays the same payload, so the
+          # very remedy printed below — label it, re-run — was the one thing
+          # that could not work. Reading it live is what makes that instruction
+          # true. Subscribing to `labeled`/`unlabeled` would close it too, but
+          # this file is the whole Test workflow, so it would re-run every
+          # check in it on every label edit on every PR.
+          breaking_acknowledged() {
+            # Events with no pull request (a push to main, a manual dispatch)
+            # have nothing to carry a label, so say that rather than letting an
+            # empty label set pass for a considered "not acknowledged". The
+            # job's `if:` already keeps this step off those events; stating it
+            # here means the script does not silently depend on a condition
+            # written forty lines away and outside its own text.
+            if [ -z "${PR_NUMBER}" ]; then
+              echo "No pull request in scope, so there is no \`breaking\` label to honour."
+              return 1
+            fi
+
+            # Consulted only once the gate is already failing, which is what
+            # keeps a GitHub API outage away from every PR that has no break to
+            # acknowledge. On the ones that do, a failed read fails the step
+            # and says which half broke: staying quiet would wave real breaks
+            # through during an outage, and reporting a plain "unacknowledged"
+            # would send you off to re-apply a label that is already there.
+            if ! labels="$(gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" --jq '.labels[].name')"; then
+              echo "::error::Could not read this PR's labels, so the \`breaking\` acknowledgement could not be checked. This is a failed API read, not a verdict on the label — re-run this job."
+              exit 1
+            fi
+
+            printf '%s\n' "$labels" | grep -Fxq 'breaking'
+          }
 
           if [ "$breaking" -eq 1 ]; then
             echo ""
-            if [ "$BREAKING_ACKNOWLEDGED" = "true" ]; then
+            if breaking_acknowledged; then
               echo "Incompatible changes are present and the PR carries the \`breaking\` label — not failing."
               echo "Document them in the changelog."
             else
-              echo "::error::Incompatible public API changes. If they are intentional, label this PR \`breaking\` and document them in the changelog."
+              echo "::error::Incompatible public API changes. If they are intentional, label this PR \`breaking\` and re-run this job, and document them in the changelog."
               exit 1
             fi
           fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1187,9 +1187,30 @@ jobs:
           # the same way. Enumerating instead of listing means a package added
           # later is covered on the day it appears rather than on the day
           # someone remembers to widen this line.
+          #
+          # `internal/...` is excluded for the same reason a newly added package
+          # is reported but not compared: it has no external consumer to break,
+          # since nothing outside this module subtree can import it. Excluding
+          # it is not just tidiness. apidiff refuses to compare an internal
+          # package and says so on stderr ("Ignoring internal package ..."),
+          # exiting 0; the comparisons below fold stderr into the report file
+          # and read any non-empty report as a finding, so the first internal
+          # package to exist in both revisions would be announced as a breaking
+          # change and fail this gate. A gate that fails on something that
+          # cannot break anyone is how a `breaking` label gets applied to a
+          # non-break — or how the gate gets switched off.
+          #
+          # `all` is assigned on its own line, not filtered through a pipeline,
+          # so a failing `go list` still aborts the step under `set -e` —
+          # inside a pipeline only the last command's status would survive, and
+          # enumeration silently returning nothing is how this gate would pass
+          # while checking no packages at all. awk rather than grep because it
+          # exits 0 whether or not it matched, and its `NF` drops the empty
+          # line `printf` would otherwise produce from an empty list.
           export_apis() {
-            local prefix="$1" list="$2"
-            go list ./... > "$list"
+            local prefix="$1" list="$2" all
+            all="$(go list ./...)"
+            printf '%s\n' "$all" | awk 'NF && !/\/internal\// && !/\/internal$/' > "$list"
             while read -r pkg; do
               apidiff -w "${WORK}/${prefix}.$(printf '%s' "$pkg" | tr / _).api" "$pkg"
             done < "$list"
@@ -1222,6 +1243,39 @@ jobs:
           # Restore what was checked out, using the stored SHA
           git checkout "${ORIG_SHA}" -- .
 
+          # apidiff has three outcomes, and only two of them are verdicts about
+          # the API: a clean comparison exits 0 and writes nothing, a
+          # comparison that found differences exits 0 and writes them to
+          # stdout, and a comparison that could not run at all exits non-zero
+          # with its reason on stderr. Both call sites below used to test
+          # `apidiff ... && [ -s report ]`, which folds the third outcome into
+          # the first — `set -e` does not fire for a command used as an `if`
+          # condition, so a non-zero apidiff simply short-circuited the `&&`,
+          # left `breaking` at 0, and the gate printed "No breaking changes
+          # detected" and passed. That is this gate failing open, and it is the
+          # exact failure the comment at the top of this step already rules out
+          # for the export phase: a report that cannot be produced must not be
+          # read as "nothing changed".
+          #
+          # It was also silent. The comparator's stderr went into the report
+          # file, and that file is only ever printed on the differences path,
+          # so the reason was written down and then discarded. This prints it.
+          #
+          # Both sites go through one helper rather than repeating the check,
+          # because the way this reappears is the two drifting apart.
+          run_apidiff() {
+            local out="$1"; shift
+            local status=0
+            apidiff "$@" > "$out" 2>&1 || status=$?
+            if [ "$status" -ne 0 ]; then
+              echo "::error::apidiff exited ${status} comparing ${*} — the comparison could not be run. This is a tool failure, not a verdict on the API, so it is not something the \`breaking\` label should be used to wave through."
+              echo '```'
+              cat "$out"
+              echo '```'
+              exit 1
+            fi
+          }
+
           # Compare APIs and report breaking changes
           echo "## API Compatibility Check"
           echo ""
@@ -1238,8 +1292,9 @@ jobs:
               breaking=1
               continue
             fi
-            if apidiff -incompatible "${WORK}/base.${slug}.api" "${WORK}/pr.${slug}.api" > "${WORK}/breaking.${slug}.txt" 2>&1 \
-              && [ -s "${WORK}/breaking.${slug}.txt" ]; then
+            run_apidiff "${WORK}/breaking.${slug}.txt" -incompatible \
+              "${WORK}/base.${slug}.api" "${WORK}/pr.${slug}.api"
+            if [ -s "${WORK}/breaking.${slug}.txt" ]; then
               echo "### Breaking changes in \`${pkg}\`"
               echo ""
               echo '```'
@@ -1268,8 +1323,9 @@ jobs:
           while read -r pkg; do
             grep -Fxq "$pkg" "${WORK}/pr.pkgs" || continue
             slug="$(printf '%s' "$pkg" | tr / _)"
-            if apidiff "${WORK}/base.${slug}.api" "${WORK}/pr.${slug}.api" > "${WORK}/changes.${slug}.txt" 2>&1 \
-              && [ -s "${WORK}/changes.${slug}.txt" ]; then
+            run_apidiff "${WORK}/changes.${slug}.txt" \
+              "${WORK}/base.${slug}.api" "${WORK}/pr.${slug}.api"
+            if [ -s "${WORK}/changes.${slug}.txt" ]; then
               echo "#### \`${pkg}\`"
               echo '```'
               cat "${WORK}/changes.${slug}.txt"


### PR DESCRIPTION
Two defects in the `api-compat` job, and the second is what let the first survive. Review then found three more, and the third of those was evidence about the approach rather than another bug: the step is now `apidiff -m` over the module instead of a hand-rolled loop over its packages.

## Scope

`apidiff` compares one package at a time, so the literal `./pkg/basecamp` in this step **was** the gate's scope. Every other importable package in the module — `pkg/basecamp/oauth`, `pkg/basecamp/otel`, `pkg/basecamp/prometheus`, `pkg/types`, `pkg/generated` — has never been checked, and `pkg/basecamp/eventfeed` was about to enter the module the same way.

The gate is now the whole module: `apidiff -m -w` exports each revision, and `-m` compares them. A package added later is covered the day it appears rather than the day someone remembers to widen a literal, a package **removed** by the PR is classified incompatible, and a package **added** is classified compatible.

## Failure

The step printed "Breaking Changes Detected" and passed anyway (`# Don't fail the build, just warn`). It now exits non-zero, with the existing **`breaking`** label ("Breaking change to public API") as the sanctioned override. The label suppresses the failure, never the report — the finding still prints in full. Without a hatch the gate could not block at all: this SDK is pre-1.0 and removes surface on purpose (#504 withdrew `GetEverythingBoosts`), and a hard fail with no override gets switched off the first time it is right.

`set -eu`, so a failed export aborts instead of leaving a missing `.api` file for the comparison to read as "nothing changed".

## Verification — the widening is load-bearing

Driven against real **compiling** mutants, with the pre-change step reconstructed alongside. Recorded against `5a6d7cdc9`; the widening it measures is unchanged since, and the module-mode rewrite is re-proved separately below.

| Scenario | This PR | Today |
|---|---|---|
| Control — no change | pass | — |
| New package added | pass, reported additive | — |
| Break in `pkg/basecamp` | **FAIL** | warn, then pass |
| Break in `pkg/basecamp/oauth` | **FAIL** | **pass — "No breaking changes detected."** |
| Break in `pkg/basecamp/eventfeed` | **FAIL** | **pass** |
| Package removed | **FAIL** | invisible |
| Break + `breaking` label | pass, finding still printed | — |
| Package does not compile | **FAIL**, loudly | silent / degraded export |

The oauth and eventfeed rows are the proof the widening is load-bearing: the identical break, in identical trees, is invisible to the gate as it stands.

The "does not compile" row was found by accident — the first oauth mutant renamed a method and its call site diverged. It exited 1 for the right verdict but the wrong reason, so that run was **discarded as a vacuous kill** and redone with a compiling mutant.

## Sequencing

Lands **before** the event-feed foundations PR. Row 2 is why that is safe: a new package cannot be incompatible with a base that never had it, and the gate says so explicitly instead of staying silent.

## The comparator could fail and the gate would pass (found in review)

The section above says a failed *export* must not be read as "nothing changed". The *comparison* had precisely that hole, and it is the more dangerous one, because it is the step that renders the verdict.

`apidiff` has three outcomes and this gate distinguished two:

| outcome | exit | output |
|---|---|---|
| clean | 0 | none |
| differences found | 0 | stdout |
| **could not run** | **non-zero** | **stderr** |

Both call sites tested `apidiff ... && [ -s report ]`. `set -e` does not fire for a command used as an `if` condition, so a non-zero `apidiff` short-circuited the `&&`, the branch was skipped, `breaking` stayed `0`, and the step printed **"No breaking changes detected." and exited 0**. A merge gate failing open.

It was also silent: the comparator's stderr was redirected into a report file that is only ever printed on the *differences* path, so the reason was captured and then discarded. That is why it survived review.

### Red proof

The comparison region was extracted verbatim from the `run:` block and driven against a stubbed `apidiff`. Before the fix, **the first two rows are byte-identical reports**:

```
########## HEAD (then-current, unfixed) — apidiff stub: tool-failure ##########
## API Compatibility Check

No breaking changes detected.

### All API Changes

No API changes detected in packages present in both revisions.
REAL_EXIT=0
```

| `apidiff` stub | before | after |
|---|---|---|
| tool failure, `-incompatible` site | `No breaking changes detected.` — **exit 0** | names it a tool failure, prints the swallowed stderr — **exit 1** |
| tool failure, all-changes site | `No API changes detected…` — **exit 0** | same, **exit 1** |
| clean | pass | unchanged |
| differences found | reported | unchanged |

A tool failure is reported as a tool failure and explicitly not as something the `breaking` label should wave through — the label answers "this break is intended", not "the toolchain is broken". Both comparisons still go through one helper after the rewrite, since the way this returns is the two drifting apart.

## `internal/…` is not compared

An internal package has no external consumer to break — the same reason an added package is compatible by construction. This is not only tidiness: `apidiff` refuses to compare an internal package, says so on **stderr**, and exits 0. When the comparisons folded stderr into the report and read any non-empty report as a finding, the first internal package to exist in both revisions would have been announced as a breaking change and **failed the gate**:

```
>>> FALSE BREAKING reported for example.com/intmod/internal/secret:
    Ignoring internal package example.com/intmod/internal/secret
```

Latent today (7 packages, none internal), and a false failure on something that cannot break anyone is how a `breaking` label ends up on a non-break — or how the gate ends up switched off.

The exclusion is now `apidiff -m`'s own (`filterInternal`), and the report no longer merges stderr into stdout, so that message cannot reach the report at all. Separating the streams is what demotes the internal exclusion from a load-bearing requirement back to a nicety.

## Module mode replaces the hand-rolled loop (found in review)

Three review rounds, three defects, all of them in the per-package machinery this step wrapped around `apidiff` and none in the policy around it. A fourth was sitting there unfound: two import paths whose underscore slugs collide — `pkg/event/feed` and `pkg/event_feed` both slug to `pkg_event_feed` — overwrite each other's export file, and a real incompatible change in one of them is **silently missed**.

### Red proof

Against `1a179e76f`, with the PR breaking `Subscribe` in `pkg/event/feed`:

```
########## RED: HEAD — slug collision (pkg/event/feed vs pkg/event_feed) ##########
## API Compatibility Check

No breaking changes detected.

### All API Changes

No API changes detected in packages present in both revisions.
REAL_EXIT=0
```

After:

```
### Breaking Changes Detected
- ./pkg/event/feed.Subscribe: changed from func(string) to func(string, int)
REAL_EXIT=1
```

None of that machinery had to be owned here. The pinned `apidiff` build has module mode, priced against a two-revision scratch module across every case:

| Case | `-m` module mode | hand-rolled loop |
|---|---|---|
| Clean change | exit 0, empty stdout | exit 0 |
| Incompatible change | exit 0, finding on stdout | exit 0, same finding |
| Added package | `- package …: added`, compatible | reported "additive, not compared" |
| Removed package | `- package …: removed`, incompatible | hand-written package-set check |
| `internal/` in both, changed incompatibly | not compared, not reported | not compared (needed an `awk` filter) |
| Tool failure | **exit 1**, reason on **stderr** | exit 1, reason on merged stream |
| Slug collision | correct | **fail-open** |

Gone with it: the `go list ./...` enumeration, the `internal/` filter, the slugged filenames, the empty-directory prune, the package-set removal check, the added-package report, and both comparison loops. Kept, because it is policy rather than mechanism: the comparator-failure handling and the live label read.

Two things `-m` does not do, both handled. It writes `Ignoring internal package …` to stderr on every comparison, so the streams are kept apart. And it keys packages by their path **relative to the module**, so a module whose path changed compares as though nothing moved and reports nothing at all; that break is checked explicitly against `go list -m` on each side.

`GOWORK=off` for both exports: the repository root carries a `go.work` over three modules, so a bare `go list -m` prints all three and `apidiff -m` is handed a three-line "module path". It also measures the module as a consumer resolves it — its own `go.mod` and `go.sum` — and the two spellings export byte-identical data today.

## The two exports no longer straddle a moving base (found in review)

The PR side is the checked-out `refs/pull/N/merge` commit. The base side was `origin/${GITHUB_BASE_REF}`, a moving ref that `fetch-depth: 0` refreshes at job start, so the two could straddle a base that had advanced in between — and then a package the **base gained** reads as one **this PR removed**. Reading the `breaking` label live widened the window further, by making "label it and re-run" a normal flow that can happen long after the merge commit was cut.

### Red proof

Against `1a179e76f`, with a PR that changes **nothing** and a base that gains a package after the merge commit is cut:

```
########## RED: HEAD (1a179e76f) — case drift, PR changes NOTHING, base gained a package ##########
## API Compatibility Check

### Package removed: `example.com/mod/pkg/lateaddition`

::error::Incompatible public API changes. If they are intentional, label this PR `breaking` and re-run this job…
REAL_EXIT=1
```

After:

```
Comparing 11128b01e (this PR merged onto its base) against 12c6da22e (that base).
## API Compatibility Check

No breaking changes detected.
REAL_EXIT=0
```

The base is now the merge commit's own first parent, so both sides come from one fixed point. Verified against this PR's real merge ref rather than assumed:

```
$ git rev-list --parents -n 1 refs/pull/776/merge
ff245408e 0ef7fe38e 1a179e76f
             ^ base   ^ this PR's head
```

A guard fails the step if HEAD is not a merge commit, so changing the checkout to fetch the branch head cannot silently narrow the gate to "did the last commit break the API".

The base revision is exported from `git worktree add` under `RUNNER_TEMP`, which retires the checkout dance with it: no checking the base over this tree, no removing the files the PR added, no removing the directories that left empty, no restoring — and no path by which this step leaves `go/` dirty under the manifest guard that runs immediately after it.

## The label residual, accepted deliberately

Removing `breaking` after a green run leaves that run green. Closing it needs a label-event trigger: `labeled`/`unlabeled` on this workflow re-runs all 23 `Test` jobs on every label event on every PR (and `labeler.yml` emits label events automatically on every push that moves the changed-path set), while splitting this gate into its own workflow file makes that one job but **renames the required check**, which needs a branch-protection change by an admin.

Accepted, because the residual is narrow: `breaking` is not in `.github/labeler.yml`, so no automation can remove it; and removing it by hand buys nothing, since the label acknowledges a break rather than approving a merge — anyone who can remove it can equally leave it on and merge. It is not free either: `.github/release.yml` files `breaking` PRs under "⚠️ Breaking Changes". The acknowledged-pass message now says the run is only as good as the label at the moment it read it, and the step records the trip-wire — revisit if `breaking` becomes automated, or if a merge queue lands.

## Case matrix

Stub-driven against the extracted `run:` block on a real two-revision git repo with a real merge-shaped commit, because the label paths never execute in this PR's own CI (`breaking=0`).

| Case | exit |
|---|---|
| clean | 0 |
| incompatible, unlabelled | 1 |
| incompatible, labelled | 0 |
| added package | 0 |
| removed package | 1 |
| `internal/` changed incompatibly | 0 |
| slug collision | 1 |
| tool failure at comparison | 1 |
| tool failure at export | 1 |
| label API read fails, with a break | 1 |
| no PR number, with a break | 1 |
| HEAD not a merge commit | 1 |
| base drifted, PR changed nothing | 0 |

End-to-end against the real module at this PR's merge ref: clean, `REAL_EXIT=0`, worktree left clean. Two mutations, restored by `cp` + `diff -q`:

- `(*AccountService).GetAccount` gains a parameter → `- ./pkg/basecamp.(*AccountService).GetAccount: changed from func(context.Context) (*Account, error) to func(context.Context, int) (*Account, error)`, `REAL_EXIT=1`
- `FlexInt.MarshalJSON` gains a parameter → `- ./pkg/types.FlexInt.MarshalJSON: changed from func() ([]byte, error) to func(int) ([]byte, error)`, `REAL_EXIT=1`

The second is the point of the PR: `pkg/types` is outside the gate entirely on `main`.

`actionlint`, `zizmor` and `shellcheck` on the extracted step, all under `LC_ALL=C`: `REAL_EXIT=0` each.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expands the API compatibility gate to the entire Go module and hard-fails on incompatible changes unless the PR is labeled `breaking`. Previously it checked only `./pkg/basecamp`, warned, and passed.

- Compares module-to-module with `apidiff -m`; added packages are additive, removed packages are breaking; `internal/...` is ignored by `apidiff`.
- Detects a module path change and treats it as breaking (not visible to `apidiff -m`).
- Pins the baseline to the merge commit’s first parent and exports it from a detached worktree; sets `GOWORK=off` to avoid workspace contamination.
- Treats `apidiff` tool failures as errors and prints stderr; keeps stdout/stderr separate to prevent false positives.
- Produces a single “All API Changes” report at module scope (includes package adds/removes).
- Reads the `breaking` label live via the GitHub API; requires `pull-requests: read`. If the label read fails, the job fails and asks to re-run.
- Required action: For intentional public API breaks, label the PR `breaking` and document the change in the changelog.

<sup>Written for commit 3c6b8f15d750345bede6957cbfd386e76ba62c02. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-sdk/pull/776?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->


