### PR TITLE
Pin the conformance runners' fixture reads, and give CI a leg that can see them break

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -650,8 +650,15 @@ jobs:
         working-directory: conformance/runner/ruby
         # Frozen: the runner Gemfile.lock is tracked (#670), so the install
         # must fail fast rather than rewrite it.
+        #
+        # LC_ALL=C for the same reason as the `Test (LC_ALL=C)` leg above: the
+        # runner's fixture reads are pinned to encoding: "UTF-8", fixtures under
+        # conformance/tests/ carry non-ASCII, and an unpinned read decodes them
+        # as US-ASCII and raises before a single case runs (#774). This is what
+        # turns the pin from asserted into proven.
         env:
           BUNDLE_FROZEN: 'true'
+          LC_ALL: C
         run: |
           bundle install
           ruby runner.rb
@@ -766,6 +773,19 @@ jobs:
         working-directory: conformance/runner/python
         # --locked: the runner uv.lock is tracked (#670), so a missing or
         # out-of-date lockfile must fail the install, not regenerate it.
+        #
+        # The three env vars together are what hold the runner's UTF-8 pins
+        # (#774), and LC_ALL alone would not: under a C/POSIX locale CPython
+        # auto-enables UTF-8 mode (PEP 540), so `Path.read_text()` with no
+        # encoding= still decodes UTF-8 and an unpinned read passes. PYTHONUTF8=0
+        # turns that rescue off, which is the only way this step can observe the
+        # locale-following read it exists to catch. PYTHONIOENCODING keeps stdout
+        # on UTF-8 so the check stays about the FILE reads under test rather than
+        # failing later on a case name someone writes with an em dash.
+        env:
+          LC_ALL: C
+          PYTHONUTF8: '0'
+          PYTHONIOENCODING: utf-8
         run: |
           uv sync --locked --python ${{ matrix.python }}
           uv run --python ${{ matrix.python }} python runner.py
@@ -801,8 +821,15 @@ jobs:
         # so the target itself stays version-agnostic.
         if: matrix.python == '3.13'
         working-directory: .
+        # Same locale trio as the conformance step above, for the same reason:
+        # this suite reads conformance/tests/live-my-surface.json, which carries
+        # non-ASCII, so its read is pinned too and the pin needs a leg that can
+        # see it break (#774).
         env:
           UV_PYTHON: ${{ matrix.python }}
+          LC_ALL: C
+          PYTHONUTF8: '0'
+          PYTHONIOENCODING: utf-8
         run: make conformance-runner-tests-python
 
       # Ground truth, and the authoritative check: the static parser predicts

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -821,10 +821,15 @@ jobs:
         # so the target itself stays version-agnostic.
         if: matrix.python == '3.13'
         working-directory: .
-        # Same locale trio as the conformance step above, for the same reason:
-        # this suite reads conformance/tests/live-my-surface.json, which carries
-        # non-ASCII, so its read is pinned too and the pin needs a leg that can
-        # see it break (#774).
+        # Same locale trio as the conformance step above, and this is the step
+        # that holds most of the Python pins (#774). It reads
+        # conformance/tests/live-my-surface.json, which carries non-ASCII, so
+        # its own read is pinned too — but it is also the ONLY thing that
+        # executes the replay path: runner.py never constructs ReplayRunner or
+        # SchemaWalker, so the pins in replay_runner.py and schema_walker.py are
+        # unreachable from the conformance step above. Utf8ReplayPathTest and
+        # SchemaWalkerUtf8Test drive that path over well-formed non-ASCII UTF-8;
+        # drop any one of those four pins and this step reds.
         env:
           UV_PYTHON: ${{ matrix.python }}
           LC_ALL: C

--- a/conformance/runner/python/replay_runner.py
+++ b/conformance/runner/python/replay_runner.py
@@ -121,8 +121,11 @@ class ReplayRunner:
         self._replay_dir = replay_dir
         self._backend = backend
         self._walker = SchemaWalker(openapi_path)
+        # Fixture and snapshot reads are pinned to UTF-8 regardless of process
+        # locale (LC_ALL=C would otherwise read as US-ASCII whenever UTF-8 mode
+        # is off).
         self._fixture: list[dict] = [
-            t for t in json.loads(fixture_path.read_text())
+            t for t in json.loads(fixture_path.read_text(encoding="utf-8"))
             if t.get("mode") == "live"
         ]
 
@@ -154,14 +157,16 @@ class ReplayRunner:
         if wire_dir.exists():
             for f in sorted(wire_dir.glob("*.json")):
                 try:
-                    snap = json.loads(f.read_text())
+                    snap = json.loads(f.read_text(encoding="utf-8"))
                 except OSError as e:
                     msgs.append(f"Snapshot {f.name} could not be read: {type(e).__name__}: {e}.")
                     continue
                 except UnicodeDecodeError as e:
-                    # Path.read_text() decodes UTF-8 by default; malformed
-                    # bytes raise UnicodeDecodeError (a ValueError, NOT an
-                    # OSError), so it must be caught separately.
+                    # Path.read_text() follows the process locale unless an
+                    # encoding is given, which is why the call above pins one;
+                    # bytes that are not UTF-8 then raise UnicodeDecodeError (a
+                    # ValueError, NOT an OSError), so it must be caught
+                    # separately.
                     msgs.append(f"Snapshot {f.name} is not valid UTF-8: {e}.")
                     continue
                 except json.JSONDecodeError as e:
@@ -246,7 +251,7 @@ class ReplayRunner:
 
     def _read_snapshot(self, test_name: str) -> dict:
         path = self._replay_dir / self._backend / "wire" / f"{_safe_name(test_name)}.json"
-        return json.loads(path.read_text())
+        return json.loads(path.read_text(encoding="utf-8"))
 
     def _decode_snapshot(self, snapshot: dict) -> dict:
         operation = snapshot["operation"]

--- a/conformance/runner/python/replay_runner.py
+++ b/conformance/runner/python/replay_runner.py
@@ -241,6 +241,8 @@ class ReplayRunner:
                 print(f"skip {snapshot['operation']}: {result['skip_reason']}")
             else:
                 result = self._decode_snapshot(snapshot)
+            # Same ensure_ascii=True dependency as the execution manifest in
+            # runner.py — see the comment there before changing this call.
             (out_dir / f"{_safe_name(t['name'])}.json").write_text(
                 json.dumps(result, indent=2)
             )

--- a/conformance/runner/python/runner.py
+++ b/conformance/runner/python/runner.py
@@ -137,7 +137,9 @@ def count_non_live_cases(tests_dir: str | Path) -> int:
     cases = 0
     for file in files:
         try:
-            parsed = json.loads(file.read_text())
+            # UTF-8 regardless of process locale (LC_ALL=C would otherwise read
+            # as US-ASCII whenever UTF-8 mode is off)
+            parsed = json.loads(file.read_text(encoding="utf-8"))
         except (json.JSONDecodeError, OSError) as e:
             raise RuntimeError(f"{file}: {e}") from e
         if not isinstance(parsed, list):
@@ -1532,7 +1534,9 @@ class ConformanceRunner:
         excluded: list[tuple[str, str, str]] = []
 
         for file in files:
-            tests = json.loads(file.read_text())
+            # UTF-8 regardless of process locale (LC_ALL=C would otherwise read
+            # as US-ASCII whenever UTF-8 mode is off)
+            tests = json.loads(file.read_text(encoding="utf-8"))
             # Live tests are TS-only (canonical wire-capturer); filter them out
             # before mock dispatch so unresolved ${PROJECT_ID} fixtures and
             # live-only operations don't surface here.

--- a/conformance/runner/python/runner.py
+++ b/conformance/runner/python/runner.py
@@ -196,6 +196,13 @@ def write_execution_manifest(runner: str, total: int, executed: int,
         "executed": executed,
         "excluded": [{"file": f, "name": n, "reason": r} for f, n, r in sorted(excluded)],
     }
+    # `ensure_ascii=True` is json.dumps' default and it is load-bearing here, not
+    # incidental: `excluded` carries case names straight from the fixtures, and
+    # write_text() with no encoding= encodes in the locale's. The conformance
+    # step runs under LC_ALL=C PYTHONUTF8=0, so the moment someone passes
+    # ensure_ascii=False for prettier manifests this line raises
+    # UnicodeEncodeError on the first case name with an em dash. Pass an
+    # encoding= here if that day comes; do not just flip the flag.
     (path / f"{runner}.json").write_text(json.dumps(body, indent=2) + "\n")
 
 

--- a/conformance/runner/python/schema_walker.py
+++ b/conformance/runner/python/schema_walker.py
@@ -39,7 +39,10 @@ _MAX_DEPTH = 12
 
 class SchemaWalker:
     def __init__(self, openapi_path: Path) -> None:
-        self._doc: dict = json.loads(openapi_path.read_text())
+        # Read as UTF-8 regardless of process locale (LC_ALL=C would otherwise
+        # read as US-ASCII, whenever UTF-8 mode is off, and choke on the spec's
+        # UTF-8 bytes).
+        self._doc: dict = json.loads(openapi_path.read_text(encoding="utf-8"))
 
     def find_response_schema(self, operation_id: str) -> dict | None:
         for path_item in self._doc.get("paths", {}).values():

