### PR TITLE
Tell a body that never arrived apart from one that will not decode

### DIFF
--- a/go/pkg/basecamp/documents.go
+++ b/go/pkg/basecamp/documents.go
@@ -2,7 +2,10 @@ package basecamp
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"io"
+	"net"
 	"strings"
 	"time"
 
@@ -127,6 +130,60 @@ func (f *DocumentFields) fullBody() (generated.ReplaceDocumentJSONRequestBody, e
 	}, nil
 }
 
+// transportFailure reports whether err is the response body failing to ARRIVE
+// rather than failing to DECODE. It is the gate both decode-error renderers —
+// documentDecodeError below and scheduleEntryDecodeError in schedules.go — run
+// before they classify anything.
+//
+// It has to exist because Go streams the response body: io.ReadAll(rsp.Body) is
+// the FIRST statement of every generated Parse* function and its error is
+// returned verbatim, so a truncated body, a reset connection or an expired
+// deadline reaches those renderers by exactly the same path a JSON syntax error
+// does. Before #773 both were stamped CodeAPI, statusless, Retryable: false — a
+// caller reading Retryable treated a transient failure as permanent, and a
+// caller reaching for a JSON error through errors.As found a transport error.
+//
+// This is a DENY-LIST of the transport, and it must never be inverted into an
+// ALLOW-LIST of the decoder. The asymmetry is the whole reason:
+//
+//   - The transport's error set is CLOSED. It is the standard library's, and
+//     nothing this SDK models can extend it: io.ErrUnexpectedEOF for a body
+//     that stopped early, net.Error for resets, DNS, TLS and timeouts, and the
+//     two context sentinels.
+//   - The decoder's error set is OPEN, and grows with the model graph. The
+//     renderers' own doc comments name two members no encoding/json allow-list
+//     can reach: created_at/updated_at are time.Time, whose UnmarshalJSON
+//     returns *time.ParseError, and content_attachments /
+//     description_attachments carry *types.FlexInt dimensions rejected with a
+//     plain fmt.Errorf that has no named type at all.
+//
+// So the two mistakes are not the same size. A deny-list that misses a
+// transport case degrades to the pre-#773 behaviour for that ONE case. An
+// allow-list that misses a decoder case degrades for EVERY field type nobody
+// enumerated — silently, the day that type is added, and for the two that exist
+// today. Do not "simplify" this into errors.AsType[*json.SyntaxError] /
+// [*json.UnmarshalTypeError]: that is the shape #773 was originally filed with,
+// and it is the wrong one.
+//
+// The two sets are disjoint, which is what makes a deny-list safe to run first.
+// The one sentinel that could plausibly appear on both sides is
+// io.ErrUnexpectedEOF, and it cannot: the generated parse decodes with
+// json.Unmarshal over an already-read []byte, never a streaming json.Decoder, so
+// JSON that stops early is *json.SyntaxError ("unexpected end of JSON input")
+// and only the read itself yields io.ErrUnexpectedEOF. Both halves of that are
+// pinned by the "malformed body" case in the tests.
+func transportFailure(err error) bool {
+	switch {
+	case errors.Is(err, io.ErrUnexpectedEOF),
+		errors.Is(err, context.DeadlineExceeded),
+		errors.Is(err, context.Canceled):
+		return true
+	default:
+		_, isNetError := errors.AsType[net.Error](err)
+		return isNetError
+	}
+}
+
 // documentDecodeError renders a response-decoder failure in the SPEC §6 shape.
 //
 // Go's json.Unmarshal is the typed guard the dynamic SDKs write by hand, and it
@@ -134,16 +191,22 @@ func (f *DocumentFields) fullBody() (generated.ReplaceDocumentJSONRequestBody, e
 // that as a raw decoder error, which callers switching on *Error would miss and
 // which carries no hint. (The Swift composite does the same with DecodingError.)
 //
-// There is no classification here, deliberately. Deciding whether an error came
-// from the decoder by INSPECTING it does not work in either direction: decoder
-// errors are not enumerable (created_at/updated_at are time.Time, whose
-// UnmarshalJSON returns *time.ParseError rather than an encoding/json sentinel,
-// and content_attachments carries *types.FlexInt dimensions rejected with a
-// plain fmt.Errorf that is no named type at all), and neither are the errors
-// that precede a response — a gating hook, a token provider or a custom
+// The decoder half is not classified by INSPECTING the error, deliberately.
+// That inspection does not work in either direction: decoder errors are not
+// enumerable (created_at/updated_at are time.Time, whose UnmarshalJSON returns
+// *time.ParseError rather than an encoding/json sentinel, and
+// content_attachments carries *types.FlexInt dimensions rejected with a plain
+// fmt.Errorf that is no named type at all), and neither are the errors that
+// precede a response — a gating hook, a token provider or a custom
 // AuthStrategy may each return any sentinel they like. So DocumentsService.Get
 // splits the request from the decode and calls this on the decode step only,
 // where the origin is known by construction rather than guessed.
+//
+// Exactly one inspection survives that argument, because the split is not as
+// clean as it reads: io.ReadAll runs INSIDE the generated parse, so the decode
+// step's errors are not all decode errors (#773). transportFailure above names
+// the closed set that is not, and those pass through verbatim; everything else
+// gets the §6 shape below.
 //
 // The decoder's error is kept as Cause, not just interpolated into Message
 // (#750). Every SDK renders it into the message; only the ones that keep it let
@@ -152,6 +215,11 @@ func (f *DocumentFields) fullBody() (generated.ReplaceDocumentJSONRequestBody, e
 // at all reaches *json.UnmarshalTypeError or *json.SyntaxError through Unwrap
 // instead of pattern-matching a sentence.
 func documentDecodeError(err error) error {
+	// A body that never finished arriving is not a malformed body. Deny-list,
+	// never allow-list — transportFailure explains why.
+	if transportFailure(err) {
+		return err
+	}
 	return &Error{
 		Code:    CodeAPI,
 		Message: truncate(fmt.Sprintf("GetDocument returned a body that does not decode as a document: %v", err)),

--- a/go/pkg/basecamp/documents.go
+++ b/go/pkg/basecamp/documents.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"net"
 	"strings"
 	"time"
 
@@ -130,58 +129,56 @@ func (f *DocumentFields) fullBody() (generated.ReplaceDocumentJSONRequestBody, e
 	}, nil
 }
 
-// transportFailure reports whether err is the response body failing to ARRIVE
-// rather than failing to DECODE. It is the gate both decode-error renderers —
-// documentDecodeError below and scheduleEntryDecodeError in schedules.go — run
-// before they classify anything.
+// bodyReadError marks an error as the response body failing to ARRIVE rather
+// than failing to DECODE.
 //
-// It has to exist because Go streams the response body: io.ReadAll(rsp.Body) is
-// the FIRST statement of every generated Parse* function and its error is
-// returned verbatim, so a truncated body, a reset connection or an expired
-// deadline reaches those renderers by exactly the same path a JSON syntax error
-// does. Before #773 both were stamped CodeAPI, statusless, Retryable: false — a
-// caller reading Retryable treated a transient failure as permanent, and a
-// caller reaching for a JSON error through errors.As found a transport error.
+// The two are indistinguishable at the two call sites that parse a response by
+// hand, because io.ReadAll(rsp.Body) is the FIRST statement of every generated
+// Parse* function and its error comes back verbatim. So a truncated body, a
+// reset connection or a bad chunk header reached documentDecodeError and
+// scheduleEntryDecodeError by exactly the same path a JSON fault does, and got
+// the same statusless CodeAPI with Retryable: false — a transient failure made
+// to look permanent (#773).
 //
-// This is a DENY-LIST of the transport, and it must never be inverted into an
-// ALLOW-LIST of the decoder. The asymmetry is the whole reason:
+// Inferring the origin from the error afterwards was tried and abandoned: there
+// is no error set to match on. net/http reports bad chunk framing as a bare
+// errors.New("invalid byte in chunk length"), the transport's automatic gunzip
+// returns gzip.ErrHeader, and WithTransport lets a caller supply a body whose
+// Read returns anything at all — none of them a net.Error, none of them a named
+// type. Marking the read is what the call sites' doc comments already claim
+// happens ("the origin is known by construction rather than guessed"), so the
+// marker makes that true instead of approximating it.
+type bodyReadError struct{ err error }
+
+func (e *bodyReadError) Error() string { return e.err.Error() }
+func (e *bodyReadError) Unwrap() error { return e.err }
+
+// markedBody tags every read failure of the body it wraps.
+type markedBody struct{ inner io.ReadCloser }
+
+// Read forwards to the wrapped body and marks anything it fails with.
 //
-//   - The transport's error set is CLOSED. It is the standard library's, and
-//     nothing this SDK models can extend it: io.ErrUnexpectedEOF for a body
-//     that stopped early, net.Error for resets, DNS, TLS and timeouts, and the
-//     two context sentinels.
-//   - The decoder's error set is OPEN, and grows with the model graph. The
-//     renderers' own doc comments name two members no encoding/json allow-list
-//     can reach: created_at/updated_at are time.Time, whose UnmarshalJSON
-//     returns *time.ParseError, and content_attachments /
-//     description_attachments carry *types.FlexInt dimensions rejected with a
-//     plain fmt.Errorf that has no named type at all.
-//
-// So the two mistakes are not the same size. A deny-list that misses a
-// transport case degrades to the pre-#773 behaviour for that ONE case. An
-// allow-list that misses a decoder case degrades for EVERY field type nobody
-// enumerated — silently, the day that type is added, and for the two that exist
-// today. Do not "simplify" this into errors.AsType[*json.SyntaxError] /
-// [*json.UnmarshalTypeError]: that is the shape #773 was originally filed with,
-// and it is the wrong one.
-//
-// The two sets are disjoint, which is what makes a deny-list safe to run first.
-// The one sentinel that could plausibly appear on both sides is
-// io.ErrUnexpectedEOF, and it cannot: the generated parse decodes with
-// json.Unmarshal over an already-read []byte, never a streaming json.Decoder, so
-// JSON that stops early is *json.SyntaxError ("unexpected end of JSON input")
-// and only the read itself yields io.ErrUnexpectedEOF. Both halves of that are
-// pinned by the "malformed body" case in the tests.
-func transportFailure(err error) bool {
-	switch {
-	case errors.Is(err, io.ErrUnexpectedEOF),
-		errors.Is(err, context.DeadlineExceeded),
-		errors.Is(err, context.Canceled):
-		return true
-	default:
-		_, isNetError := errors.AsType[net.Error](err)
-		return isNetError
+// io.EOF alone passes through untouched, and the comparison is deliberately
+// against that exact value rather than errors.Is: io.ReadAll ends its loop on
+// `err == io.EOF` and treats every other value as a failure, so matching its
+// test exactly is what guarantees the marker covers precisely the errors
+// io.ReadAll will hand back — including a wrapped EOF, which io.ReadAll would
+// surface as an error too.
+func (b *markedBody) Read(p []byte) (int, error) {
+	n, err := b.inner.Read(p)
+	if err != nil && err != io.EOF { //nolint:errorlint // matching io.ReadAll's own exact test, deliberately
+		err = &bodyReadError{err: err}
 	}
+	return n, err
+}
+
+func (b *markedBody) Close() error { return b.inner.Close() }
+
+// markBodyReadFailures wraps a response body so the two decode-error renderers
+// can tell a failed read from a failed decode by construction. Call it on
+// httpResp.Body before handing the response to a generated Parse* function.
+func markBodyReadFailures(body io.ReadCloser) io.ReadCloser {
+	return &markedBody{inner: body}
 }
 
 // documentDecodeError renders a response-decoder failure in the SPEC §6 shape.
@@ -202,11 +199,10 @@ func transportFailure(err error) bool {
 // splits the request from the decode and calls this on the decode step only,
 // where the origin is known by construction rather than guessed.
 //
-// Exactly one inspection survives that argument, because the split is not as
-// clean as it reads: io.ReadAll runs INSIDE the generated parse, so the decode
-// step's errors are not all decode errors (#773). transportFailure above names
-// the closed set that is not, and those pass through verbatim; everything else
-// gets the §6 shape below.
+// The split needs one piece of help, because it is not as clean as it reads:
+// io.ReadAll runs INSIDE the generated parse, so the decode step's errors are
+// not all decode errors (#773). markBodyReadFailures above tags the ones that
+// are not, at the read, and those pass through verbatim.
 //
 // The decoder's error is kept as Cause, not just interpolated into Message
 // (#750). Every SDK renders it into the message; only the ones that keep it let
@@ -215,10 +211,10 @@ func transportFailure(err error) bool {
 // at all reaches *json.UnmarshalTypeError or *json.SyntaxError through Unwrap
 // instead of pattern-matching a sentence.
 func documentDecodeError(err error) error {
-	// A body that never finished arriving is not a malformed body. Deny-list,
-	// never allow-list — transportFailure explains why.
-	if transportFailure(err) {
-		return err
+	// A body that never finished arriving is not a malformed body. Unwrap the
+	// marker so the caller sees the transport's own error, not our plumbing.
+	if marked, ok := errors.AsType[*bodyReadError](err); ok {
+		return marked.err
 	}
 	return &Error{
 		Code:    CodeAPI,

--- a/go/pkg/basecamp/documents_test.go
+++ b/go/pkg/basecamp/documents_test.go
@@ -5,9 +5,12 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
+	"time"
 )
 
 // The documents write surface: the merge-safe Update, the read-modify-write
@@ -734,6 +737,156 @@ func TestDocumentsService_UpdateKeepsTheDecoderErrorReachable(t *testing.T) {
 	var apiErr *Error
 	if !errors.As(err, &apiErr) || apiErr.Code != CodeAPI {
 		t.Fatalf("expected a statusless api_error over the decoder error, got %T: %v", err, err)
+	}
+}
+
+// truncatedBodyServer answers every request with a 200 whose Content-Length
+// promises 4096 bytes and then writes a few dozen before hanging up. It also
+// counts the PUTs it saw, so a caller can prove no write-back followed.
+//
+// That is the wire shape of a connection dropped mid-body, and net/http reports
+// it to io.ReadAll as io.ErrUnexpectedEOF (transfer.go turns an early EOF on a
+// Content-Length body into exactly that). Hijacking is the only way to stage it:
+// a normal handler's ResponseWriter derives Content-Length from what was
+// actually written, so it cannot be made to contradict itself.
+//
+// Shared with schedules_test.go — the two composites read through the same two
+// generated Parse* functions, and #773 is a property of both.
+func truncatedBodyServer(t *testing.T) (*httptest.Server, *atomic.Int64) {
+	t.Helper()
+	puts := &atomic.Int64{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodPut {
+			puts.Add(1)
+		}
+		hj, ok := w.(http.Hijacker)
+		if !ok {
+			t.Error("the test server does not support hijacking, so a mid-body truncation cannot be staged")
+			return
+		}
+		conn, buf, err := hj.Hijack()
+		if err != nil {
+			t.Errorf("hijack failed: %v", err)
+			return
+		}
+		defer conn.Close()
+		_, _ = buf.WriteString("HTTP/1.1 200 OK\r\n" +
+			"Content-Type: application/json\r\n" +
+			"Content-Length: 4096\r\n" +
+			"\r\n" +
+			`{"id":1069479300,"title":"Q3 P`)
+		_ = buf.Flush()
+	}))
+	t.Cleanup(srv.Close)
+	return srv, puts
+}
+
+// #773: the document read's decode step sees three different failures and only
+// two of them are the decoder's, because io.ReadAll runs INSIDE
+// ParseGetDocumentResponse. All three arrive at documentDecodeError by the same
+// path, so the gate is what tells them apart — and the three cases here are one
+// test rather than three so that a later "simplification" has to look at all of
+// them at once.
+//
+// The third case is the load-bearing one. The obvious fix for #773 — allow-list
+// *json.SyntaxError and *json.UnmarshalTypeError, return everything else
+// verbatim — passes the first two and silently breaks the third, because
+// created_at is a time.Time and time.Time.UnmarshalJSON returns *time.ParseError,
+// which is not an encoding/json type at all.
+func TestDocumentsService_GetSeparatesTransportFailuresFromDecodeFailures(t *testing.T) {
+	// 1. The body never finished arriving. There is nothing malformed about it —
+	// re-requesting is exactly the right move — so the read error has to survive
+	// as itself rather than becoming a statusless, permanently non-retryable
+	// api_error.
+	t.Run("a body that stops mid-read stays the transport's error", func(t *testing.T) {
+		srv, puts := truncatedBodyServer(t)
+		cfg := DefaultConfig()
+		cfg.BaseURL = srv.URL
+		client := NewClient(cfg, &StaticTokenProvider{Token: "test-token"})
+
+		_, err := client.ForAccount("99999").Documents().Update(context.Background(), 1069479300,
+			&UpdateDocumentRequest{Title: "Q3 Plan"})
+		if err == nil {
+			t.Fatal("expected the call to fail, but it succeeded")
+		}
+		if !errors.Is(err, io.ErrUnexpectedEOF) {
+			t.Fatalf("expected the read failure to reach the caller as itself, got %T: %v", err, err)
+		}
+		if apiErr, ok := errors.AsType[*Error](err); ok {
+			t.Fatalf("expected the transport error verbatim, got a %q *Error (retryable=%v): %v",
+				apiErr.Code, apiErr.Retryable, err)
+		}
+		if n := puts.Load(); n != 0 {
+			t.Fatalf("expected no write-back after a failed read, got %d PUT(s)", n)
+		}
+	})
+
+	// 2. The body arrived whole and is not JSON. Re-requesting cannot repair it,
+	// and the merge-safe composites would write it back, so this keeps the
+	// statusless api_error — with the decoder's own error still reachable.
+	t.Run("a malformed body is the statusless api_error", func(t *testing.T) {
+		fixture := loadDocumentsFixture(t, "get.json")
+		svc, reqs := testDocumentsCaptureServer(t, []byte(`{"id":1069479300,`), fixture, nil)
+
+		_, err := svc.Update(context.Background(), 1069479300, &UpdateDocumentRequest{Title: "Q3 Plan"})
+		if err == nil {
+			t.Fatal("expected the call to fail, but it succeeded")
+		}
+		assertStatuslessDocumentAPIError(t, err)
+		if _, ok := errors.AsType[*json.SyntaxError](err); !ok {
+			t.Errorf("expected the JSON error to be reachable through Cause, got %v", err)
+		}
+		if errors.Is(err, io.ErrUnexpectedEOF) {
+			t.Error("a body that arrived whole must not be reported as a truncated read")
+		}
+		for _, r := range *reqs {
+			if r.method == "PUT" {
+				t.Fatalf("expected no PUT after a decode failure, got %+v", r)
+			}
+		}
+	})
+
+	// 3. Neither: valid JSON, decoded by a type encoding/json does not own. An
+	// allow-list of encoding/json sentinels drops the §6 classification here, so
+	// this case is the one that decides the shape of the gate.
+	t.Run("a decoder error that is neither is still the statusless api_error", func(t *testing.T) {
+		fixture := loadDocumentsFixture(t, "get.json")
+		getBody := patchDocumentFixture(t, fixture, map[string]any{"created_at": "not-a-date"})
+		svc, _ := testDocumentsCaptureServer(t, getBody, fixture, nil)
+
+		_, err := svc.Update(context.Background(), 1069479300, &UpdateDocumentRequest{Title: "Q3 Plan"})
+		if err == nil {
+			t.Fatal("expected the call to fail, but it succeeded")
+		}
+		// Pin the premise as well as the conclusion: if created_at ever stops
+		// being a time.Time this case silently stops testing what it claims to.
+		if _, ok := errors.AsType[*time.ParseError](err); !ok {
+			t.Fatalf("expected a *time.ParseError from created_at, got %T: %v", err, err)
+		}
+		assertStatuslessDocumentAPIError(t, err)
+	})
+}
+
+// assertStatuslessDocumentAPIError pins the SPEC §6 shape the merge-safe
+// composites depend on: an api_error with no HTTP status, not retryable, and
+// carrying the escape-hatch hint.
+func assertStatuslessDocumentAPIError(t *testing.T, err error) {
+	t.Helper()
+	apiErr, ok := errors.AsType[*Error](err)
+	if !ok {
+		t.Fatalf("expected *Error, got %T: %v", err, err)
+	}
+	if apiErr.Code != CodeAPI {
+		t.Errorf("expected code %q, got %q", CodeAPI, apiErr.Code)
+	}
+	if apiErr.HTTPStatus != 0 {
+		t.Errorf("expected a statusless error, got HTTP %d", apiErr.HTTPStatus)
+	}
+	if apiErr.Retryable {
+		t.Error("re-requesting cannot repair a malformed body")
+	}
+	if apiErr.Hint == "" {
+		t.Error("expected a hint naming the deliberate-overwrite escape hatch")
 	}
 }
 

--- a/go/pkg/basecamp/documents_test.go
+++ b/go/pkg/basecamp/documents_test.go
@@ -826,14 +826,19 @@ func assertUnclassifiedReadFailure(t *testing.T, err error, puts *atomic.Int64) 
 	}
 }
 
-// #773: the document read's decode step sees three different failures and only
+// #773: the document read's decode step sees four different failures, and only
 // two of them are the decoder's, because io.ReadAll runs INSIDE
-// ParseGetDocumentResponse. All three arrive at documentDecodeError by the same
-// path, so the gate is what tells them apart — and the three cases here are one
-// test rather than four so that a later "simplification" has to look at all of
-// them at once.
+// ParseGetDocumentResponse. Two are the body failing to ARRIVE (cases 1 and 4)
+// and two are the body failing to DECODE (cases 2 and 3). All four reach
+// documentDecodeError by the same path, so what tells them apart is the marker
+// markBodyReadFailures puts on the read itself — not anything about the errors.
+// They are one test rather than four so a later "simplification" has to face
+// all of them at once.
 //
-// Cases 3 and 4 are the load-bearing pair, and they fail in opposite directions:
+// Cases 3 and 4 are the load-bearing pair, and they fail in opposite
+// directions. That pairing is the point: either one alone rules out a single
+// bad gate, but together they rule out inferring the origin from the error's
+// type AT ALL, in either direction.
 //
 //   - An ALLOW-LIST of the decoder (*json.SyntaxError, *json.UnmarshalTypeError,
 //     everything else verbatim) breaks case 3, because created_at is a time.Time

--- a/go/pkg/basecamp/documents_test.go
+++ b/go/pkg/basecamp/documents_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"sync/atomic"
@@ -740,19 +741,40 @@ func TestDocumentsService_UpdateKeepsTheDecoderErrorReachable(t *testing.T) {
 	}
 }
 
-// truncatedBodyServer answers every request with a 200 whose Content-Length
-// promises 4096 bytes and then writes a few dozen before hanging up. It also
-// counts the PUTs it saw, so a caller can prove no write-back followed.
+// A 200 whose Content-Length promises 4096 bytes and then stops after thirty:
+// the wire shape of a connection dropped mid-body. net/http's transfer.go turns
+// an early EOF on a Content-Length body into io.ErrUnexpectedEOF.
+const truncatedResponse = "HTTP/1.1 200 OK\r\n" +
+	"Content-Type: application/json\r\n" +
+	"Content-Length: 4096\r\n" +
+	"\r\n" +
+	`{"id":1069479300,"title":"Q3 P`
+
+// A 200 whose chunked framing is corrupt. net/http reports that as a bare
+// errors.New("invalid byte in chunk length") — no named type, not a net.Error,
+// not io.ErrUnexpectedEOF, and so invisible to any deny-list of transport error
+// TYPES. It shares that property with the transport's automatic gunzip
+// (gzip.ErrHeader) and with anything a WithTransport-supplied body chooses to
+// return, which is why the origin is marked at the read rather than inferred
+// from the error afterwards.
+const chunkedGarbageResponse = "HTTP/1.1 200 OK\r\n" +
+	"Content-Type: application/json\r\n" +
+	"Transfer-Encoding: chunked\r\n" +
+	"\r\n" +
+	"zz\r\n"
+
+// brokenBodyServer answers every request by hijacking the connection, writing
+// raw verbatim, and hanging up. It also counts the PUTs it saw, so a caller can
+// prove no write-back followed a failed read.
 //
-// That is the wire shape of a connection dropped mid-body, and net/http reports
-// it to io.ReadAll as io.ErrUnexpectedEOF (transfer.go turns an early EOF on a
-// Content-Length body into exactly that). Hijacking is the only way to stage it:
-// a normal handler's ResponseWriter derives Content-Length from what was
-// actually written, so it cannot be made to contradict itself.
+// Hijacking is the only way to stage a body that fails mid-read: a normal
+// handler's ResponseWriter derives Content-Length from what was actually
+// written and re-frames chunked output itself, so it cannot be made to
+// contradict itself.
 //
 // Shared with schedules_test.go — the two composites read through the same two
 // generated Parse* functions, and #773 is a property of both.
-func truncatedBodyServer(t *testing.T) (*httptest.Server, *atomic.Int64) {
+func brokenBodyServer(t *testing.T, raw string) (*httptest.Server, *atomic.Int64) {
 	t.Helper()
 	puts := &atomic.Int64{}
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -761,7 +783,7 @@ func truncatedBodyServer(t *testing.T) (*httptest.Server, *atomic.Int64) {
 		}
 		hj, ok := w.(http.Hijacker)
 		if !ok {
-			t.Error("the test server does not support hijacking, so a mid-body truncation cannot be staged")
+			t.Error("the test server does not support hijacking, so a mid-body failure cannot be staged")
 			return
 		}
 		conn, buf, err := hj.Hijack()
@@ -770,54 +792,73 @@ func truncatedBodyServer(t *testing.T) (*httptest.Server, *atomic.Int64) {
 			return
 		}
 		defer conn.Close()
-		_, _ = buf.WriteString("HTTP/1.1 200 OK\r\n" +
-			"Content-Type: application/json\r\n" +
-			"Content-Length: 4096\r\n" +
-			"\r\n" +
-			`{"id":1069479300,"title":"Q3 P`)
+		_, _ = buf.WriteString(raw)
 		_ = buf.Flush()
 	}))
 	t.Cleanup(srv.Close)
 	return srv, puts
 }
 
+// brokenBodyClient points a client at a brokenBodyServer serving raw.
+func brokenBodyClient(t *testing.T, raw string) (*AccountClient, *atomic.Int64) {
+	t.Helper()
+	srv, puts := brokenBodyServer(t, raw)
+	cfg := DefaultConfig()
+	cfg.BaseURL = srv.URL
+	return NewClient(cfg, &StaticTokenProvider{Token: "test-token"}).ForAccount("99999"), puts
+}
+
+// assertUnclassifiedReadFailure pins what a failed body read owes the caller: it
+// reaches them as itself, and it is NOT the statusless non-retryable api_error
+// that a malformed body gets. Nothing wrote back afterwards, either — a read
+// that failed cannot be merge-safely echoed.
+func assertUnclassifiedReadFailure(t *testing.T, err error, puts *atomic.Int64) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("expected the call to fail, but it succeeded")
+	}
+	if apiErr, ok := errors.AsType[*Error](err); ok {
+		t.Fatalf("expected the read failure verbatim, got a %q *Error (retryable=%v): %v",
+			apiErr.Code, apiErr.Retryable, err)
+	}
+	if n := puts.Load(); n != 0 {
+		t.Fatalf("expected no write-back after a failed read, got %d PUT(s)", n)
+	}
+}
+
 // #773: the document read's decode step sees three different failures and only
 // two of them are the decoder's, because io.ReadAll runs INSIDE
 // ParseGetDocumentResponse. All three arrive at documentDecodeError by the same
 // path, so the gate is what tells them apart — and the three cases here are one