--- a/conformance/runner/python/test_replay_runner.py
+++ b/conformance/runner/python/test_replay_runner.py
@@ -33,7 +33,9 @@ LIVE_FIXTURE = Path(__file__).parent.parent.parent / "tests" / "live-my-surface.
 
 
 def _live_operations() -> set[str]:
-    tests = json.loads(LIVE_FIXTURE.read_text())
+    # Pinned like every other fixture read: the file carries non-ASCII, and
+    # read_text() follows the process locale unless told otherwise.
+    tests = json.loads(LIVE_FIXTURE.read_text(encoding="utf-8"))
     ops = {t["operation"] for t in tests if t.get("mode") == "live"}
     # Fail closed: an empty set would make the assertions below vacuous.
     assert ops, f"{LIVE_FIXTURE} declared no live operations — the reader is broken"

--- a/conformance/runner/python/test_replay_runner.py
+++ b/conformance/runner/python/test_replay_runner.py
@@ -17,6 +17,17 @@ Covers two known bugs:
     diagnostic. Post-fix, the gate appends a "not valid UTF-8" message and
     keeps going.
 
+  * Locale-following reads (#774) — every fixture, snapshot and schema read
+    in the replay path is pinned to ``encoding="utf-8"``, because
+    ``Path.read_text()`` with no ``encoding=`` decodes in the process
+    locale's. ``Utf8ReplayPathTest`` and ``SchemaWalkerUtf8Test`` below run
+    the production path over WELL-FORMED non-ASCII UTF-8, which is what
+    makes those pins load-bearing under the ``LC_ALL=C PYTHONUTF8=0`` leg
+    CI runs this suite in. The malformed-bytes case above cannot do that
+    job: those bytes decode under neither US-ASCII nor UTF-8, so it passes
+    with or without a pin. The two are complementary — do not fold either
+    into the other.
+
 Run: ``uv run python -m unittest test_replay_runner -v``
 """
 
@@ -27,9 +38,19 @@ import tempfile
 import unittest
 from pathlib import Path
 
-from replay_runner import DECODERS, ReplayRunner, _decode, _resolve_body_text
+from replay_runner import DECODERS, ReplayRunner, _decode, _resolve_body_text, _safe_name
+from schema_walker import SchemaWalker
 
 LIVE_FIXTURE = Path(__file__).parent.parent.parent / "tests" / "live-my-surface.json"
+
+# Literal non-ASCII for each file the replay path opens: the fixture's case
+# name, the schema's description, and the wire body's values and keys. Mixed
+# 2- and 3-byte sequences, since a US-ASCII decode must fail on the first byte
+# either way and a narrower set would be a weaker fixture for no gain.
+UTF8_CASE_NAME = "GetProject — café ☕"
+UTF8_SCHEMA_DESCRIPTION = "Projet — café"
+UTF8_PROJECT_NAME = "Café — Ünicode ☕"
+UTF8_EXTRA_FIELD = "résumé"
 
 
 def _live_operations() -> set[str]:
@@ -123,6 +144,144 @@ class CoverageGateUtf8Test(unittest.TestCase):
                 any("not valid UTF-8" in m for m in msgs),
                 f"expected 'not valid UTF-8' diagnostic in {msgs!r}",
             )
+
+
+def _write_utf8_json(path: Path, payload: object) -> None:
+    """Write ``payload`` as JSON with LITERAL non-ASCII bytes on disk.
+
+    Both arguments are load-bearing. ``json.dumps`` defaults to
+    ``ensure_ascii=True``, which escapes every non-ASCII character back to
+    ``\\uXXXX`` and would leave a pure-ASCII file that any decoder accepts —
+    that is precisely why the pre-existing constructor fixture proved nothing.
+    ``write_text`` with no ``encoding=`` encodes in the process locale's, which
+    under this suite's CI env is US-ASCII, so the write itself would raise.
+    """
+    path.write_text(json.dumps(payload, indent=2, ensure_ascii=False), encoding="utf-8")
+
+
+def _build_utf8_replay_tree(tmpdir: Path) -> tuple[Path, Path, Path]:
+    """Lay out a valid single-operation replay tree carrying real UTF-8.
+
+    Returns ``(replay_dir, fixture_path, openapi_path)``. Every file the
+    production path opens — fixture, openapi document, wire snapshot — holds
+    non-ASCII, so each pinned read is exercised for real rather than over an
+    ASCII stand-in.
+    """
+    fixture_path = tmpdir / "live.json"
+    _write_utf8_json(fixture_path, [
+        {"name": UTF8_CASE_NAME, "mode": "live", "operation": "GetProject"},
+        # A non-live entry, to keep the constructor's mode filter honest.
+        {"name": "mock — ignoré", "mode": "mock", "operation": "ListProjects"},
+    ])
+
+    openapi_path = tmpdir / "openapi.json"
+    _write_utf8_json(openapi_path, {
+        "paths": {
+            "/projects/{id}.json": {
+                "get": {
+                    "operationId": "GetProject",
+                    "responses": {
+                        "200": {
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "type": "object",
+                                        "description": UTF8_SCHEMA_DESCRIPTION,
+                                        "required": ["id", "name"],
+                                        "properties": {
+                                            "id": {"type": "integer"},
+                                            "name": {"type": "string"},
+                                        },
+                                    }
+                                }
+                            }
+                        }
+                    },
+                }
+            }
+        }
+    })
+
+    body = {"id": 1, "name": UTF8_PROJECT_NAME, UTF8_EXTRA_FIELD: "présent"}
+    replay_dir = tmpdir / "replay"
+    wire_dir = replay_dir / "bc4" / "wire"
+    wire_dir.mkdir(parents=True)
+    _write_utf8_json(wire_dir / f"{_safe_name(UTF8_CASE_NAME)}.json", {
+        "operation": "GetProject",
+        "pages_count": 1,
+        "pages": [{
+            "status": 200,
+            "headers": {},
+            "body": body,
+            "bodyText": json.dumps(body, ensure_ascii=False),
+            "url": "https://example.test/projects/1.json",
+        }],
+    })
+
+    return replay_dir, fixture_path, openapi_path
+
+
+class Utf8ReplayPathTest(unittest.TestCase):
+    """Run the production replay path over well-formed non-ASCII UTF-8.
+
+    Every read this exercises is pinned to ``encoding="utf-8"``; drop any one
+    of them and this class reds under ``LC_ALL=C PYTHONUTF8=0``, which is the
+    env .github/workflows/test.yml runs the suite in. Before these tests
+    existed the pins were assertions nothing could falsify: the only
+    ``ReplayRunner`` construction wrote its fixture with default ASCII
+    escaping, the coverage gate was only ever handed malformed bytes, and
+    ``_read_snapshot`` was reached by nothing.
+    """
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.replay_dir, self.fixture_path, self.openapi_path = \
+            _build_utf8_replay_tree(Path(self._tmp.name))
+
+    def _runner(self) -> ReplayRunner:
+        return ReplayRunner(self.replay_dir, "bc4", self.fixture_path, self.openapi_path)
+
+    def test_constructor_reads_a_non_ascii_fixture(self) -> None:
+        # Covers ReplayRunner.__init__'s fixture read. Asserting the name
+        # round-trips (not just that construction succeeded) keeps this from
+        # passing on a mojibake decode.
+        self.assertEqual([UTF8_CASE_NAME], [t["name"] for t in self._runner()._fixture])
+
+    def test_coverage_gate_accepts_a_well_formed_non_ascii_snapshot(self) -> None:
+        # Covers coverage_gate's snapshot read. Unpinned, the read raises
+        # UnicodeDecodeError, the gate's own handler turns it into a "not
+        # valid UTF-8" message, and this assertion fails — the gate reports a
+        # corrupt snapshot that is in fact perfectly good.
+        self.assertEqual([], self._runner().coverage_gate())
+
+    def test_run_decodes_a_non_ascii_snapshot(self) -> None:
+        # Covers _read_snapshot, reachable only through run().
+        self.assertEqual(0, self._runner().run())
+
+        result = json.loads(
+            (self.replay_dir / "bc4" / "decode" / "python"
+             / f"{_safe_name(UTF8_CASE_NAME)}.json").read_text(encoding="utf-8")
+        )
+        page = result["pages"][0]
+        self.assertTrue(page["decoded"], page["decode_error"])
+        self.assertEqual([], page["missing_required"])
+        # The snapshot's non-ASCII content reached the schema walker intact —
+        # a decoded=True on its own would also hold for an empty body.
+        self.assertEqual([UTF8_EXTRA_FIELD], page["extras_seen"])
+
+
+class SchemaWalkerUtf8Test(unittest.TestCase):
+    def test_walker_reads_a_non_ascii_openapi_document(self) -> None:
+        # Covers SchemaWalker.__init__ directly. The real openapi.json carries
+        # non-ASCII descriptions; the only construction in this suite before
+        # now passed the ASCII-only document "{}".
+        with tempfile.TemporaryDirectory() as tmp:
+            _, _, openapi_path = _build_utf8_replay_tree(Path(tmp))
+            schema = SchemaWalker(openapi_path).find_response_schema("GetProject")
+
+            self.assertIsNotNone(schema)
+            self.assertEqual(UTF8_SCHEMA_DESCRIPTION, schema["description"])
 
 
 if __name__ == "__main__":

--- a/conformance/runner/ruby/replay-runner.rb
+++ b/conformance/runner/ruby/replay-runner.rb
@@ -114,6 +114,9 @@ class ReplayRunner
         else
           decode_snapshot(snapshot)
         end
+      # Unpinned on purpose, like the manifest write in runner.rb — File.write
+      # emits the string's bytes and only transcodes when handed an explicit
+      # encoding:. See that comment for the read/write asymmetry.
       File.write(File.join(out_dir, "#{safe_name(test["name"])}.json"), JSON.pretty_generate(result))
       failures += 1 if result[:pages].any? { |p| !p[:decoded] || p[:missing_required].any? }
     end

--- a/conformance/runner/ruby/runner.rb
+++ b/conformance/runner/ruby/runner.rb
@@ -118,7 +118,8 @@ module CaseCensus
 
     files.sum do |file|
       begin
-        parsed = JSON.parse(File.read(file))
+        # UTF-8 regardless of process locale (LC_ALL=C would otherwise read as US-ASCII)
+        parsed = JSON.parse(File.read(file, encoding: "UTF-8"))
       rescue JSON::ParserError, SystemCallError => e
         raise Error, "#{file}: #{e.message}"
       end

--- a/conformance/runner/ruby/runner.rb
+++ b/conformance/runner/ruby/runner.rb
@@ -193,6 +193,14 @@ module ExecutionManifest
       "executed" => executed,
       "excluded" => excluded.sort.map { |file, name, reason| { "file" => file, "name" => name, "reason" => reason } }
     }
+    # Deliberately NOT pinned, unlike every read above, and the asymmetry is
+    # real rather than an oversight: Encoding.default_external governs how a
+    # read DECODES, but File.write emits the string's own bytes and transcodes
+    # only when an encoding: is passed explicitly. `excluded` carries case names
+    # straight from the fixtures, so this line writes UTF-8 under LC_ALL=C —
+    # verified by running the suite with a non-ASCII skipped case name, which
+    # landed in the manifest intact. Adding `encoding: "UTF-8"` here would be
+    # inert; naming the locale's encoding would be the only way to break it.
     File.write(File.join(dir, "#{runner}.json"), "#{JSON.pretty_generate(body)}\n")
   end
 end


### PR DESCRIPTION
`make conformance` cannot run under `LC_ALL=C`. One read in the Ruby runner
follows the process locale, and under the C locale it decodes the fixtures as
US-ASCII and raises before a single case runs:

```
conformance/runner/ruby/runner.rb:121: Encoding::InvalidByteSequenceError
```

Ten of the 22 files in `conformance/tests/` carry non-ASCII —
`cards_write.json`, `documents_write.json`, `downloads.json`,
`live-my-surface.json`, `network-retry.json`, `pagination.json`, `retry.json`,
`search.json`, `todolists_read.json`, `todos_write.json` — so the census hits one
on its first pass.

Closes #774.

## What was unpinned

**Ruby — one site.** `runner.rb:121`, `JSON.parse(File.read(file))` in
`CaseCensus.non_live_case_count`. Every sibling read in the runner directory was
already pinned (`runner.rb:1682`, `replay-runner.rb:91`/`:154`/`:210`,
`schema-walker.rb:35`); this was the only survivor, and it now carries the same
`encoding: "UTF-8"` and the same one-line comment as the rest. A grep of
`conformance/runner/ruby/**/*.rb` for an unpinned read now returns nothing.

**Python — seven sites, which the issue does not mention at all.**
`Path.read_text()` with no `encoding=` uses `locale.getencoding()`:

| file | line |
|---|---|
| `runner.py` | 140 (fixture census), 1535 (dispatch loop) |
| `replay_runner.py` | 125 (live fixture), 157 (snapshot recognition), 249 (snapshot read) |
| `schema_walker.py` | 42 (`openapi.json`) |
| `test_replay_runner.py` | 36 (`live-my-surface.json`) |

The seventh is the one the issue's scope would have missed twice over: it is in
the runner's own unit-test suite, not the runner, and that suite is what
`make conformance-runner-tests-python` runs. It reads a fixture that is on the
non-ASCII list above, so it fails in exactly the same way — demonstrated below.

`replay_runner.py:162` also carried the belief that produced all seven:

> `Path.read_text()` decodes UTF-8 by default

It does not. It decodes in the locale's encoding, which is why the `except
UnicodeDecodeError` the comment was attached to could fire on *well-formed*
UTF-8. Corrected in place.

## Python's pass today is an accident, and `LC_ALL=C` alone does not expose it

This is the part that changes what CI has to set, so it is worth the four lines
of output. On CPython 3.14 (macOS, arm64), reading a UTF-8 file with
`read_text()` under the C locale:

```
--- LC_ALL=C ---
  flags.utf8_mode = 1
  getpreferredencoding(False) = utf-8
  locale.getencoding() = US-ASCII
  read_text() -> 'café'
--- LC_ALL=C PYTHONCOERCECLOCALE=0 ---
  flags.utf8_mode = 1
  getpreferredencoding(False) = utf-8
  locale.getencoding() = US-ASCII
  read_text() -> 'café'
--- LC_ALL=C PYTHONUTF8=0 ---
  flags.utf8_mode = 0
  getpreferredencoding(False) = US-ASCII
  locale.getencoding() = US-ASCII
  read_text() RAISED UnicodeDecodeError 'ascii' codec can't decode byte 0xc3 in position 3: ordinal not in range(128)
--- LC_ALL=C PYTHONUTF8=0 PYTHONCOERCECLOCALE=0 ---
  flags.utf8_mode = 0
  getpreferredencoding(False) = US-ASCII
  locale.getencoding() = US-ASCII
  read_text() RAISED UnicodeDecodeError 'ascii' codec can't decode byte 0xc3 in position 3: ordinal not in range(128)
```

`locale.getencoding()` says `US-ASCII` in all four. What saves the read in the
first two is **UTF-8 mode (PEP 540), which CPython auto-enables when the locale
is `C` or `POSIX`** — not PEP 538 C-locale coercion, which `PYTHONCOERCECLOCALE=0`
disables here to no effect. Either way it is a rescue supplied by the
interpreter's startup logic, not a property of the code, and PEP 686 makes it
stronger in 3.15 rather than weaker.

The operative consequence: **`LC_ALL: C` on the Python step would have proved
nothing.** The unpinned reads pass under it. `PYTHONUTF8: '0'` is what lets the
step observe the read it exists to catch, so the Python steps set both.
`PYTHONIOENCODING: utf-8` rides along to keep stdout on UTF-8, so the leg stays
about the *file* reads under test and does not start failing later on a case
name someone writes with an em dash.

## Red proof

`LC_ALL=C` for Ruby; `LC_ALL=C PYTHONUTF8=0 PYTHONIOENCODING=utf-8` for Python —
the exact env each CI step now sets. Output captured to a file with
`REAL_EXIT=$?` written into the log and grepped back, never `; echo` after a
pipe. The pre-fix state was restored by `cp` and verified with `diff -q`, never
`git checkout --`.

**RED — `LC_ALL=C make conformance-ruby`, `REAL_EXIT=2`:**

```
/…/json-2.21.2/lib/json/common.rb:364:in 'String#encode': "\xE2" on US-ASCII (Encoding::InvalidByteSequenceError)
	from /…/json/common.rb:364:in 'JSON.parse'
	from runner.rb:121:in 'block in CaseCensus.non_live_case_count'
	from runner.rb:119:in 'CaseCensus.non_live_case_count'
	from runner.rb:1657:in 'ConformanceRunner#run'
	from runner.rb:1746:in '<main>'
make: *** [conformance-ruby] Error 1
```

**RED — `LC_ALL=C PYTHONUTF8=0 PYTHONIOENCODING=utf-8 make conformance-python`, `REAL_EXIT=2`:**

```
  File "…/conformance/runner/python/runner.py", line 140, in count_non_live_cases
    parsed = json.loads(file.read_text())
                        ~~~~~~~~~~~~~~^^
  File "…/python3.14/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 476: ordinal not in range(128)
make: *** [conformance-python] Error 1
```

**RED — the seventh site, `make conformance-runner-tests-python` under the same
env with only `test_replay_runner.py` reverted, `REAL_EXIT=2`:**

```
FAILED test_replay_runner.py::DecoderCoverageTest::test_no_decoder_for_an_unknown_operation - UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 2896: ordinal not in range(128)
2 failed, 41 passed, 31 subtests passed
```

For completeness, the run that motivates `PYTHONUTF8: '0'` —
**`LC_ALL=C make conformance-python` pre-fix, `REAL_EXIT=0`**, `201 passed,
0 failed, 0 skipped`. `LC_ALL` on its own is green against the broken code.

**GREEN, all four, after the fix:**

| command | result |
|---|---|
| `LC_ALL=C make conformance-ruby` | `190 passed, 0 failed, 11 skipped`, `REAL_EXIT=0` |
| `LC_ALL=C PYTHONUTF8=0 PYTHONIOENCODING=utf-8 make conformance-python` | `201 passed, 0 failed, 0 skipped`, `REAL_EXIT=0` |
| `LC_ALL=C make conformance-runner-tests-ruby` | `9 runs, 13 assertions, 0 failures`, `REAL_EXIT=0` |
| `LC_ALL=C PYTHONUTF8=0 PYTHONIOENCODING=utf-8 make conformance-runner-tests-python` | `43 passed, 31 subtests passed`, `REAL_EXIT=0` |

Also green under `LC_ALL=C`: `make rb-check`, `make py-check`, `make
lint-actions` (actionlint + zizmor, `No findings to report`), `make
doc-constants-check`.

### The gate is not vacuous on the OS that will run it

The probes above are macOS/arm64; `test-python` is `ubuntu-latest`. PEP 538
C-locale coercion is a real way this leg could have been green-by-default on
Linux and nowhere else, so it was checked on glibc (Arch, CPython 3.14) rather
than assumed:

```
--- LC_ALL=C ---
  utf8_mode= 1  getencoding= ANSI_X3.4-1968  preferred= utf-8         read_text() -> 'café'
--- LC_ALL=C PYTHONCOERCECLOCALE=0 ---
  utf8_mode= 1  getencoding= ANSI_X3.4-1968  preferred= utf-8         read_text() -> 'café'
--- LC_ALL=C PYTHONUTF8=0 ---
  utf8_mode= 0  getencoding= ANSI_X3.4-1968  preferred= ANSI_X3.4-1968  read_text() RAISED UnicodeDecodeError
--- LC_ALL=C PYTHONUTF8=0 PYTHONCOERCECLOCALE=0 ---
  utf8_mode= 0  getencoding= ANSI_X3.4-1968  preferred= ANSI_X3.4-1968  read_text() RAISED UnicodeDecodeError
```

`getencoding()` stays `ANSI_X3.4-1968` in every row, so **coercion never fires
and `PYTHONCOERCECLOCALE` is inert** — PEP 538 skips coercion outright when
`LC_ALL` is set, which is exactly how this step spells the locale. Two env vars
are the whole requirement on both platforms.

End to end on that Linux box, on this branch:

| run | result |
|---|---|
| `LC_ALL=C PYTHONUTF8=0 PYTHONIOENCODING=utf-8 make conformance-python` | `201 passed, 0 failed, 0 skipped`, `REAL_EXIT=0` |
| the same, with **only** `runner.py:140`'s `encoding="utf-8"` removed (`cp` restore, `diff -q` clean after) | `UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 476`, `REAL_EXIT=2` |

## CI: the real gap

Nothing held the fix. The six conformance steps —
`.github/workflows/test.yml:452` (Go), `:542` (TS), `:648` (Ruby), `:764`
(Python), `:852` (Swift), `:941` (Kotlin), fan-in gate at `:972` — set no locale
between them. Meanwhile the repo-wide gates in `spec-gates` and
`fixture-coverage` already run under `LC_ALL: C` on purpose, and `test-ruby`
already carries a dedicated `Test (LC_ALL=C)` leg **in the same job** as its
unpinned conformance step.

Three steps now set the locale, all of them Ruby or Python:

- **Run Ruby conformance tests** — `LC_ALL: C`
- **Run Python conformance tests** — `LC_ALL: C`, `PYTHONUTF8: '0'`, `PYTHONIOENCODING: utf-8`
- **Run Python conformance runner unit tests** — the same trio, because this PR
  pins a read in that suite too and an ungated pin is the exact failure #774 is
  about

### Why not all six

Go, TypeScript, Swift and Kotlin are safe *by construction*, not by luck, so a
locale on their steps would guard nothing and cost a per-language contract
nobody asked for. Read before deciding:

| SDK | reads | why locale cannot reach it |
|---|---|---|
| Go | `os.ReadFile` / `os.Open` (`schema_walker.go:46`, `case_census.go:90`, `replay_runner.go:256`/`:321`/`:423`, `main.go:254`) | returns `[]byte`; `encoding/json` decodes UTF-8 unconditionally |
| TypeScript | `fs.readFileSync(…, "utf-8")` (`case-census.ts:101`, `schema-validator.ts:56`, both test files) | encoding already an explicit argument at every site |
| Swift | `Data(contentsOf:)` → `JSONDecoder` (`Runner.swift:107`, `CaseCensus.swift:141`) | bytes in, `JSONDecoder` sniffs UTF-8/16/32 per RFC 4627 |
| Kotlin | `File.readText()` (`SchemaWalker.kt:41`, `CaseCensus.kt:107`, `ReplayRunner.kt:164`/`:203`/`:317`, `Main.kt:262`) | `readText(charset: Charset = Charsets.UTF_8)` — the default is a constant, not the locale |

If one of those four turns out to have a latent hole, that is an issue to file
with its own red proof, not a silent env addition here.

## The write class: audited, attacked, and left alone

Pinning every read makes the writes the obvious next target, so they were swept
deliberately rather than incidentally. There are four, all the same shape, plus
none at all in either schema walker (they only read):

| site | call | verdict |
|---|---|---|
| `ruby/runner.rb:196` | `File.write(…, JSON.pretty_generate(body))` — execution manifest | safe unconditionally |
| `ruby/replay-runner.rb:117` | `File.write(…, JSON.pretty_generate(result))` | safe unconditionally |
| `python/runner.py:199` | `write_text(json.dumps(body, indent=2))` — execution manifest | safe **by a default** |
| `python/replay_runner.py:244` | `write_text(json.dumps(result, indent=2))` | safe **by a default** |

All four carry case names straight out of the fixtures, so all four can be
handed non-ASCII.

### Ruby: the red would not materialize, so nothing was patched

The predicted failure was `Encoding::UndefinedConversionError`: default external
encoding is US-ASCII under `LC_ALL=C`, the manifest holds fixture-sourced case
names, therefore the write should transcode and blow up. It does not.

An existing skipped case was renamed to `PUT operation is naturally idempotent —
café` in both `conformance/tests/idempotency.json` and `RUBY_SKIPS`, and the
suite run under `LC_ALL=C`:

```
Results: 190 passed, 0 failed, 11 skipped (fixtures declare 201 non-live case(s))
REAL_EXIT=0
```

```
conformance/manifests/ruby.json:33:      "name": "PUT operation is naturally idempotent — café",
```

Green, and the name reached the manifest as intact UTF-8. Both files restored by
`cp`, `diff -q` clean. The mechanism, probed directly and **identically on macOS
and Linux**:

```
default_external=#<Encoding:US-ASCII> string=#<Encoding:UTF-8>
File.write(str)              -> OK, first bytes [80, 85, 84, 32, 111, 112]
File.write(pretty_generate)  -> OK, contains raw UTF-8: true
File.write(..., US-ASCII)    -> RAISED Encoding::UndefinedConversionError
puts(str)                    -> PUT operation is naturally idempotent — café
```

`Encoding.default_external` governs how a read **decodes**; `File.write` emits
the string's own bytes and transcodes only when handed an explicit `encoding:`.
The read/write asymmetry is the whole story. `encoding: "UTF-8"` on those two
lines would be inert — and reaching for the locale's encoding instead is the
only way to actually break them. No red, no patch; a comment at each site
records it so the next reader does not re-derive it or "finish the job".

### Python: safe, but on a default someone could delete

`json.dumps` defaults to `ensure_ascii=True`, so the payload is pure ASCII before
`write_text()` ever sees it. That is the only thing holding it, and **this PR is
what arms the trap** — under the `LC_ALL=C PYTHONUTF8=0` now set on the
conformance step:

```
json.dumps(indent=2)                     -> OK (payload is pure ASCII: True)
json.dumps(indent=2, ensure_ascii=False) -> RAISED UnicodeEncodeError: 'ascii' codec can't encode character '—' in position 51: ordinal not in range(128)
```

`ensure_ascii=False` is exactly the sort of change someone makes to get readable
manifests. Both Python write sites now say so in place, and say to pass an
`encoding=` rather than just flipping the flag.

## Two corrections to the record

**#774 as filed is Ruby-only.** It names `runner.rb:121`, labels the issue
`ruby`, and says only that the other five runners are "worth checking". Six of
the seven Python sites are the same defect in the same directory, and the
seventh is in the suite that unit-tests the runner. All are fixed here.

**"conformance has no PR CI coverage" would be false**, and this PR does not
claim it. The comment at `test.yml:753` says the *aggregate* `make conformance`
target is not run in PR CI — true, and the reason the fixture-schema gates are
invoked directly in the Python job. All six runners do run their conformance
suite in PR CI, each inside its own language job, with a fan-in gate at `:972`
that fails if any of them did not succeed. What was missing was a locale, not
the coverage.