-// test rather than three so that a later "simplification" has to look at all of
+// test rather than four so that a later "simplification" has to look at all of
 // them at once.
 //
-// The third case is the load-bearing one. The obvious fix for #773 — allow-list
-// *json.SyntaxError and *json.UnmarshalTypeError, return everything else
-// verbatim — passes the first two and silently breaks the third, because
-// created_at is a time.Time and time.Time.UnmarshalJSON returns *time.ParseError,
-// which is not an encoding/json type at all.
+// Cases 3 and 4 are the load-bearing pair, and they fail in opposite directions:
+//
+//   - An ALLOW-LIST of the decoder (*json.SyntaxError, *json.UnmarshalTypeError,
+//     everything else verbatim) breaks case 3, because created_at is a time.Time
+//     and time.Time.UnmarshalJSON returns *time.ParseError, which is not an
+//     encoding/json type at all.
+//   - A DENY-LIST of the transport (io.ErrUnexpectedEOF, net.Error, the context
+//     sentinels — classify everything else) breaks case 4, because net/http
+//     reports corrupt chunk framing as a bare errors.New with no type to match.
+//
+// Both were tried on this branch. Neither survives both cases, because both
+// INFER the origin from the error's type, and neither error set is closed
+// enough to infer from. Marking the origin at the read is what passes all four.
 func TestDocumentsService_GetSeparatesTransportFailuresFromDecodeFailures(t *testing.T) {
 	// 1. The body never finished arriving. There is nothing malformed about it —
 	// re-requesting is exactly the right move — so the read error has to survive
 	// as itself rather than becoming a statusless, permanently non-retryable
 	// api_error.
 	t.Run("a body that stops mid-read stays the transport's error", func(t *testing.T) {
-		srv, puts := truncatedBodyServer(t)
-		cfg := DefaultConfig()
-		cfg.BaseURL = srv.URL
-		client := NewClient(cfg, &StaticTokenProvider{Token: "test-token"})
+		ac, puts := brokenBodyClient(t, truncatedResponse)
 
-		_, err := client.ForAccount("99999").Documents().Update(context.Background(), 1069479300,
+		_, err := ac.Documents().Update(context.Background(), 1069479300,
 			&UpdateDocumentRequest{Title: "Q3 Plan"})
-		if err == nil {
-			t.Fatal("expected the call to fail, but it succeeded")
-		}
+		assertUnclassifiedReadFailure(t, err, puts)
 		if !errors.Is(err, io.ErrUnexpectedEOF) {
 			t.Fatalf("expected the read failure to reach the caller as itself, got %T: %v", err, err)
-		}
-		if apiErr, ok := errors.AsType[*Error](err); ok {
-			t.Fatalf("expected the transport error verbatim, got a %q *Error (retryable=%v): %v",
-				apiErr.Code, apiErr.Retryable, err)
-		}
-		if n := puts.Load(); n != 0 {
-			t.Fatalf("expected no write-back after a failed read, got %d PUT(s)", n)
 		}
 	})
 
@@ -865,6 +906,37 @@ func TestDocumentsService_GetSeparatesTransportFailuresFromDecodeFailures(t *tes
 		}
 		assertStatuslessDocumentAPIError(t, err)
 	})
+
+	// 4. A read failure with no type to match on: corrupt chunk framing, which
+	// net/http reports as a bare errors.New. It is the mirror of case 3 — where
+	// an allow-list of decoder types drops a decode failure, a deny-list of
+	// transport types drops THIS, and stamps a transient failure permanently
+	// non-retryable exactly as #773 described. Raised by Copilot on PR #779.
+	t.Run("a read failure with no matchable type stays the transport's error", func(t *testing.T) {
+		ac, puts := brokenBodyClient(t, chunkedGarbageResponse)
+
+		_, err := ac.Documents().Update(context.Background(), 1069479300,
+			&UpdateDocumentRequest{Title: "Q3 Plan"})
+		assertUnclassifiedReadFailure(t, err, puts)
+		assertOutsideEveryTransportDenyList(t, err)
+	})
+}
+
+// assertOutsideEveryTransportDenyList pins this case's PREMISE: the framing
+// error carries none of the marks a type-based gate could have recognised. If
+// net/http ever gives it a named type or makes it a net.Error, this case
+// silently stops being the thing it was added to prove and has to be restaged.
+func assertOutsideEveryTransportDenyList(t *testing.T, err error) {
+	t.Helper()
+	if errors.Is(err, io.ErrUnexpectedEOF) {
+		t.Error("this case only proves anything while the framing error is NOT io.ErrUnexpectedEOF")
+	}
+	if _, ok := errors.AsType[net.Error](err); ok {
+		t.Error("this case only proves anything while the framing error is NOT a net.Error")
+	}
+	if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+		t.Error("this case only proves anything while the framing error is NOT a context sentinel")
+	}
 }
 
 // assertStatuslessDocumentAPIError pins the SPEC §6 shape the merge-safe

--- a/go/pkg/basecamp/schedules.go
+++ b/go/pkg/basecamp/schedules.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"slices"
 	"strings"
@@ -482,19 +483,19 @@ func nonNilIDs(ids []int64) []int64 {
 //
 // The decode step's errors are not all decode errors, though: io.ReadAll runs
 // INSIDE the generated parse, so a body that never finished arriving lands here
-// too (#773). transportFailure in documents.go names that closed set and those
-// return verbatim — a deny-list of the transport, never an allow-list of the
-// decoder, for the reason written out in full at its definition.
+// too (#773). getEntryWithBody wraps the body in markBodyReadFailures
+// (documents.go) so those arrive tagged and return verbatim, rather than being
+// guessed at from the error's type — see bodyReadError for why guessing failed.
 //
 // The decoder's error is kept as Cause the way documentDecodeError keeps it
 // (#750): interpolating it into Message tells a human what happened and leaves
 // a caller nothing to switch on, where Unwrap puts *json.UnmarshalTypeError and
 // *json.SyntaxError back within reach of errors.As.
 func scheduleEntryDecodeError(err error) error {
-	// A body that never finished arriving is not a malformed body. Deny-list,
-	// never allow-list — transportFailure in documents.go explains why.
-	if transportFailure(err) {
-		return err
+	// A body that never finished arriving is not a malformed body. Unwrap the
+	// marker so the caller sees the transport's own error, not our plumbing.
+	if marked, ok := errors.AsType[*bodyReadError](err); ok {
+		return marked.err
 	}
 	return &Error{
 		Code:    CodeAPI,
@@ -805,8 +806,9 @@ func (s *SchedulesService) GetEntry(ctx context.Context, entryID int64) (*Schedu
 // matters: the body is STREAMED, so the transport is still running when
 // ParseGetScheduleEntryResponse calls io.ReadAll on it, and a truncated or reset
 // body surfaces from the parse rather than from the call above it (#773).
-// scheduleEntryDecodeError gates that closed set out before classifying. Same
-// split as DocumentsService.Get.
+// Wrapping the body marks those where they happen, so scheduleEntryDecodeError
+// can return them verbatim instead of guessing at them from the error's type
+// afterwards. Same split as DocumentsService.Get.
 func (s *SchedulesService) getEntryWithBody(ctx context.Context, entryID int64) (result *ScheduleEntry, body []byte, err error) {
 	op := OperationInfo{
 		Service: "Schedules", Operation: "GetEntry",
@@ -828,6 +830,7 @@ func (s *SchedulesService) getEntryWithBody(ctx context.Context, entryID int64) 
 	if err != nil {
 		return nil, nil, err
 	}
+	httpResp.Body = markBodyReadFailures(httpResp.Body)
 	resp, decodeErr := generated.ParseGetScheduleEntryResponse(httpResp)
 	if decodeErr != nil {
 		err = scheduleEntryDecodeError(decodeErr)

--- a/go/pkg/basecamp/schedules.go
+++ b/go/pkg/basecamp/schedules.go
@@ -472,19 +472,30 @@ func nonNilIDs(ids []int64) []int64 {
 // that as a raw decoder error, which callers switching on *Error would miss and
 // which carries no hint.
 //
-// There is no classification here, deliberately: decoder errors are not
-// enumerable (created_at is time.Time, whose UnmarshalJSON returns
-// *time.ParseError; description_attachments carries *types.FlexInt dimensions
-// rejected with a plain fmt.Errorf that is no named type at all), and neither
-// are the errors that precede a response. So getEntryWithBody splits the
-// request from the decode and calls this on the decode step only, where the
-// origin is known by construction rather than guessed.
+// The decoder half is not classified by inspection, deliberately: decoder
+// errors are not enumerable (created_at is time.Time, whose UnmarshalJSON
+// returns *time.ParseError; description_attachments carries *types.FlexInt
+// dimensions rejected with a plain fmt.Errorf that is no named type at all),
+// and neither are the errors that precede a response. So getEntryWithBody
+// splits the request from the decode and calls this on the decode step only,
+// where the origin is known by construction rather than guessed.
+//
+// The decode step's errors are not all decode errors, though: io.ReadAll runs
+// INSIDE the generated parse, so a body that never finished arriving lands here
+// too (#773). transportFailure in documents.go names that closed set and those
+// return verbatim — a deny-list of the transport, never an allow-list of the
+// decoder, for the reason written out in full at its definition.
 //
 // The decoder's error is kept as Cause the way documentDecodeError keeps it
 // (#750): interpolating it into Message tells a human what happened and leaves
 // a caller nothing to switch on, where Unwrap puts *json.UnmarshalTypeError and
 // *json.SyntaxError back within reach of errors.As.
 func scheduleEntryDecodeError(err error) error {
+	// A body that never finished arriving is not a malformed body. Deny-list,
+	// never allow-list — transportFailure in documents.go explains why.
+	if transportFailure(err) {
+		return err
+	}
 	return &Error{
 		Code:    CodeAPI,
 		Message: truncate(fmt.Sprintf("GetScheduleEntry returned a body that does not decode as a schedule entry: %v", err)),
@@ -783,13 +794,19 @@ func (s *SchedulesService) GetEntry(ctx context.Context, entryID int64) (*Schedu
 // GetScheduleEntryWithResponse, so the two error origins never mix. The
 // merge-safe composites read this body and write every field of it back, so a
 // malformed one has to arrive as the documented statusless api_error
-// (scheduleEntryDecodeError) — but everything BEFORE the response is a different
+// (scheduleEntryDecodeError) — but a failure to REACH a response is a different
 // failure with its own meaning, and no inspection of the returned error can
-// reliably tell them apart. GetScheduleEntry covers the gate's successors: the
+// reliably tell those apart. GetScheduleEntry covers the gate's successors: the
 // per-request auth editor (a token provider or custom AuthStrategy may return
-// ANY error), the transport, and context cancellation. Those return verbatim, so
-// errors.Is keeps working; only ParseGetScheduleEntryResponse's failure is a
-// decode failure. Same split as DocumentsService.Get.
+// ANY error), the request half of the transport, and context cancellation.
+// Those return verbatim, so errors.Is keeps working.
+//
+// The split is by origin, not by position in the exchange, and the difference
+// matters: the body is STREAMED, so the transport is still running when
+// ParseGetScheduleEntryResponse calls io.ReadAll on it, and a truncated or reset
+// body surfaces from the parse rather than from the call above it (#773).
+// scheduleEntryDecodeError gates that closed set out before classifying. Same
+// split as DocumentsService.Get.
 func (s *SchedulesService) getEntryWithBody(ctx context.Context, entryID int64) (result *ScheduleEntry, body []byte, err error) {
 	op := OperationInfo{
 		Service: "Schedules", Operation: "GetEntry",

--- a/go/pkg/basecamp/schedules_test.go
+++ b/go/pkg/basecamp/schedules_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -13,6 +14,7 @@ import (
 	"slices"
 	"strings"
 	"testing"
+	"time"
 )
 
 func schedulesFixturesDir() string {
@@ -1605,6 +1607,100 @@ func TestSchedulesService_UpdateEntryKeepsTheDecoderErrorReachable(t *testing.T)
 	var apiErr *Error
 	if !errors.As(err, &apiErr) || apiErr.Code != CodeAPI {
 		t.Fatalf("expected a statusless api_error over the decoder error, got %T: %v", err, err)
+	}
+}
+
+// #773 at the second of the two sites. getEntryWithBody reads through
+// ParseGetScheduleEntryResponse, whose first statement is io.ReadAll, so a body
+// that never finished arriving reaches scheduleEntryDecodeError by the same path
+// a JSON fault does. Same three cases as
+// TestDocumentsService_GetSeparatesTransportFailuresFromDecodeFailures, and the
+// third is the one an allow-list of encoding/json sentinels would have broken.
+func TestSchedulesService_GetEntrySeparatesTransportFailuresFromDecodeFailures(t *testing.T) {
+	// 1. Truncated mid-body: a transient failure, not a malformed record.
+	t.Run("a body that stops mid-read stays the transport's error", func(t *testing.T) {
+		srv, puts := truncatedBodyServer(t)
+		cfg := DefaultConfig()
+		cfg.BaseURL = srv.URL
+		client := NewClient(cfg, &StaticTokenProvider{Token: "test-token"})
+
+		_, err := client.ForAccount("99999").Schedules().UpdateEntry(context.Background(), 1069479400,
+			&UpdateScheduleEntryRequest{Summary: strPtr("Q3 Kickoff")})
+		if err == nil {
+			t.Fatal("expected the call to fail, but it succeeded")
+		}
+		if !errors.Is(err, io.ErrUnexpectedEOF) {
+			t.Fatalf("expected the read failure to reach the caller as itself, got %T: %v", err, err)
+		}
+		if apiErr, ok := errors.AsType[*Error](err); ok {
+			t.Fatalf("expected the transport error verbatim, got a %q *Error (retryable=%v): %v",
+				apiErr.Code, apiErr.Retryable, err)
+		}
+		if n := puts.Load(); n != 0 {
+			t.Fatalf("expected no write-back after a failed read, got %d PUT(s)", n)
+		}
+	})
+
+	// 2. Arrived whole, not JSON: still the statusless api_error.
+	t.Run("a malformed body is the statusless api_error", func(t *testing.T) {
+		base := scheduleEntryReadBack(t)
+		svc, reqs := testSchedulesCaptureServer(t, []byte(`{"id":1069479400,`), base, nil)
+
+		_, err := svc.UpdateEntry(context.Background(), 1069479400,
+			&UpdateScheduleEntryRequest{Summary: strPtr("Q3 Kickoff")})
+		if err == nil {
+			t.Fatal("expected the call to fail, but it succeeded")
+		}
+		assertStatuslessScheduleEntryAPIError(t, err)
+		if _, ok := errors.AsType[*json.SyntaxError](err); !ok {
+			t.Errorf("expected the JSON error to be reachable through Cause, got %v", err)
+		}
+		if errors.Is(err, io.ErrUnexpectedEOF) {
+			t.Error("a body that arrived whole must not be reported as a truncated read")
+		}
+		assertNoPUT(t, reqs)
+	})
+
+	// 3. Neither. This is the case the originally-proposed allow-list fix broke.
+	t.Run("a decoder error that is neither is still the statusless api_error", func(t *testing.T) {
+		base := scheduleEntryReadBack(t)
+		get := patchScheduleEntryFixture(t, base, map[string]any{"created_at": "not-a-date"})
+		svc, reqs := testSchedulesCaptureServer(t, get, base, nil)
+
+		_, err := svc.UpdateEntry(context.Background(), 1069479400,
+			&UpdateScheduleEntryRequest{Summary: strPtr("Q3 Kickoff")})
+		if err == nil {
+			t.Fatal("expected the call to fail, but it succeeded")
+		}
+		// The premise, pinned alongside the conclusion: created_at has to still
+		// be a time.Time for this case to be testing what it says it is.
+		if _, ok := errors.AsType[*time.ParseError](err); !ok {
+			t.Fatalf("expected a *time.ParseError from created_at, got %T: %v", err, err)
+		}
+		assertStatuslessScheduleEntryAPIError(t, err)
+		assertNoPUT(t, reqs)
+	})
+}
+
+// assertStatuslessScheduleEntryAPIError pins the SPEC §6 shape for the entry
+// read, the way assertStatuslessDocumentAPIError does for the document read.
+func assertStatuslessScheduleEntryAPIError(t *testing.T, err error) {
+	t.Helper()
+	apiErr, ok := errors.AsType[*Error](err)
+	if !ok {
+		t.Fatalf("expected *Error, got %T: %v", err, err)
+	}
+	if apiErr.Code != CodeAPI {
+		t.Errorf("expected code %q, got %q", CodeAPI, apiErr.Code)
+	}
+	if apiErr.HTTPStatus != 0 {
+		t.Errorf("expected a statusless error, got HTTP %d", apiErr.HTTPStatus)
+	}
+	if apiErr.Retryable {
+		t.Error("re-requesting cannot repair a malformed body")
+	}
+	if apiErr.Hint == "" {
+		t.Error("expected a hint naming the deliberate-overwrite escape hatch")
 	}
 }
 

--- a/go/pkg/basecamp/schedules_test.go
+++ b/go/pkg/basecamp/schedules_test.go
@@ -1613,31 +1613,20 @@ func TestSchedulesService_UpdateEntryKeepsTheDecoderErrorReachable(t *testing.T)
 // #773 at the second of the two sites. getEntryWithBody reads through
 // ParseGetScheduleEntryResponse, whose first statement is io.ReadAll, so a body
 // that never finished arriving reaches scheduleEntryDecodeError by the same path
-// a JSON fault does. Same three cases as
-// TestDocumentsService_GetSeparatesTransportFailuresFromDecodeFailures, and the
-// third is the one an allow-list of encoding/json sentinels would have broken.
+// a JSON fault does. Same four cases as
+// TestDocumentsService_GetSeparatesTransportFailuresFromDecodeFailures, whose
+// comment carries the argument: 3 and 4 fail in opposite directions and rule out
+// inferring the origin from the error's type in either direction.
 func TestSchedulesService_GetEntrySeparatesTransportFailuresFromDecodeFailures(t *testing.T) {
 	// 1. Truncated mid-body: a transient failure, not a malformed record.
 	t.Run("a body that stops mid-read stays the transport's error", func(t *testing.T) {
-		srv, puts := truncatedBodyServer(t)
-		cfg := DefaultConfig()
-		cfg.BaseURL = srv.URL
-		client := NewClient(cfg, &StaticTokenProvider{Token: "test-token"})
+		ac, puts := brokenBodyClient(t, truncatedResponse)
 
-		_, err := client.ForAccount("99999").Schedules().UpdateEntry(context.Background(), 1069479400,
+		_, err := ac.Schedules().UpdateEntry(context.Background(), 1069479400,
 			&UpdateScheduleEntryRequest{Summary: strPtr("Q3 Kickoff")})
-		if err == nil {
-			t.Fatal("expected the call to fail, but it succeeded")
-		}
+		assertUnclassifiedReadFailure(t, err, puts)
 		if !errors.Is(err, io.ErrUnexpectedEOF) {
 			t.Fatalf("expected the read failure to reach the caller as itself, got %T: %v", err, err)
-		}
-		if apiErr, ok := errors.AsType[*Error](err); ok {
-			t.Fatalf("expected the transport error verbatim, got a %q *Error (retryable=%v): %v",
-				apiErr.Code, apiErr.Retryable, err)
-		}
-		if n := puts.Load(); n != 0 {
-			t.Fatalf("expected no write-back after a failed read, got %d PUT(s)", n)
 		}
 	})
 
@@ -1679,6 +1668,18 @@ func TestSchedulesService_GetEntrySeparatesTransportFailuresFromDecodeFailures(t
 		}
 		assertStatuslessScheduleEntryAPIError(t, err)
 		assertNoPUT(t, reqs)
+	})
+
+	// 4. A read failure with no type to match on — corrupt chunk framing. The
+	// mirror of case 3, and the case a deny-list of transport types drops.
+	// Raised by Copilot on PR #779.
+	t.Run("a read failure with no matchable type stays the transport's error", func(t *testing.T) {
+		ac, puts := brokenBodyClient(t, chunkedGarbageResponse)
+
+		_, err := ac.Schedules().UpdateEntry(context.Background(), 1069479400,
+			&UpdateScheduleEntryRequest{Summary: strPtr("Q3 Kickoff")})
+		assertUnclassifiedReadFailure(t, err, puts)
+		assertOutsideEveryTransportDenyList(t, err)
 	})
 }
 

--- a/go/pkg/basecamp/vaults.go
+++ b/go/pkg/basecamp/vaults.go
@@ -493,12 +493,18 @@ func (s *DocumentsService) Get(ctx context.Context, documentID int64) (result *D
 	// so the two error origins never mix. The merge-safe composites read this
 	// body and write every field of it back, so a malformed one has to arrive as
 	// the documented statusless api_error (documentDecodeError in documents.go)
-	// — but everything BEFORE the response is a different failure with its own
-	// meaning, and no inspection of the returned error can reliably tell them
+	// — but a failure to REACH a response is a different failure with its own
+	// meaning, and no inspection of the returned error can reliably tell those
 	// apart. GetDocument covers the gate's successors: the per-request auth
 	// editor (a token provider or custom AuthStrategy may return ANY error), the
-	// transport, and context cancellation. Those return verbatim, so errors.Is
-	// keeps working; only ParseGetDocumentResponse's failure is a decode failure.
+	// request half of the transport, and context cancellation. Those return
+	// verbatim, so errors.Is keeps working.
+	//
+	// The split is by origin, not by position in the exchange: the body is
+	// STREAMED, so the transport is still running when ParseGetDocumentResponse
+	// calls io.ReadAll on it, and a truncated or reset body surfaces from the
+	// parse rather than from the call above it (#773). documentDecodeError gates
+	// that closed set out before classifying.
 	//nolint:bodyclose // ParseGetDocumentResponse below closes the body (it defers
 	// rsp.Body.Close()), and it is called unconditionally on the next line.
 	httpResp, err := s.client.parent.gen.GetDocument(ctx, s.client.accountID, documentID)

--- a/go/pkg/basecamp/vaults.go
+++ b/go/pkg/basecamp/vaults.go
@@ -503,14 +503,16 @@ func (s *DocumentsService) Get(ctx context.Context, documentID int64) (result *D
 	// The split is by origin, not by position in the exchange: the body is
 	// STREAMED, so the transport is still running when ParseGetDocumentResponse
 	// calls io.ReadAll on it, and a truncated or reset body surfaces from the
-	// parse rather than from the call above it (#773). documentDecodeError gates
-	// that closed set out before classifying.
+	// parse rather than from the call above it (#773). Wrapping the body marks
+	// those where they happen, so documentDecodeError can return them verbatim
+	// instead of guessing at them from the error's type afterwards.
 	//nolint:bodyclose // ParseGetDocumentResponse below closes the body (it defers
 	// rsp.Body.Close()), and it is called unconditionally on the next line.
 	httpResp, err := s.client.parent.gen.GetDocument(ctx, s.client.accountID, documentID)
 	if err != nil {
 		return nil, err
 	}
+	httpResp.Body = markBodyReadFailures(httpResp.Body)
 	resp, decodeErr := generated.ParseGetDocumentResponse(httpResp)
 	if decodeErr != nil {
 		err = documentDecodeError(decodeErr)


### PR DESCRIPTION
`go/pkg/basecamp/vaults.go` and `schedules.go` are the only two non-test call sites of a
`generated.Parse*` function, and both handed any error from it to a SPEC §6 renderer that stamps
`CodeAPI`, statusless, `Retryable: false`. But `io.ReadAll(rsp.Body)` is the **first statement** of
both generated parsers and its error is returned verbatim, so a truncated body, a reset connection
or corrupt chunk framing arrived at those renderers by exactly the same path a JSON fault does — and
came out permanently non-retryable. A caller reading `Retryable` treated a transient failure as
permanent; a caller reaching for a JSON error through `errors.As` found a transport error.

## The fix: mark the origin at the read

Both call sites hold the `*http.Response` between the generated call and the parse, so the body is
wrapped there. A private `io.ReadCloser` forwards `Read`/`Close` and tags every failure with a
private `bodyReadError`; the two renderers gate on that marker and unwrap it, so the caller still
sees the transport's own error and no new type becomes public.

`io.EOF` passes through untouched, compared against that exact value rather than through
`errors.Is`: `io.ReadAll` ends its loop on `err == io.EOF` and treats every other value as a
failure, so matching its test exactly is what makes the marker cover precisely the set `io.ReadAll`
can hand back — including a wrapped EOF, which `io.ReadAll` would also surface as an error.

The origin is now a fact of construction rather than a judgement about an error, which is what the
three surrounding doc comments already claimed happened ("the origin is known by construction rather
than guessed"). They are now literally true instead of approximately true.

### Rejected: inferring the origin from the error's type

An earlier revision of this PR gated on a deny-list of transport error types (`io.ErrUnexpectedEOF`,
`net.Error`, the context sentinels). **Copilot caught that it does not close the bug**, and it was
right: there is no error set to match on. `net/http` reports corrupt chunk framing as a bare
`errors.New("invalid byte in chunk length")`, the transport's automatic gunzip returns
`gzip.ErrHeader`, and `WithTransport` lets a caller supply a body whose `Read` returns anything at
all — none of them a `net.Error`, none of them a named type. All were still stamped statusless
non-retryable, which is #773 surviving under a different error shape. Inverting it into an
allow-list of `encoding/json` sentinels fails the other way (see case 3 below). Marking is also the
*smaller* change: it needs no argument about which error set is closed, so **42 lines of comment
defending a classification became 28 explaining a wrapper**. One sentence in `bodyReadError`'s doc
keeps the record of why inference was rejected, so nobody re-derives the deny-list.

## Red proof, per case

Four cases per site, in one test function each so a later edit has to face all of them at once: two
body-read failures (1, 4) and two decoder failures (2, 3). Implementation stashed and restored by
`cp` + `diff -q` throughout — never `git checkout --`, never `git stash`, since the stash stack is
shared across worktrees here.

### 1. The original bug, against the pre-fix source (`origin/main` at `a6d3c0ba4`)

```
--- FAIL: TestDocumentsService_GetSeparatesTransportFailuresFromDecodeFailures
    documents_test.go: expected the transport error verbatim, got a "api_error" *Error (retryable=false): GetDocument returned a body that does not decode as a document: unexpected EOF: ...
--- FAIL: TestSchedulesService_GetEntrySeparatesTransportFailuresFromDecodeFailures
    schedules_test.go: expected the transport error verbatim, got a "api_error" *Error (retryable=false): GetScheduleEntry returned a body that does not decode as a schedule entry: unexpected EOF: ...
REAL_EXIT=1
```

Cases 2 and 3 are **green** pre-fix, and that is correct — pre-fix behaviour for a body that arrived
whole was already right, so both are no-regression controls, not red proofs.

### 2. Copilot's case, against the rejected deny-list revision

```
=== RUN   .../a_read_failure_with_no_matchable_type_stays_the_transport's_error
    documents_test.go:920: expected the read failure verbatim, got a "api_error" *Error (retryable=false): GetDocument returned a body that does not decode as a document: invalid byte in chunk length: The merge-safe Update/Edit resend this record's fields verbatim, so a malformed response cannot be written back safely. Use Replace to write the record deliberately.
    schedules_test.go:1681: expected the read failure verbatim, got a "api_error" *Error (retryable=false): GetScheduleEntry returned a body that does not decode as a schedule entry: invalid byte in chunk length: The merge-safe UpdateEntry/EditEntry resend this record's fields verbatim, so a malformed response cannot be written back safely. Use ReplaceEntry to write the record deliberately.
--- FAIL: TestDocumentsService_GetSeparatesTransportFailuresFromDecodeFailures
    --- PASS: .../a_body_that_stops_mid-read_stays_the_transport's_error
    --- PASS: .../a_malformed_body_is_the_statusless_api_error
    --- PASS: .../a_decoder_error_that_is_neither_is_still_the_statusless_api_error
    --- FAIL: .../a_read_failure_with_no_matchable_type_stays_the_transport's_error
--- FAIL: TestSchedulesService_GetEntrySeparatesTransportFailuresFromDecodeFailures
    (same four)
REAL_EXIT=1
```

The deny-list passes cases 1–3 and fails case 4 at both sites. All four pass against the marker.

### 3. Cases 3 and 4 fail in opposite directions

Either case alone rules out one bad gate; together they rule out inferring the origin from the
error's type *at all*. Each half is shown load-bearing by mutating the shipped fix, not by
assertion:

| Mutation applied to the shipped fix | Case 3 (`*time.ParseError`) | Case 4 (chunk framing) |
|---|---|---|
| **Allow-list** the decoder (`*json.SyntaxError` / `*json.UnmarshalTypeError`) | **FAIL** | pass |
| **Deny-list** the transport (`io.ErrUnexpectedEOF` / `net.Error` / context) | pass | **FAIL** |
| Marker (shipped) | pass | pass |

Allow-list mutant, applied to `documents.go`:

```
--- FAIL: .../a_decoder_error_that_is_neither_is_still_the_statusless_api_error (0.01s)
    documents_test.go:907: expected *Error, got *time.ParseError: parsing time "not-a-date" as "2006-01-02T15:04:05Z07:00": cannot parse "not-a-date" as "2006"
REAL_EXIT=1
```

Case 4 pins its own premise — the framing error must be **not** `io.ErrUnexpectedEOF`, **not** a
`net.Error` and **not** a context sentinel — so if `net/http` ever gives it a type, the case fails
loudly instead of quietly ceasing to test what it was added for.

### 4. The `io.EOF` carve-out is load-bearing

Removing it (marking every read error, `io.EOF` included) reddens 69 assertions across the documents
and schedules suites, `REAL_EXIT=1`, starting `documents_test.go:154: unexpected error: EOF`. The
happy path covers that line; it is not an untested branch.

### Staging the failures

A normal handler's `ResponseWriter` derives `Content-Length` from what was written and re-frames
chunked output itself, so both failures are staged by hijacking the connection and writing raw
bytes: `Content-Length: 4096` followed by thirty bytes for the truncation, and
`Transfer-Encoding: chunked` followed by a bogus chunk length for the framing error. The helper
counts PUTs, so every case proves no write-back followed the failed read.

## Gates

Run with mise activated and under `LC_ALL=C`, exit codes written into the log rather than echoed
after a pipe:

- `LC_ALL=C make go-check` — `REAL_EXIT=0` (fmt-check, vet, golangci-lint, full test suite)
- `LC_ALL=C make go-check-drift` — `REAL_EXIT=0` (250 / 250 operations, no critical drift)
- `LC_ALL=C go test -race -count=3` over the affected tests — `REAL_EXIT=0`

No generated files, no spec, no other SDK: the other five buffer the body before decoding, as
triaged on the issue.

Closes #773
