### PR TITLE
Deflake three tests that raced a wall clock, and gate the class that produced two of them

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -511,6 +511,20 @@ jobs:
       - name: Lint
         run: npm run lint
 
+      # Two steps, deliberately. The self-test comes FIRST and is not optional:
+      # oxlint's JS plugin API is alpha and un-semvered behind a caret range, so
+      # a bump that stopped dispatching the rule's visitor would leave the gate
+      # below exiting 0 while enforcing nothing. The self-test asserts the rule
+      # still fires on the shapes #783 removed, so that fail-open reds here.
+      #
+      # `make ts-check` runs both too, but no CI job runs `make check`, so
+      # membership in a make target is not CI coverage in this repo.
+      - name: Self-test the timer-scheduled-abort lint rule
+        run: npm run test:lint-rules
+
+      - name: Check for timer-scheduled aborts in tests
+        run: npm run lint:test-timers
+
       - name: Type check
         run: npm run typecheck
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -134,22 +134,39 @@ The same rule reads sideways in Ruby: a value written by a server thread is
 read by the test only across an explicit happens-before edge — a `Queue`, or a
 `join` — never "in practice, via the socket close" (#739).
 
-#655 swept for this class and missed two instances, because its selector
-required a **no-argument** `abort()` and both survivors passed a reason (#783).
-The sweep is a manual `rg`, not a gate, so the corrected form lives here:
+**This half is enforced, so you should not need to remember it.**
+`typescript/lint-rules/no-timer-scheduled-abort.js` is an oxlint rule that fails
+the build on a timer-scheduled `abort()` anywhere under `typescript/tests/`:
 
 ```sh
-# The class, without spelling the abort's arguments or its receiver:
-rg -nU --pcre2 'setTimeout\([\s\S]{0,300}?\.abort\(' typescript/tests
+cd typescript && npm run test:lint-rules && npm run lint:test-timers
 ```
 
-It over-matches — a `setTimeout` and an unrelated `.abort(` within 300
-characters both hit — and that bias is deliberate: a false positive costs a
-glance, a false negative costs the next contributor an hour deciding whether
-they caused somebody else's red. It still cannot see an abort scheduled through
-a wrapper or a renamed timer, so treat `rg -n '\.abort\(' typescript/tests` as
-the real population bound and classify each site by *what makes the abort
-land*, not by the shape it is written in.
+Both run in `make ts-check` and as their own steps in the TypeScript CI job. Run
+the self-test first and always — oxlint's JS plugin API is alpha, so a version
+bump could disarm the rule silently, and the self-test is what turns that into a
+build failure instead of a green gate enforcing nothing.
+
+A test whose *subject* is a caller's own timer-driven abort is a legitimate
+exception; suppress it at the site with the reason, never by widening the rule:
+
+```ts
+// oxlint-disable-next-line basecamp-tests/no-timer-scheduled-abort -- why
+```
+
+#655 tried to scope this class with an `rg` typed into an issue body that
+required a **no-argument** `abort()`. Both survivors passed a reason, so they
+shipped and one later went red in CI (#783) — which is why the rule reads syntax
+rather than text: it can tell a timer that *schedules* an abort from one the
+abort is merely racing, and a proximity selector cannot.
+
+**What the rule does not cover** is stated in its own header rather than
+restated here: a renamed timer, a callback passed by reference, a computed
+`.abort` access. The honest population bound is
+`rg -n '\.abort\(' typescript/tests` — classify each site by *what makes the
+abort land*, not by the shape it is written in. The rest of this rule, above,
+is judgment the linter cannot hold: which assertion is the discriminating one,
+and when a wall-clock ceiling is redundant with it.
 
 ## Commit Conventions
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -118,6 +118,39 @@ A Basecamp account is optional (for integration testing only).
 - Mock HTTP responses using `httptest`
 - Test both success and error paths
 
+#### Never schedule a cancellation on a wall clock
+
+A test that arms `setTimeout(… abort …, N)` and races it against a mocked
+response is asserting machine load, not behavior. Abort from a seam that proves
+the request is already in flight: from inside the MSW handler
+(`typescript/tests/client.test.ts`), or from the retry hook the loop fires
+immediately before it sleeps (`typescript/tests/retry-after.test.ts`,
+`typescript/tests/middleware-lifecycle.test.ts`). Then drop any accompanying
+`Date.now() - startedAt < N` bound — the error's identity (`AbortError` vs
+`TimeoutError`, or `err === reason`) and the attempt ledger already
+discriminate, and the ceiling contributes only load sensitivity.
+
+The same rule reads sideways in Ruby: a value written by a server thread is
+read by the test only across an explicit happens-before edge — a `Queue`, or a
+`join` — never "in practice, via the socket close" (#739).
+
+#655 swept for this class and missed two instances, because its selector
+required a **no-argument** `abort()` and both survivors passed a reason (#783).
+The sweep is a manual `rg`, not a gate, so the corrected form lives here:
+
+```sh
+# The class, without spelling the abort's arguments or its receiver:
+rg -nU --pcre2 'setTimeout\([\s\S]{0,300}?\.abort\(' typescript/tests
+```
+
+It over-matches — a `setTimeout` and an unrelated `.abort(` within 300
+characters both hit — and that bias is deliberate: a false positive costs a
+glance, a false negative costs the next contributor an hour deciding whether
+they caused somebody else's red. It still cannot see an abort scheduled through
+a wrapper or a renamed timer, so treat `rg -n '\.abort\(' typescript/tests` as
+the real population bound and classify each site by *what makes the abort
+land*, not by the shape it is written in.
+
 ## Commit Conventions
 
 We follow [Conventional Commits](https://www.conventionalcommits.org/) for clear, structured commit history.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -181,9 +181,11 @@ abort is merely racing, and a proximity selector cannot.
 **What the rule does not cover** is stated in its own header rather than
 restated here: a renamed timer, a callback passed by reference, a computed
 `.abort` access whose key is not a literal. The honest population bound is
-`rg -n 'abort\s*\(|\["abort"\]\s*\(' typescript/tests` — every spelling the
-rule treats as an abort, not dot-member access alone, so a later sweep cannot
-come back clean while a bare `abort()` or `controller["abort"]()` is live.
+`rg -n "abort\s*\(|\[[\"']abort[\"']\]\s*\(" typescript/tests` — every spelling
+the rule treats as an abort, not dot-member access alone, so a later sweep
+cannot come back clean while a bare `abort()`, a `controller["abort"]()` or a
+`controller['abort']()` is live (the rule reads the literal's value, so either
+quote style is an abort to it).
 Classify each site by *what makes the abort land*, not by the shape it is
 written in. The rest of this rule, above,
 is judgment the linter cannot hold: which assertion is the discriminating one,

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -125,10 +125,28 @@ response is asserting machine load, not behavior. Abort from a seam that proves
 the request is already in flight: from inside the MSW handler
 (`typescript/tests/client.test.ts`), or from the retry hook the loop fires
 immediately before it sleeps (`typescript/tests/retry-after.test.ts`,
-`typescript/tests/middleware-lifecycle.test.ts`). Then drop any accompanying
-`Date.now() - startedAt < N` bound — the error's identity (`AbortError` vs
-`TimeoutError`, or `err === reason`) and the attempt ledger already
-discriminate, and the ceiling contributes only load sensitivity.
+`typescript/tests/middleware-lifecycle.test.ts`). Then replace any accompanying
+`Date.now() - startedAt < N` bound. Usually there is nothing to put in its
+place: the error's identity (`AbortError` vs `TimeoutError`, or
+`err === reason`) and the attempt ledger already discriminate, and the ceiling
+was contributing only load sensitivity.
+
+**But check what the ceiling was carrying before you delete it.** If the named
+behavior is *promptness* — "rejects as soon as the abort lands" rather than
+"rejects with the right reason, eventually" — identity and the ledger do not
+cover it: a sleep that notices the abort and then waits out its timer anyway
+satisfies both, late. Assert promptness by freezing the clock instead of
+bounding it. Fake `setTimeout`/`clearTimeout` (`vi.useFakeTimers({ toFake: […] })`),
+never advance it, and assert the request settled after a barrier counted in
+event-loop turns (`setImmediate`), not milliseconds — a delay that only the test
+can release cannot have been waited out. `middleware-lifecycle.test.ts`'s
+"rejects promptly when the caller aborts during a retry backoff" is the worked
+example; the mutant it kills is precisely the sleep described above.
+
+Restore real timers from the suite's `afterEach`, not from the test's own
+`finally`: a timed-out test is never resumed, so its `finally` does not run —
+and a hung test is exactly the failure a broken abort produces — which would
+leak a frozen clock into every test after it.
 
 The same rule reads sideways in Ruby: a value written by a server thread is
 read by the test only across an explicit happens-before edge — a `Queue`, or a

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -162,9 +162,12 @@ abort is merely racing, and a proximity selector cannot.
 
 **What the rule does not cover** is stated in its own header rather than
 restated here: a renamed timer, a callback passed by reference, a computed
-`.abort` access. The honest population bound is
-`rg -n '\.abort\(' typescript/tests` — classify each site by *what makes the
-abort land*, not by the shape it is written in. The rest of this rule, above,
+`.abort` access whose key is not a literal. The honest population bound is
+`rg -n 'abort\s*\(|\["abort"\]\s*\(' typescript/tests` — every spelling the
+rule treats as an abort, not dot-member access alone, so a later sweep cannot
+come back clean while a bare `abort()` or `controller["abort"]()` is live.
+Classify each site by *what makes the abort land*, not by the shape it is
+written in. The rest of this rule, above,
 is judgment the linter cannot hold: which assertion is the discriminating one,
 and when a wall-clock ceiling is redundant with it.
 

--- a/Makefile
+++ b/Makefile
@@ -413,7 +413,7 @@ auth-routable-check:
 # TypeScript SDK targets
 #------------------------------------------------------------------------------
 
-.PHONY: ts-install ts-generate ts-generate-services ts-build ts-test ts-typecheck ts-check ts-check-drift ts-clean
+.PHONY: ts-install ts-generate ts-generate-services ts-build ts-test ts-typecheck ts-check ts-check-drift ts-lint-test-timers ts-clean
 
 TS_NODE_STAMP := typescript/node_modules/.install-stamp
 
@@ -463,8 +463,23 @@ ts-check-drift: ts-install
 	@echo "==> Checking TypeScript generated code drift..."
 	@./scripts/check-typescript-service-drift.sh
 
+# Forbid scheduling an abort() on a wall-clock timer in typescript/tests/ — the
+# shape that flaked in #655 and again in #783. An oxlint JS plugin rather than a
+# grep: the AST can tell a timer that SCHEDULES the abort from one the abort is
+# racing, and a proximity selector cannot (see the rule's header).
+#
+# The self-test runs beside it, not only when someone edits the rule. oxlint's
+# JS plugin API is alpha and un-semvered behind a caret range, so a bump that
+# stopped dispatching the visitor would leave lint-test-timers exiting 0 while
+# matching nothing; the self-test asserts the rule still FIRES on the two forms
+# #783 removed, which turns that fail-open into a build failure.
+ts-lint-test-timers: ts-install
+	@echo "==> Checking for timer-scheduled aborts in TypeScript tests..."
+	cd typescript && npm run --silent test:lint-rules
+	cd typescript && npm run --silent lint:test-timers
+
 # Run all TypeScript checks
-ts-check: ts-check-drift ts-typecheck ts-test
+ts-check: ts-check-drift ts-typecheck ts-lint-test-timers ts-test
 	@echo "==> TypeScript SDK checks passed"
 
 # Clean TypeScript build artifacts

--- a/ruby/test/basecamp/oauth_transport_test.rb
+++ b/ruby/test/basecamp/oauth_transport_test.rb
@@ -815,13 +815,30 @@ class OAuthTransportTest < Minitest::Test
     # credentials or authenticated proxies reject the request.
     proxy = TCPServer.new("127.0.0.1", 0)
     @servers << proxy
-    captured = +""
+    # The preamble is HANDED ACROSS a Queue rather than shared as a mutable
+    # String (#739). The old form appended to a `captured = +""` that the main
+    # thread read the instant assert_raises returned, with no join, queue or
+    # condvar between them — it was ordered only in practice, by the socket
+    # close, and the client's own `timeout: 1` can fire while the proxy is
+    # still mid-gets on a loaded runner. That failure reads as absent
+    # credentials, which points at percent-decoding, which is not the bug.
+    #
+    # Queue rather than Thread#join: join also establishes the happens-before
+    # edge, but a join(timeout) that returns nil leaves you reading the shared
+    # String with no edge at all — the race re-enters through the hang guard.
+    # Here the VALUE's existence is the evidence: it can only be popped if the
+    # producer finished reading the preamble, so a wedged producer is a
+    # distinguishable, explicitly-reported failure instead of an empty match.
+    # Same idiom as this file's other header-capture tests.
+    captured = Queue.new
     @server_threads << Thread.new do
       conn = proxy.accept
       @conns << conn
+      lines = []
       while (line = conn.gets) && line != "\r\n"
-        captured << line
+        lines << line
       end
+      captured << lines.join
       conn.close
     rescue IOError, SystemCallError
       nil
@@ -833,8 +850,15 @@ class OAuthTransportTest < Minitest::Test
       assert_raises(Faraday::Error) do
         Basecamp::Oauth::Fetcher.stream_http(:get, "https://proxy-auth.test/token", timeout: 1)
       end
+      # A WAIT bound, not a timing assertion: this test is about content, so a
+      # generous wait costs nothing (unlike the sub-second bounds #734 kept on
+      # the siblings, where the margin between correct and broken IS the
+      # deadline).
+      preamble = captured.pop(timeout: 15)
+      assert preamble, \
+        "the proxy never finished reading the CONNECT preamble — nothing was handed over to assert against"
       expected = [ "user:p@s+s" ].pack("m0")
-      assert_includes captured, "Proxy-Authorization: Basic #{expected}"
+      assert_includes preamble, "Proxy-Authorization: Basic #{expected}"
     end
   end
 

--- a/typescript/lint-rules/no-timer-scheduled-abort.js
+++ b/typescript/lint-rules/no-timer-scheduled-abort.js
@@ -28,7 +28,8 @@
  * `setTimeout` / `setInterval`, spelled bare or as a member access
  * (`globalThis.setTimeout`, `window.setTimeout`). Nesting is followed: an abort
  * inside a function inside the timer callback still reports, because the timer
- * is still what schedules it.
+ * is still what schedules it. So is type-only syntax around the callback —
+ * `as`, `satisfies`, `!` — which changes the AST without changing what runs.
  *
  * ## What it cannot see
  *
@@ -47,10 +48,16 @@
  * So this holds a SYNTACTIC invariant across the call sites its matcher
  * recognizes, including ones not written yet. It does not observe what a test
  * does at runtime, and it is not the whole guarantee — the population bound is
- * `rg -n '\.abort\(' typescript/tests`, and each site should be classified by
- * what makes the abort land. At the time this rule was written that was 14 call
- * sites: stubbed sleep or fetch 5, MSW handler 3, retry hook 3, already aborted
- * before the call 2, synchronous after dispatch 1. None timer-scheduled.
+ *
+ *     rg -n 'abort\s*\(|\["abort"\]\s*\(' typescript/tests
+ *
+ * which covers every spelling the rule recognizes (`x.abort(`, bare `abort(`,
+ * `x["abort"](`) rather than dot-member access alone, so a sweep cannot report
+ * clean while a form the rule treats as an abort is live. Each site should be
+ * classified by what makes the abort land. At the time this rule was written
+ * that was 14 call sites: stubbed sleep or fetch 5, MSW handler 3, retry hook
+ * 3, already aborted before the call 2, synchronous after dispatch 1. None
+ * timer-scheduled, and the two spellings return the same set today.
  *
  * ## Suppressing it
  *
@@ -102,6 +109,31 @@ function isFunction(node) {
   );
 }
 
+/**
+ * Type-only syntax that can sit between a callback and the call it is an
+ * argument of. These wrap the function in an extra AST node while erasing to
+ * nothing at runtime, so `setTimeout((() => c.abort()) as () => void, 50)` has
+ * a TSAsExpression — not the arrow function — as `arguments[0]`. Comparing the
+ * function itself against `arguments[0]` therefore missed every one of them.
+ */
+const TYPE_ONLY_WRAPPERS = new Set([
+  "TSAsExpression",
+  "TSSatisfiesExpression",
+  "TSNonNullExpression",
+  "TSTypeAssertion",
+  "TSInstantiationExpression",
+  "ParenthesizedExpression",
+]);
+
+/** The outermost node that IS `node` once type-only syntax is erased. */
+function withTypeWrappers(node) {
+  let outermost = node;
+  while (outermost.parent && TYPE_ONLY_WRAPPERS.has(outermost.parent.type)) {
+    outermost = outermost.parent;
+  }
+  return outermost;
+}
+
 const rule = {
   meta: {
     type: "problem",
@@ -120,12 +152,15 @@ const rule = {
         // directly at any nesting depth without a hand-rolled subtree walk.
         for (let current = node.parent; current; current = current.parent) {
           if (!isFunction(current)) continue;
-          const parent = current.parent;
+          // Compare the callback WITH any type-only wrappers around it: those
+          // are what the call actually holds as `arguments[0]`.
+          const callback = withTypeWrappers(current);
+          const parent = callback.parent;
           if (
             parent &&
             parent.type === "CallExpression" &&
             isTimerCall(parent) &&
-            parent.arguments[0] === current
+            parent.arguments[0] === callback
           ) {
             context.report({
               node,

--- a/typescript/lint-rules/no-timer-scheduled-abort.js
+++ b/typescript/lint-rules/no-timer-scheduled-abort.js
@@ -1,0 +1,149 @@
+/**
+ * oxlint JS plugin: no-timer-scheduled-abort.
+ *
+ * Forbids scheduling an `abort()` on a wall-clock timer inside
+ * `typescript/tests/`. A test that arms `setTimeout(() => controller.abort(), N)`
+ * and races it against a mocked response is asserting machine load, not
+ * behavior: it passes when the scheduler is prompt and reds when it is not, on
+ * somebody else's unrelated PR.
+ *
+ * Abort from a seam that proves the request is already in flight instead —
+ * inside the MSW handler, or from the retry hook the loop fires immediately
+ * before it sleeps. See CONTRIBUTING.md, "Never schedule a cancellation on a
+ * wall clock".
+ *
+ * ## Why this rule exists at all
+ *
+ * #655 fixed one instance of this shape and declared the class contained,
+ * scoping itself with an `rg` typed into an issue body that required a
+ * NO-ARGUMENT `abort()`. Two instances passing a reason were live in
+ * `middleware-lifecycle.test.ts` at that moment and shipped anyway; one of them
+ * went red in CI two months later (#783). There was no instrument to reassess,
+ * so this is the first one.
+ *
+ * ## What it recognizes
+ *
+ * A call to something named `abort` — `x.abort(…)`, `x["abort"](…)`, or a bare
+ * `abort(…)` — lexically inside a function passed as the FIRST argument of
+ * `setTimeout` / `setInterval`, spelled bare or as a member access
+ * (`globalThis.setTimeout`, `window.setTimeout`). Nesting is followed: an abort
+ * inside a function inside the timer callback still reports, because the timer
+ * is still what schedules it.
+ *
+ * ## What it cannot see
+ *
+ * State this honestly rather than claiming every call site (AGENTS.md):
+ *
+ *   - a timer function reached under another name — `const later = setTimeout`,
+ *     an import alias, a wrapper such as `delay(() => c.abort(), 50)`;
+ *   - a callback passed by reference rather than written inline —
+ *     `setTimeout(cancel, 50)` where `cancel` aborts;
+ *   - a computed abort access whose key is not a literal — `c[method]()`;
+ *   - anything outside `typescript/tests/`, which is deliberate: production
+ *     code schedules aborts on timers legitimately (`src/client.ts`,
+ *     `src/download.ts`, `src/oauth/*`) and those are request timeouts, not
+ *     test assertions.
+ *
+ * So this holds a SYNTACTIC invariant across the call sites its matcher
+ * recognizes, including ones not written yet. It does not observe what a test
+ * does at runtime, and it is not the whole guarantee — the population bound is
+ * `rg -n '\.abort\(' typescript/tests`, and each site should be classified by
+ * what makes the abort land. At the time this rule was written that was 14 call
+ * sites: stubbed sleep or fetch 5, MSW handler 3, retry hook 3, already aborted
+ * before the call 2, synchronous after dispatch 1. None timer-scheduled.
+ *
+ * ## Suppressing it
+ *
+ * A test whose SUBJECT is a caller's own timer-driven abort is a legitimate
+ * exception. Suppress at the site, with the reason, so a reader can evaluate
+ * it — never widen the matcher to be blind to a shape:
+ *
+ *     // oxlint-disable-next-line basecamp-tests/no-timer-scheduled-abort -- why
+ *
+ * ## Fail-closed
+ *
+ * oxlint's JS plugin API is alpha and explicitly not covered by semver, and
+ * `oxlint` here is a caret range. If a bump changed the API such that this rule
+ * silently stopped matching, the gate would pass while enforcing nothing.
+ * `lint-rules/test-no-timer-scheduled-abort.mjs` is what makes that loud: it
+ * asserts the rule still FIRES on the two forms this repo removed, so an API
+ * break fails the build instead of disarming it. Run it wherever this rule
+ * runs.
+ */
+
+const TIMER_NAMES = new Set(["setTimeout", "setInterval"]);
+
+/** `setTimeout(…)`, `globalThis.setTimeout(…)`, `window.setTimeout(…)`. */
+function isTimerCall(node) {
+  const callee = node.callee;
+  if (callee.type === "Identifier") return TIMER_NAMES.has(callee.name);
+  if (callee.type === "MemberExpression" && !callee.computed && callee.property.type === "Identifier") {
+    return TIMER_NAMES.has(callee.property.name);
+  }
+  return false;
+}
+
+/** `x.abort(…)`, `x["abort"](…)`, bare `abort(…)`. */
+function isAbortCall(node) {
+  const callee = node.callee;
+  if (callee.type === "Identifier") return callee.name === "abort";
+  if (callee.type !== "MemberExpression") return false;
+  if (!callee.computed) {
+    return callee.property.type === "Identifier" && callee.property.name === "abort";
+  }
+  return callee.property.type === "Literal" && callee.property.value === "abort";
+}
+
+function isFunction(node) {
+  return (
+    node.type === "ArrowFunctionExpression" ||
+    node.type === "FunctionExpression" ||
+    node.type === "FunctionDeclaration"
+  );
+}
+
+const rule = {
+  meta: {
+    type: "problem",
+    docs: {
+      description: "Disallow scheduling an abort() on a wall-clock timer in tests",
+    },
+    schema: [],
+  },
+  create(context) {
+    return {
+      CallExpression(node) {
+        if (!isAbortCall(node)) return;
+
+        // Walk UP rather than descending from the timer: the question is
+        // "what schedules this abort?", and the ancestor chain answers it
+        // directly at any nesting depth without a hand-rolled subtree walk.
+        for (let current = node.parent; current; current = current.parent) {
+          if (!isFunction(current)) continue;
+          const parent = current.parent;
+          if (
+            parent &&
+            parent.type === "CallExpression" &&
+            isTimerCall(parent) &&
+            parent.arguments[0] === current
+          ) {
+            context.report({
+              node,
+              message:
+                "Do not schedule abort() on a wall-clock timer in a test — it races machine " +
+                "load. Abort from a seam that proves the request is in flight (inside the MSW " +
+                "handler, or from the retry hook fired immediately before the backoff sleep). " +
+                "See CONTRIBUTING.md, 'Never schedule a cancellation on a wall clock'.",
+            });
+            return;
+          }
+        }
+      },
+    };
+  },
+};
+
+export default {
+  meta: { name: "basecamp-tests" },
+  rules: { "no-timer-scheduled-abort": rule },
+};

--- a/typescript/lint-rules/no-timer-scheduled-abort.js
+++ b/typescript/lint-rules/no-timer-scheduled-abort.js
@@ -26,7 +26,9 @@
  * A call to something named `abort` — `x.abort(…)`, `x["abort"](…)`, or a bare
  * `abort(…)` — lexically inside a function passed as the FIRST argument of
  * `setTimeout` / `setInterval`, spelled bare or as a member access
- * (`globalThis.setTimeout`, `window.setTimeout`). Nesting is followed: an abort
+ * (`globalThis.setTimeout`, `window.setTimeout`, `globalThis["setTimeout"]` —
+ * like the abort, a computed property is read by its literal VALUE, so the
+ * quote style is invisible). Nesting is followed: an abort
  * inside a function inside the timer callback still reports, because the timer
  * is still what schedules it. So is type-only syntax around the callback —
  * `as`, `satisfies`, `!` — which changes the AST without changing what runs.
@@ -39,7 +41,8 @@
  *     an import alias, a wrapper such as `delay(() => c.abort(), 50)`;
  *   - a callback passed by reference rather than written inline —
  *     `setTimeout(cancel, 50)` where `cancel` aborts;
- *   - a computed abort access whose key is not a literal — `c[method]()`;
+ *   - a computed abort or timer access whose key is not a literal —
+ *     `c[method]()`, `globalThis[timer](…)`;
  *   - anything outside `typescript/tests/`, which is deliberate: production
  *     code schedules aborts on timers legitimately (`src/client.ts`,
  *     `src/download.ts`, `src/oauth/*`) and those are request timeouts, not
@@ -82,14 +85,15 @@
 
 const TIMER_NAMES = new Set(["setTimeout", "setInterval"]);
 
-/** `setTimeout(…)`, `globalThis.setTimeout(…)`, `window.setTimeout(…)`. */
+/** `setTimeout(…)`, `globalThis.setTimeout(…)`, `globalThis["setTimeout"](…)`. */
 function isTimerCall(node) {
   const callee = node.callee;
   if (callee.type === "Identifier") return TIMER_NAMES.has(callee.name);
-  if (callee.type === "MemberExpression" && !callee.computed && callee.property.type === "Identifier") {
-    return TIMER_NAMES.has(callee.property.name);
+  if (callee.type !== "MemberExpression") return false;
+  if (!callee.computed) {
+    return callee.property.type === "Identifier" && TIMER_NAMES.has(callee.property.name);
   }
-  return false;
+  return callee.property.type === "Literal" && TIMER_NAMES.has(callee.property.value);
 }
 
 /** `x.abort(…)`, `x["abort"](…)`, bare `abort(…)`. */

--- a/typescript/lint-rules/no-timer-scheduled-abort.js
+++ b/typescript/lint-rules/no-timer-scheduled-abort.js
@@ -49,10 +49,12 @@
  * recognizes, including ones not written yet. It does not observe what a test
  * does at runtime, and it is not the whole guarantee — the population bound is
  *
- *     rg -n 'abort\s*\(|\["abort"\]\s*\(' typescript/tests
+ *     rg -n "abort\s*\(|\[[\"']abort[\"']\]\s*\(" typescript/tests
  *
  * which covers every spelling the rule recognizes (`x.abort(`, bare `abort(`,
- * `x["abort"](`) rather than dot-member access alone, so a sweep cannot report
+ * `x["abort"](` and `x['abort'](` — `isAbortCall` reads the literal's VALUE,
+ * so the quote style is invisible to it and must not be visible to the sweep
+ * either) rather than dot-member access alone, so a sweep cannot report
  * clean while a form the rule treats as an abort is live. Each site should be
  * classified by what makes the abort land. At the time this rule was written
  * that was 14 call sites: stubbed sleep or fetch 5, MSW handler 3, retry hook

--- a/typescript/lint-rules/oxlintrc.json
+++ b/typescript/lint-rules/oxlintrc.json
@@ -1,0 +1,16 @@
+{
+  "$schema": "../node_modules/oxlint/configuration_schema.json",
+  "jsPlugins": ["./no-timer-scheduled-abort.js"],
+  "categories": {
+    "correctness": "off",
+    "nursery": "off",
+    "pedantic": "off",
+    "perf": "off",
+    "restriction": "off",
+    "style": "off",
+    "suspicious": "off"
+  },
+  "rules": {
+    "basecamp-tests/no-timer-scheduled-abort": "error"
+  }
+}

--- a/typescript/lint-rules/test-no-timer-scheduled-abort.mjs
+++ b/typescript/lint-rules/test-no-timer-scheduled-abort.mjs
@@ -66,14 +66,18 @@ export const abortTimer = setTimeout(() => controller.abort(), 50);
   ],
   [
     // Spelling variations the original rg could not have seen. If the rule
-    // regressed to text matching, these are the first to go quiet.
-    "block body, member-spelled timer, computed abort, nested function",
+    // regressed to text matching, these are the first to go quiet. The
+    // computed access is spelled with both quote styles on purpose: the rule
+    // reads the literal's VALUE, and the documented population sweep has to
+    // match both too (review follow-up, Copilot).
+    "block body, member-spelled timer, computed abort in both quote styles, nested function",
     `const controller = new AbortController();
 export const a = globalThis.setTimeout(() => { controller.abort(); }, 10);
 export const b = setInterval(function () { controller["abort"](); }, 10);
 export const c = setTimeout(() => { const inner = () => controller.abort(); inner(); }, 10);
+export const d = setInterval(() => { controller['abort'](); }, 10);
 `,
-    [2, 3, 4],
+    [2, 3, 4, 5],
   ],
   [
     // Review follow-up (Copilot). TypeScript-only syntax between the callback

--- a/typescript/lint-rules/test-no-timer-scheduled-abort.mjs
+++ b/typescript/lint-rules/test-no-timer-scheduled-abort.mjs
@@ -24,6 +24,25 @@ import { fileURLToPath } from "node:url";
 
 const HERE = dirname(fileURLToPath(import.meta.url));
 const CONFIG = join(HERE, "oxlintrc.json");
+const OXLINT = join(HERE, "..", "node_modules", ".bin", "oxlint");
+
+/**
+ * `--format json`, and every case is run twice — once with `GITHUB_ACTIONS`
+ * unset and once with it set.
+ *
+ * The first CI run of this gate failed for exactly this reason: oxlint detects
+ * `GITHUB_ACTIONS` and switches to the `##[error]…` annotation format, which the
+ * original line-scraping parser did not match. The rule was firing perfectly;
+ * the harness could not see it. That is a harness that reads differently on the
+ * machine that matters, so the environment is now part of the matrix rather
+ * than something the local run happens to get right.
+ */
+const ENVIRONMENTS = [
+  ["local", { GITHUB_ACTIONS: undefined }],
+  ["github-actions", { GITHUB_ACTIONS: "true" }],
+];
+
+const RULE_CODE = "basecamp-tests(no-timer-scheduled-abort)";
 
 /** [name, source, expected 1-based lines that must report] */
 const CASES = [
@@ -116,38 +135,59 @@ export const t = setTimeout(() => controller.abort(), 50);
 
 const dir = mkdtempSync(join(tmpdir(), "abort-timer-rule-"));
 const failures = [];
+let checks = 0;
 
 try {
-  for (const [name, source, expected] of CASES) {
-    const file = join(dir, "case.ts");
-    writeFileSync(file, source);
+  for (const [envName, envOverrides] of ENVIRONMENTS) {
+    const env = { ...process.env, ...envOverrides };
+    if (envOverrides.GITHUB_ACTIONS === undefined) delete env.GITHUB_ACTIONS;
 
-    let output = "";
-    try {
-      output = execFileSync("npx", ["oxlint", "-c", CONFIG, file], {
-        cwd: join(HERE, ".."),
-        encoding: "utf8",
-        stdio: ["ignore", "pipe", "pipe"],
-      });
-    } catch (error) {
-      // oxlint exits 1 when it reports an error; that is a result, not a crash.
-      // Anything else — a plugin that failed to load, a config it could not
-      // parse — must fail loudly rather than read as "no findings".
-      if (error.status !== 1) {
-        failures.push(`${name}: oxlint exited ${error.status}\n${error.stdout ?? ""}${error.stderr ?? ""}`);
+    for (const [name, source, expected] of CASES) {
+      checks += 1;
+      const label = `[${envName}] ${name}`;
+      const file = join(dir, "case.ts");
+      writeFileSync(file, source);
+
+      let output = "";
+      try {
+        output = execFileSync(OXLINT, ["-c", CONFIG, "--format", "json", file], {
+          cwd: join(HERE, ".."),
+          encoding: "utf8",
+          env,
+          stdio: ["ignore", "pipe", "pipe"],
+        });
+      } catch (error) {
+        // oxlint exits 1 when it reports an error; that is a result, not a
+        // crash. Anything else — a plugin that failed to load, a config it
+        // could not parse — must fail loudly rather than read as "no findings".
+        if (error.status !== 1) {
+          failures.push(`${label}: oxlint exited ${error.status}\n${error.stdout ?? ""}${error.stderr ?? ""}`);
+          continue;
+        }
+        output = `${error.stdout ?? ""}`;
+      }
+
+      let parsed;
+      try {
+        parsed = JSON.parse(output);
+      } catch {
+        failures.push(`${label}: could not parse oxlint --format json output\n${output}`);
         continue;
       }
-      output = `${error.stdout ?? ""}${error.stderr ?? ""}`;
-    }
 
-    const reported = [...output.matchAll(/case\.ts:(\d+):\d+: error basecamp-tests\(no-timer-scheduled-abort\)/g)]
-      .map((m) => Number(m[1]))
-      .sort((a, b) => a - b);
+      // Match on the rule CODE, not on message text: this asserts the finding
+      // came from this rule rather than from anything else oxlint decided to
+      // report.
+      const reported = (parsed.diagnostics ?? [])
+        .filter((d) => d.code === RULE_CODE)
+        .map((d) => d.labels?.[0]?.span?.line)
+        .sort((a, b) => a - b);
 
-    const want = JSON.stringify(expected);
-    const got = JSON.stringify(reported);
-    if (want !== got) {
-      failures.push(`${name}: expected reports on lines ${want}, got ${got}\n${output}`);
+      const want = JSON.stringify(expected);
+      const got = JSON.stringify(reported);
+      if (want !== got) {
+        failures.push(`${label}: expected reports on lines ${want}, got ${got}\n${output}`);
+      }
     }
   }
 } finally {
@@ -160,4 +200,4 @@ if (failures.length > 0) {
   process.exit(1);
 }
 
-console.log(`no-timer-scheduled-abort self-test: ${CASES.length} cases passed.`);
+console.log(`no-timer-scheduled-abort self-test: ${checks} checks passed (${CASES.length} cases x ${ENVIRONMENTS.length} environments).`);

--- a/typescript/lint-rules/test-no-timer-scheduled-abort.mjs
+++ b/typescript/lint-rules/test-no-timer-scheduled-abort.mjs
@@ -1,0 +1,163 @@
+/**
+ * Self-test for the no-timer-scheduled-abort oxlint rule.
+ *
+ * oxlint has no RuleTester, so this drives the real binary over real fixture
+ * files in a temp directory and asserts on the reported lines. That is a
+ * feature rather than a compromise: it exercises plugin LOADING and rule
+ * dispatch, which is precisely the path oxlint's alpha, non-semver JS plugin
+ * API can break under a caret bump.
+ *
+ * Without this, such a break is a silent fail-open — the gate keeps exiting 0
+ * while matching nothing. With it, the build reds. That is the whole reason it
+ * runs alongside the rule rather than only when someone edits the rule.
+ *
+ * The two POSITIVE fixtures are the verbatim shapes this repo removed in #783
+ * plus the one #715 removed, so "the gate is known to fail" is anchored to real
+ * defects rather than to invented ones. The NEGATIVE fixtures are the seams
+ * that replaced them, plus the shape a text selector gets wrong.
+ */
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const CONFIG = join(HERE, "oxlintrc.json");
+
+/** [name, source, expected 1-based lines that must report] */
+const CASES = [
+  [
+    // #783, middleware-lifecycle.test.ts:244 — the form that survived #655's
+    // sweep because its selector demanded a no-argument abort().
+    "timer abort WITH a reason (the #655 survivor)",
+    `const controller = new AbortController();
+const reason = new Error("caller cancelled");
+export const abortTimer = setTimeout(() => controller.abort(reason), 50);
+`,
+    [3],
+  ],
+  [
+    // client.test.ts:586 before #715 — the one shape #655's selector did match.
+    "timer abort with NO argument (what #655 itself caught)",
+    `const controller = new AbortController();
+export const abortTimer = setTimeout(() => controller.abort(), 50);
+`,
+    [2],
+  ],
+  [
+    // Spelling variations the original rg could not have seen. If the rule
+    // regressed to text matching, these are the first to go quiet.
+    "block body, member-spelled timer, computed abort, nested function",
+    `const controller = new AbortController();
+export const a = globalThis.setTimeout(() => { controller.abort(); }, 10);
+export const b = setInterval(function () { controller["abort"](); }, 10);
+export const c = setTimeout(() => { const inner = () => controller.abort(); inner(); }, 10);
+`,
+    [2, 3, 4],
+  ],
+  [
+    // The seams that replaced them: abort from inside the MSW handler, and
+    // abort queued from the retry hook. Neither is timer-scheduled.
+    "in-flight seams are allowed",
+    `const controller = new AbortController();
+const reason = new Error("x");
+export const handler = async () => {
+  controller.abort(reason);
+  await new Promise((r) => setTimeout(r, 1000));
+};
+export const onRetry = () => {
+  queueMicrotask(() => controller.abort(reason));
+};
+`,
+    [],
+  ],
+  [
+    // device.test.ts:1632-1640. A never-settling 60s display hook, with the
+    // abort as a separate synchronous statement afterwards: the timer is the
+    // thing being BEATEN, not the thing scheduling the abort. A proximity grep
+    // flags this; the AST does not, and that difference is why this is a rule
+    // and not a `make` target running rg.
+    "a timer the abort races, rather than one that schedules it",
+    `const controller = new AbortController();
+export const display = () =>
+  new Promise((resolve) => {
+    setTimeout(() => {
+      resolve();
+    }, 60_000);
+  });
+controller.abort();
+`,
+    [],
+  ],
+  [
+    // A stubbed sleep or fetch that aborts is deterministic — the abort lands
+    // when the code under test calls it, not when a clock says so.
+    "abort from a stubbed sleep or fetch is allowed",
+    `const controller = new AbortController();
+export const sleepStub = (_ms) => {
+  controller.abort();
+  return Promise.resolve();
+};
+`,
+    [],
+  ],
+  [
+    // The sanctioned escape hatch. If this stops working, the rule has no
+    // legitimate exception path and becomes a reason to delete it.
+    "an inline suppression with a reason is honored",
+    `const controller = new AbortController();
+// oxlint-disable-next-line basecamp-tests/no-timer-scheduled-abort -- this test's SUBJECT is a caller's own timer
+export const t = setTimeout(() => controller.abort(), 50);
+`,
+    [],
+  ],
+];
+
+const dir = mkdtempSync(join(tmpdir(), "abort-timer-rule-"));
+const failures = [];
+
+try {
+  for (const [name, source, expected] of CASES) {
+    const file = join(dir, "case.ts");
+    writeFileSync(file, source);
+
+    let output = "";
+    try {
+      output = execFileSync("npx", ["oxlint", "-c", CONFIG, file], {
+        cwd: join(HERE, ".."),
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "pipe"],
+      });
+    } catch (error) {
+      // oxlint exits 1 when it reports an error; that is a result, not a crash.
+      // Anything else — a plugin that failed to load, a config it could not
+      // parse — must fail loudly rather than read as "no findings".
+      if (error.status !== 1) {
+        failures.push(`${name}: oxlint exited ${error.status}\n${error.stdout ?? ""}${error.stderr ?? ""}`);
+        continue;
+      }
+      output = `${error.stdout ?? ""}${error.stderr ?? ""}`;
+    }
+
+    const reported = [...output.matchAll(/case\.ts:(\d+):\d+: error basecamp-tests\(no-timer-scheduled-abort\)/g)]
+      .map((m) => Number(m[1]))
+      .sort((a, b) => a - b);
+
+    const want = JSON.stringify(expected);
+    const got = JSON.stringify(reported);
+    if (want !== got) {
+      failures.push(`${name}: expected reports on lines ${want}, got ${got}\n${output}`);
+    }
+  }
+} finally {
+  rmSync(dir, { recursive: true, force: true });
+}
+
+if (failures.length > 0) {
+  console.error("no-timer-scheduled-abort self-test FAILED:\n");
+  for (const failure of failures) console.error(`  - ${failure}\n`);
+  process.exit(1);
+}
+
+console.log(`no-timer-scheduled-abort self-test: ${CASES.length} cases passed.`);

--- a/typescript/lint-rules/test-no-timer-scheduled-abort.mjs
+++ b/typescript/lint-rules/test-no-timer-scheduled-abort.mjs
@@ -96,6 +96,21 @@ export const c = setTimeout((() => controller.abort()) satisfies () => void, 50)
     [2, 3, 4],
   ],
   [
+    // Review follow-up (Copilot). `isAbortCall` reads a computed literal's VALUE,
+    // so `c["abort"]()` is an abort; `isTimerCall` refused computed access
+    // outright, so `globalThis["setTimeout"](…)` was not a timer and the inline
+    // callback under it went unreported while the header claimed member-spelled
+    // timers were covered. Same class as the quote-style fix above: a spelling
+    // of the shape the rule targets, not a renamed timer or a dynamic key.
+    "computed-literal timer property, both quote styles",
+    `const controller = new AbortController();
+export const a = globalThis["setTimeout"](() => controller.abort(), 50);
+export const b = globalThis['setInterval'](() => controller.abort(), 50);
+export const c = window["setTimeout"](() => { controller["abort"](); }, 50);
+`,
+    [2, 3, 4],
+  ],
+  [
     // The seams that replaced them: abort from inside the MSW handler, and
     // abort queued from the retry hook. Neither is timer-scheduled.
     "in-flight seams are allowed",

--- a/typescript/lint-rules/test-no-timer-scheduled-abort.mjs
+++ b/typescript/lint-rules/test-no-timer-scheduled-abort.mjs
@@ -76,6 +76,22 @@ export const c = setTimeout(() => { const inner = () => controller.abort(); inne
     [2, 3, 4],
   ],
   [
+    // Review follow-up (Copilot). TypeScript-only syntax between the callback
+    // and the timer changes the AST shape without changing what runs, and the
+    // ancestor walk used to compare the FUNCTION against `arguments[0]` — which
+    // is the wrapper node here, so all three of these slipped the gate while
+    // the rule's header claimed inline callbacks were covered. These are
+    // spellings of the shape the rule targets, not the renamed-timer /
+    // by-reference classes it declares out of scope.
+    "TypeScript wrappers between the callback and the timer",
+    `const controller = new AbortController();
+export const a = setTimeout((() => controller.abort()) as () => void, 50);
+export const b = setTimeout((() => controller.abort())!, 50);
+export const c = setTimeout((() => controller.abort()) satisfies () => void, 50);
+`,
+    [2, 3, 4],
+  ],
+  [
     // The seams that replaced them: abort from inside the MSW handler, and
     // abort queued from the retry hook. Neither is timer-scheduled.
     "in-flight seams are allowed",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -29,7 +29,9 @@
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
     "typecheck": "tsc --noEmit && tsc -p tsconfig.test.json --noEmit",
-    "lint": "oxlint src --ignore-pattern 'src/generated/**'"
+    "lint": "oxlint src --ignore-pattern 'src/generated/**'",
+    "lint:test-timers": "oxlint -c lint-rules/oxlintrc.json tests",
+    "test:lint-rules": "node lint-rules/test-no-timer-scheduled-abort.mjs"
   },
   "keywords": [
     "basecamp",

--- a/typescript/tests/middleware-lifecycle.test.ts
+++ b/typescript/tests/middleware-lifecycle.test.ts
@@ -70,6 +70,22 @@ const starts = (e: ReturnType<typeof recordingHooks>["events"]) =>
 const ends = (e: ReturnType<typeof recordingHooks>["events"]) =>
   e.filter((x) => x.kind === "end");
 
+/**
+ * Runs the event loop forward by `turns` complete turns without consulting a
+ * clock. `setImmediate` fires after the current turn's microtasks and pending
+ * I/O callbacks, so awaiting it N times gives every promise chain that is NOT
+ * waiting on a timer N chances to settle. Under load a turn takes longer; the
+ * number of turns a settlement needs does not change — which is what makes
+ * this a barrier rather than the elapsed-time threshold #783 removed. Left
+ * real by the fake-timer install below, which fakes `setTimeout`/`clearTimeout`
+ * only.
+ */
+async function drainEventLoop(turns: number): Promise<void> {
+  for (let i = 0; i < turns; i++) {
+    await new Promise((resolve) => setImmediate(resolve));
+  }
+}
+
 describe("middleware request lifecycle", () => {
   afterEach(() => {
     vi.restoreAllMocks();
@@ -274,67 +290,115 @@ describe("middleware request lifecycle", () => {
   // (start + auth refresh) against an already-aborted signal. The same seam
   // guards the request-timeout budget, which shares this signal.
   it("rejects promptly when the caller aborts during a retry backoff", async () => {
-    server.use(
-      http.get(`${BASE_URL}/projects.json`, () =>
-        // Retry-After: 2 puts the loop into a 2s backoff we can abort inside.
-        new HttpResponse(null, { status: 429, headers: { "Retry-After": "2" } })
-      )
-    );
+    // Review follow-up (Codex, round 3). PROMPTNESS is the named behavior, and
+    // the attempt ledger below does not pin it: a sleep that noticed the abort
+    // but deferred its rejection to the timer's expiry never starts attempt 2
+    // and still rejects with the caller's reason, so every other assertion
+    // here passes — two seconds late. Fake timers close that gap by
+    // construction. With the clock frozen the 2s backoff timer can only fire
+    // if this test advances it, and it never does; "the request settled" and
+    // "it settled before the backoff elapsed" therefore become the same
+    // statement. No threshold for load to beat, which is what put the deleted
+    // `Date.now() - startedAt < 1000` in #783's sights.
+    //
+    // Only setTimeout/clearTimeout are faked: `setImmediate` stays real so
+    // drainEventLoop can run turns, and Date is left alone so nothing else in
+    // the request path sees a stopped clock.
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
 
-    const reason = new Error("caller cancelled during backoff");
-    const controller = new AbortController();
-
-    const { hooks, events } = recordingHooks();
-    const announce = hooks.onRetry!;
-    hooks.onRetry = (info, upcoming, error, delayMs) => {
-      announce(info, upcoming, error, delayMs);
-      // Abort from the hook the loop fires immediately before it sleeps, so
-      // the abort lands inside the backoff BY CONSTRUCTION rather than by a
-      // timer beating a 2s window under whatever load the runner is carrying
-      // (#783). #781 aborts from the same seam one layer down.
-      //
-      // The microtask is what puts it INSIDE the sleep rather than before it.
-      // executeWithRetry calls sleep() synchronously once this hook returns,
-      // and sleep's promise executor registers its abort listener
-      // synchronously in turn — so a queued abort cannot run until that
-      // listener exists, and it is the listener that has to reject. Aborting
-      // synchronously here would only ever reach sleep's already-aborted fast
-      // path, leaving the listener untested. If a future `await` appears
-      // between the hook and the sleep, this degrades to that fast path — it
-      // gets weaker, never flaky.
-      queueMicrotask(() => controller.abort(reason));
-    };
-
-    const client = createBasecampClient({
-      accountId: "12345",
-      accessToken: "test-token",
-      hooks,
-    });
-
-    const err = await client
-      .GET("/projects.json", { signal: controller.signal } as never)
-      .then(
-        () => undefined,
-        (e: unknown) => e
+    try {
+      server.use(
+        http.get(`${BASE_URL}/projects.json`, () =>
+          // Retry-After: 2 puts the loop into a 2s backoff we can abort inside.
+          new HttpResponse(null, { status: 429, headers: { "Retry-After": "2" } })
+        )
       );
 
-    expect(err).toBe(reason);
-    // The mechanism, not the clock. Attempt 1 was started and ended (429)
-    // before the backoff; attempt 2 must never start. A backoff sleep that
-    // ignored the signal would run the full 2s Retry-After and only then begin
-    // attempt 2 — start, auth refresh, fetch — against an already-aborted
-    // signal, which surfaces here as starts [1, 2]. That is what the deleted
-    // `Date.now() - startedAt < 1000` was standing in for, and these say it
-    // without consulting a clock.
-    //
-    // onRetry had already announced attempt 2 — that is the inherent race of
-    // cancelling between announce and begin — but starts and ends stay
-    // balanced.
-    expect(starts(events).map((e) => e.attempt)).toEqual([1]);
-    expect(ends(events).map((e) => e.attempt)).toEqual([1]);
-    expect(ends(events)[0]!.statusCode).toBe(429);
-    // Hang guard only: a non-signal-aware sleep fails the assertions above,
-    // and this just stops it wedging the file if it fails some other way.
+      const reason = new Error("caller cancelled during backoff");
+      const controller = new AbortController();
+
+      // Resolved once the abort has actually been delivered, so the barrier
+      // below starts counting from the abort rather than from the start of the
+      // request — attempt 1's round trip legitimately spans several turns, and
+      // only what happens AFTER the abort is under test.
+      let abortDelivered!: () => void;
+      const aborted = new Promise<void>((resolve) => {
+        abortDelivered = resolve;
+      });
+
+      const { hooks, events } = recordingHooks();
+      const announce = hooks.onRetry!;
+      hooks.onRetry = (info, upcoming, error, delayMs) => {
+        announce(info, upcoming, error, delayMs);
+        // Abort from the hook the loop fires immediately before it sleeps, so
+        // the abort lands inside the backoff BY CONSTRUCTION rather than by a
+        // timer beating a 2s window under whatever load the runner is carrying
+        // (#783). #781 aborts from the same seam one layer down.
+        //
+        // The microtask is what puts it INSIDE the sleep rather than before it.
+        // executeWithRetry calls sleep() synchronously once this hook returns,
+        // and sleep's promise executor registers its abort listener
+        // synchronously in turn — so a queued abort cannot run until that
+        // listener exists, and it is the listener that has to reject. Aborting
+        // synchronously here would only ever reach sleep's already-aborted fast
+        // path, leaving the listener untested. If a future `await` appears
+        // between the hook and the sleep, this degrades to that fast path — it
+        // gets weaker, never flaky.
+        queueMicrotask(() => {
+          controller.abort(reason);
+          abortDelivered();
+        });
+      };
+
+      const client = createBasecampClient({
+        accountId: "12345",
+        accessToken: "test-token",
+        hooks,
+      });
+
+      const request = client
+        .GET("/projects.json", { signal: controller.signal } as never)
+        .then(
+          () => undefined,
+          (e: unknown) => e
+        );
+
+      let settled = false;
+      void request.then(() => {
+        settled = true;
+      });
+
+      await aborted;
+      await drainEventLoop(5);
+
+      // Promptness, asserted rather than named. The rejection travels from the
+      // sleep's abort listener to here through microtasks alone, so one turn
+      // is enough and five are slack; nothing in that chain waits on a timer.
+      // A rejection deferred to the backoff timer cannot arrive at all while
+      // the clock is frozen, so it reads as `false` here — immediately, and
+      // for the same reason every time.
+      expect(settled).toBe(true);
+
+      const err = await request;
+      expect(err).toBe(reason);
+      // The mechanism, not the clock. Attempt 1 was started and ended (429)
+      // before the backoff; attempt 2 must never start. A backoff sleep that
+      // ignored the signal ENTIRELY would run the full 2s Retry-After and only
+      // then begin attempt 2 — start, auth refresh, fetch — against an
+      // already-aborted signal, which surfaces here as starts [1, 2].
+      //
+      // onRetry had already announced attempt 2 — that is the inherent race of
+      // cancelling between announce and begin — but starts and ends stay
+      // balanced.
+      expect(starts(events).map((e) => e.attempt)).toEqual([1]);
+      expect(ends(events).map((e) => e.attempt)).toEqual([1]);
+      expect(ends(events)[0]!.statusCode).toBe(429);
+    } finally {
+      // Restored on the failure path too: leaking a frozen clock into the rest
+      // of the file would hang the next test that backs off.
+      vi.useRealTimers();
+    }
+    // Hang guard only: the assertions above carry the discrimination.
   }, 10_000);
 
   // Defect 4, updated for network-error retry. A 503 followed by fetch

--- a/typescript/tests/middleware-lifecycle.test.ts
+++ b/typescript/tests/middleware-lifecycle.test.ts
@@ -225,8 +225,17 @@ describe("middleware request lifecycle", () => {
   // that path too: no retry, no backoff, and the caller's reason surfaces
   // untouched.
   it("treats a caller abort with a custom reason as terminal", async () => {
+    const reason = new Error("caller cancelled");
+    const controller = new AbortController();
+
     server.use(
       http.get(`${BASE_URL}/projects.json`, async () => {
+        // Abort from INSIDE the handler, per #655's option 1: the request has
+        // demonstrably reached the transport, so nothing is racing a timer
+        // against machine load (#783). The delayed response stays behind it as
+        // the fallback — if the caller's signal ever stopped reaching the
+        // request, this resolves and `err` below is undefined.
+        controller.abort(reason);
         await new Promise((r) => setTimeout(r, 1000));
         return HttpResponse.json([]);
       })
@@ -239,26 +248,24 @@ describe("middleware request lifecycle", () => {
       hooks,
     });
 
-    const reason = new Error("caller cancelled");
-    const controller = new AbortController();
-    const abortTimer = setTimeout(() => controller.abort(reason), 50);
+    const err = await client
+      .GET("/projects.json", { signal: controller.signal } as never)
+      .then(
+        () => undefined,
+        (e: unknown) => e
+      );
 
-    try {
-      const err = await client
-        .GET("/projects.json", { signal: controller.signal } as never)
-        .then(
-          () => undefined,
-          (e: unknown) => e
-        );
-
-      expect(err).toBe(reason);
-      // Terminal on attempt 1: no retry started, no onRetry announced.
-      expect(starts(events).map((e) => e.attempt)).toEqual([1]);
-      expect(ends(events).map((e) => e.attempt)).toEqual([1]);
-      expect(events.filter((e) => e.kind === "retry")).toHaveLength(0);
-    } finally {
-      clearTimeout(abortTimer);
-    }
+    // Identity, not elapsed time: the caller's own reason OBJECT came back,
+    // which nothing else on this path can produce — the request timeout aborts
+    // with a TimeoutError DOMException, and a completed request resolves. A
+    // wall-clock ceiling would add no discriminating power here, only load
+    // sensitivity (#655).
+    expect(err).toBe(reason);
+    // Terminal on attempt 1: no retry started, no onRetry announced.
+    expect(starts(events).map((e) => e.attempt)).toEqual([1]);
+    expect(ends(events).map((e) => e.attempt)).toEqual([1]);
+    expect(events.filter((e) => e.kind === "retry")).toHaveLength(0);
+    // Hang guard only — the assertions above carry the discrimination.
   }, 10_000);
 
   // Review follow-up (Codex, round 2). An abort that fires DURING the backoff
@@ -274,39 +281,60 @@ describe("middleware request lifecycle", () => {
       )
     );
 
+    const reason = new Error("caller cancelled during backoff");
+    const controller = new AbortController();
+
     const { hooks, events } = recordingHooks();
+    const announce = hooks.onRetry!;
+    hooks.onRetry = (info, upcoming, error, delayMs) => {
+      announce(info, upcoming, error, delayMs);
+      // Abort from the hook the loop fires immediately before it sleeps, so
+      // the abort lands inside the backoff BY CONSTRUCTION rather than by a
+      // timer beating a 2s window under whatever load the runner is carrying
+      // (#783). #781 aborts from the same seam one layer down.
+      //
+      // The microtask is what puts it INSIDE the sleep rather than before it.
+      // executeWithRetry calls sleep() synchronously once this hook returns,
+      // and sleep's promise executor registers its abort listener
+      // synchronously in turn — so a queued abort cannot run until that
+      // listener exists, and it is the listener that has to reject. Aborting
+      // synchronously here would only ever reach sleep's already-aborted fast
+      // path, leaving the listener untested. If a future `await` appears
+      // between the hook and the sleep, this degrades to that fast path — it
+      // gets weaker, never flaky.
+      queueMicrotask(() => controller.abort(reason));
+    };
+
     const client = createBasecampClient({
       accountId: "12345",
       accessToken: "test-token",
       hooks,
     });
 
-    const reason = new Error("caller cancelled during backoff");
-    const controller = new AbortController();
-    const abortTimer = setTimeout(() => controller.abort(reason), 100);
+    const err = await client
+      .GET("/projects.json", { signal: controller.signal } as never)
+      .then(
+        () => undefined,
+        (e: unknown) => e
+      );
 
-    try {
-      const startedAt = Date.now();
-      const err = await client
-        .GET("/projects.json", { signal: controller.signal } as never)
-        .then(
-          () => undefined,
-          (e: unknown) => e
-        );
-
-      expect(err).toBe(reason);
-      // Prompt: nowhere near the 2s Retry-After backoff.
-      expect(Date.now() - startedAt).toBeLessThan(1000);
-      // Attempt 1 was started and ended (429) before the backoff; attempt 2
-      // must never start. onRetry had already announced it — that is the
-      // inherent race of cancelling between announce and begin — but starts
-      // and ends stay balanced.
-      expect(starts(events).map((e) => e.attempt)).toEqual([1]);
-      expect(ends(events).map((e) => e.attempt)).toEqual([1]);
-      expect(ends(events)[0]!.statusCode).toBe(429);
-    } finally {
-      clearTimeout(abortTimer);
-    }
+    expect(err).toBe(reason);
+    // The mechanism, not the clock. Attempt 1 was started and ended (429)
+    // before the backoff; attempt 2 must never start. A backoff sleep that
+    // ignored the signal would run the full 2s Retry-After and only then begin
+    // attempt 2 — start, auth refresh, fetch — against an already-aborted
+    // signal, which surfaces here as starts [1, 2]. That is what the deleted
+    // `Date.now() - startedAt < 1000` was standing in for, and these say it
+    // without consulting a clock.
+    //
+    // onRetry had already announced attempt 2 — that is the inherent race of
+    // cancelling between announce and begin — but starts and ends stay
+    // balanced.
+    expect(starts(events).map((e) => e.attempt)).toEqual([1]);
+    expect(ends(events).map((e) => e.attempt)).toEqual([1]);
+    expect(ends(events)[0]!.statusCode).toBe(429);
+    // Hang guard only: a non-signal-aware sleep fails the assertions above,
+    // and this just stops it wedging the file if it fails some other way.
   }, 10_000);
 
   // Defect 4, updated for network-error retry. A 503 followed by fetch

--- a/typescript/tests/middleware-lifecycle.test.ts
+++ b/typescript/tests/middleware-lifecycle.test.ts
@@ -89,6 +89,16 @@ async function drainEventLoop(turns: number): Promise<void> {
 describe("middleware request lifecycle", () => {
   afterEach(() => {
     vi.restoreAllMocks();
+    // Review follow-up (Copilot). The backoff-abort test below installs fake
+    // timers, and restoring them in its own `finally` does NOT cover the path
+    // that matters: if a regression stops `onRetry` firing, the test awaits
+    // forever, vitest marks it timed out — and the suspended async function is
+    // never resumed, so the `finally` never runs and a frozen clock leaks into
+    // every later test in this file. Measured: on a timed-out test the
+    // `finally` does not run and this hook does, with `vi.isFakeTimers()` still
+    // true. So the restore lives here, where both paths reach it, instead of in
+    // two places where one is unreachable exactly when it is needed.
+    vi.useRealTimers();
   });
 
   // Defect 1. Two concurrent same-method/same-URL mutations with Date.now()
@@ -306,98 +316,96 @@ describe("middleware request lifecycle", () => {
     // the request path sees a stopped clock.
     vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
 
-    try {
-      server.use(
-        http.get(`${BASE_URL}/projects.json`, () =>
-          // Retry-After: 2 puts the loop into a 2s backoff we can abort inside.
-          new HttpResponse(null, { status: 429, headers: { "Retry-After": "2" } })
-        )
+    // Restored in this describe's afterEach rather than in a `finally` here:
+    // a timed-out test never resumes to run its own finally, and the timeout
+    // is exactly the failure this test produces when the abort stops reaching
+    // the sleep. One restore, on every path.
+    server.use(
+      http.get(`${BASE_URL}/projects.json`, () =>
+        // Retry-After: 2 puts the loop into a 2s backoff we can abort inside.
+        new HttpResponse(null, { status: 429, headers: { "Retry-After": "2" } })
+      )
+    );
+
+    const reason = new Error("caller cancelled during backoff");
+    const controller = new AbortController();
+
+    // Resolved once the abort has actually been delivered, so the barrier
+    // below starts counting from the abort rather than from the start of the
+    // request — attempt 1's round trip legitimately spans several turns, and
+    // only what happens AFTER the abort is under test.
+    let abortDelivered!: () => void;
+    const aborted = new Promise<void>((resolve) => {
+      abortDelivered = resolve;
+    });
+
+    const { hooks, events } = recordingHooks();
+    const announce = hooks.onRetry!;
+    hooks.onRetry = (info, upcoming, error, delayMs) => {
+      announce(info, upcoming, error, delayMs);
+      // Abort from the hook the loop fires immediately before it sleeps, so
+      // the abort lands inside the backoff BY CONSTRUCTION rather than by a
+      // timer beating a 2s window under whatever load the runner is carrying
+      // (#783). #781 aborts from the same seam one layer down.
+      //
+      // The microtask is what puts it INSIDE the sleep rather than before it.
+      // executeWithRetry calls sleep() synchronously once this hook returns,
+      // and sleep's promise executor registers its abort listener
+      // synchronously in turn — so a queued abort cannot run until that
+      // listener exists, and it is the listener that has to reject. Aborting
+      // synchronously here would only ever reach sleep's already-aborted fast
+      // path, leaving the listener untested. If a future `await` appears
+      // between the hook and the sleep, this degrades to that fast path — it
+      // gets weaker, never flaky.
+      queueMicrotask(() => {
+        controller.abort(reason);
+        abortDelivered();
+      });
+    };
+
+    const client = createBasecampClient({
+      accountId: "12345",
+      accessToken: "test-token",
+      hooks,
+    });
+
+    const request = client
+      .GET("/projects.json", { signal: controller.signal } as never)
+      .then(
+        () => undefined,
+        (e: unknown) => e
       );
 
-      const reason = new Error("caller cancelled during backoff");
-      const controller = new AbortController();
+    let settled = false;
+    void request.then(() => {
+      settled = true;
+    });
 
-      // Resolved once the abort has actually been delivered, so the barrier
-      // below starts counting from the abort rather than from the start of the
-      // request — attempt 1's round trip legitimately spans several turns, and
-      // only what happens AFTER the abort is under test.
-      let abortDelivered!: () => void;
-      const aborted = new Promise<void>((resolve) => {
-        abortDelivered = resolve;
-      });
+    await aborted;
+    await drainEventLoop(5);
 
-      const { hooks, events } = recordingHooks();
-      const announce = hooks.onRetry!;
-      hooks.onRetry = (info, upcoming, error, delayMs) => {
-        announce(info, upcoming, error, delayMs);
-        // Abort from the hook the loop fires immediately before it sleeps, so
-        // the abort lands inside the backoff BY CONSTRUCTION rather than by a
-        // timer beating a 2s window under whatever load the runner is carrying
-        // (#783). #781 aborts from the same seam one layer down.
-        //
-        // The microtask is what puts it INSIDE the sleep rather than before it.
-        // executeWithRetry calls sleep() synchronously once this hook returns,
-        // and sleep's promise executor registers its abort listener
-        // synchronously in turn — so a queued abort cannot run until that
-        // listener exists, and it is the listener that has to reject. Aborting
-        // synchronously here would only ever reach sleep's already-aborted fast
-        // path, leaving the listener untested. If a future `await` appears
-        // between the hook and the sleep, this degrades to that fast path — it
-        // gets weaker, never flaky.
-        queueMicrotask(() => {
-          controller.abort(reason);
-          abortDelivered();
-        });
-      };
+    // Promptness, asserted rather than named. The rejection travels from the
+    // sleep's abort listener to here through microtasks alone, so one turn
+    // is enough and five are slack; nothing in that chain waits on a timer.
+    // A rejection deferred to the backoff timer cannot arrive at all while
+    // the clock is frozen, so it reads as `false` here — immediately, and
+    // for the same reason every time.
+    expect(settled).toBe(true);
 
-      const client = createBasecampClient({
-        accountId: "12345",
-        accessToken: "test-token",
-        hooks,
-      });
-
-      const request = client
-        .GET("/projects.json", { signal: controller.signal } as never)
-        .then(
-          () => undefined,
-          (e: unknown) => e
-        );
-
-      let settled = false;
-      void request.then(() => {
-        settled = true;
-      });
-
-      await aborted;
-      await drainEventLoop(5);
-
-      // Promptness, asserted rather than named. The rejection travels from the
-      // sleep's abort listener to here through microtasks alone, so one turn
-      // is enough and five are slack; nothing in that chain waits on a timer.
-      // A rejection deferred to the backoff timer cannot arrive at all while
-      // the clock is frozen, so it reads as `false` here — immediately, and
-      // for the same reason every time.
-      expect(settled).toBe(true);
-
-      const err = await request;
-      expect(err).toBe(reason);
-      // The mechanism, not the clock. Attempt 1 was started and ended (429)
-      // before the backoff; attempt 2 must never start. A backoff sleep that
-      // ignored the signal ENTIRELY would run the full 2s Retry-After and only
-      // then begin attempt 2 — start, auth refresh, fetch — against an
-      // already-aborted signal, which surfaces here as starts [1, 2].
-      //
-      // onRetry had already announced attempt 2 — that is the inherent race of
-      // cancelling between announce and begin — but starts and ends stay
-      // balanced.
-      expect(starts(events).map((e) => e.attempt)).toEqual([1]);
-      expect(ends(events).map((e) => e.attempt)).toEqual([1]);
-      expect(ends(events)[0]!.statusCode).toBe(429);
-    } finally {
-      // Restored on the failure path too: leaking a frozen clock into the rest
-      // of the file would hang the next test that backs off.
-      vi.useRealTimers();
-    }
+    const err = await request;
+    expect(err).toBe(reason);
+    // The mechanism, not the clock. Attempt 1 was started and ended (429)
+    // before the backoff; attempt 2 must never start. A backoff sleep that
+    // ignored the signal ENTIRELY would run the full 2s Retry-After and only
+    // then begin attempt 2 — start, auth refresh, fetch — against an
+    // already-aborted signal, which surfaces here as starts [1, 2].
+    //
+    // onRetry had already announced attempt 2 — that is the inherent race of
+    // cancelling between announce and begin — but starts and ends stay
+    // balanced.
+    expect(starts(events).map((e) => e.attempt)).toEqual([1]);
+    expect(ends(events).map((e) => e.attempt)).toEqual([1]);
+    expect(ends(events)[0]!.statusCode).toBe(429);
     // Hang guard only: the assertions above carry the discrimination.
   }, 10_000);
 


### PR DESCRIPTION
Three tests whose assertions rested on a clock. Two of them are the second and
third instances of the shape #655 fixed and then declared contained; the third
is the same failure written in Ruby, where a wall-clock timer is replaced by a
missing happens-before edge. None of them changes production code — but each
now fails for the reason it exists, and passes for one too.

## TypeScript, #783: the two survivors of #655's sweep

`typescript/tests/middleware-lifecycle.test.ts`, both landed by #538 a fortnight
before #655 was filed.

**Line 244, "treats a caller abort with a custom reason as terminal"** — a 50ms
abort timer against a 1000ms mocked response, which is #655's own numbers
exactly. It had not been seen red; it was one scheduling hiccup from it. It now
takes #655's option 1 verbatim, the same way `client.test.ts:573` did: the abort
fires from **inside the MSW handler**, so the request has demonstrably reached
the transport before anything cancels it, and the 1000ms response stays behind it
as the fallback that resolves — and fails the test — if the caller's signal ever
stops reaching the request.

**Line 286, "rejects promptly when the caller aborts during a retry backoff"** —
the one observed red: a 100ms timer against a 2s `Retry-After` backoff, plus
`expect(Date.now() - startedAt).toBeLessThan(1000)`. It now aborts from
`hooks.onRetry`, the seam `executeWithRetry` fires immediately before
`await sleep(delay, signal)` — the same seam #781 used one layer down in
`retry-after.test.ts`. The wall-clock ceiling is deleted.

### What each assertion rests on now

| test | rests on |
|---|---|
| custom-reason abort | `err === reason` — the caller's own `Error` **object** came back. Nothing else on that path can produce it: the request timeout aborts with a `TimeoutError` `DOMException`, and a completed request resolves. Plus `starts == [1]`, `ends == [1]`, zero `onRetry` events. |
| abort during backoff | `starts == [1]`. A backoff sleep that ignored the signal runs the full 2s and *then* begins attempt 2 — start, auth refresh, fetch — against an already-aborted signal, which shows up as `starts == [1, 2]`. That is precisely what the deleted `< 1000` ceiling was standing in for, said without a clock. |
| Ruby proxy credentials | `Queue#pop` — the assertion reads a value that provably exists only because the producer finished reading the preamble. |

### The abort is queued as a microtask, not called synchronously

#783's sketch says to call `controller.abort(reason)` straight from the hook.
That would be deterministic, but it would land the abort **before** the sleep
rather than inside it, so only `sleep`'s already-aborted fast path would ever
run and its `addEventListener("abort", …)` branch — the one the test's name is
about — would go untested. `queueMicrotask` fixes the ordering by construction:
`executeWithRetry` calls `sleep()` synchronously once the hook returns, and
`sleep`'s promise executor registers the listener synchronously in turn, so the
queued abort cannot run until the listener exists. Proved below. If a future
`await` ever appears between the hook and the sleep, this degrades to the fast
path — weaker, never flaky.

## Ruby, #739: a thread race, not #720's resolver stall

`ruby/test/basecamp/oauth_transport_test.rb:818` shared a `captured = +""` between
the proxy thread that filled it and the main thread that asserted on it, with no
`join`, `Queue` or condvar. The ordering that made it pass was incidental — the
socket close — and the client's own `timeout: 1` can raise while the proxy is
still mid-`gets` on a loaded runner. Observed red on CI twice, on a branch
touching only two Go files.

**This is not #720.** #720 was `URI#find_proxy` → `IPSocket.getaddress` stalling
on an unresolvable `.test` name inside a sub-second budget; #734 removed the
resolver from these tests entirely and closed it. This survives that fix because
nothing about it is a resolver. #734's remedy is not re-applied here.

**`Queue`, not `join`.** Both establish the happens-before edge, but a
`join(timeout)` that returns `nil` leaves you reading the shared `String` with no
edge at all — the race re-enters through the hang guard. With a `Queue` the
*value's existence* is the evidence: it can only be popped because the producer
finished reading the preamble, so a wedged producer is a distinguishable,
explicitly reported failure instead of a silently empty match. `pop(timeout: 15)`
is a wait bound, not a timing assertion; this test is about content, so a
generous wait costs nothing. The sub-second bounds #734 deliberately kept on the
siblings are untouched — there the margin between correct and broken *is* the
deadline.

It is also this file's existing idiom: `test_ipv6_host_header_is_bracketed` and
`test_caller_headers_cannot_override_identity_encoding` already hand captured
request headers across a `Queue`.

## Non-vacuity: four mutations, four reds and one deliberate green

Every rewritten test was run against code mutated to contain the bug it targets.
Sources restored by `cp` and verified with `diff -q`; `git status` clean of
non-test changes before committing.

**1. Caller abort is not terminal** — `retry.ts`, drop `signal?.aborted === true`
from `isAbort`, so a custom-reason abort (a plain `Error`, not a `DOMException`)
classifies as a retryable transport error:

```
× treats a caller abort with a custom reason as terminal 16ms
AssertionError: expected [ { kind: 'retry', attempt: 2, …(1) } ] to have a length of +0 but got 1
Tests  1 failed | 15 skipped (16)
REAL_EXIT=1
```

**2. Backoff sleep ignores the signal** — `retry.ts`, `await sleep(delay, signal ?? undefined)`
→ `await sleep(delay)`:

```
× rejects promptly when the caller aborts during a retry backoff 2022ms
AssertionError: expected [ 1, 2 ] to deeply equal [ 1 ]
Tests  1 failed | 15 skipped (16)
REAL_EXIT=1
```

The 2022ms is the full `Retry-After: 2` running out — exactly what the deleted
wall-clock ceiling used to catch, now caught by the attempt ledger.

**3. `sleep` loses only its abort listener** — `signal?.addEventListener("abort", onAbort, { once: true })`
removed, the already-aborted fast path kept. This is the mutation that justifies
the microtask:

```
× rejects promptly when the caller aborts during a retry backoff 2017ms
AssertionError: expected [ 1, 2 ] to deeply equal [ 1 ]
REAL_EXIT=1
```

**4. …and the same mutation with a synchronous abort in the hook** (#783's literal
sketch, applied on top of mutation 3):

```
Tests  1 passed | 15 skipped (16)
REAL_EXIT=0
```

Green against a real defect. That is the test the microtask avoids writing.

**5. Ruby: percent-decoding removed** — `fetcher.rb`, `CGI.unescapeURIComponent(proxy_uri.user)`
→ `proxy_uri.user` (and the password):

```
1) Failure:
OAuthTransportTest#test_proxy_credentials_are_percent_decoded [test/basecamp/oauth_transport_test.rb:861]:
Expected "CONNECT proxy-auth.test:443 HTTP/1.1\r\nHost: proxy-auth.test:443\r\nProxy-Authorization: Basic dXNlcjpwJTQwcytz\r\n"
to include "Proxy-Authorization: Basic dXNlcjpwQHMrcw==".

1 runs, 4 assertions, 1 failures, 0 errors, 0 skips
REAL_EXIT=1
```

The failure prints the whole preamble, which is the second thing this proves:
the `Queue` handed over real bytes, so the assertion is reading content and not
an empty string that happens to match nothing either way.

## Why #655's sweep missed these, and the corrected selector

#655 scoped itself with:

> It is the only test in `typescript/tests/` with this shape
> (`rg "setTimeout\(\(\) => controller.abort\(\), [0-9]+\)"` returns one hit),
> so the fix is contained.

That selector requires a **no-argument** `abort()`. Both survivors pass a reason,
so it matched neither — one regex character class is the entire reason they
stayed. Run both forms against `00de0f2a2~1`, the exact tree the containment
claim was made about:

```
$ git grep -nE 'setTimeout\(\(\) => controller\.abort\(\), [0-9]+\)' 00de0f2a2~1 -- typescript/tests
typescript/tests/client.test.ts:586

$ git grep -nE 'setTimeout\(\(\) => controller\.abort\([^)]*\), [0-9]+\)' 00de0f2a2~1 -- typescript/tests
typescript/tests/client.test.ts:586
typescript/tests/middleware-lifecycle.test.ts:244
typescript/tests/middleware-lifecycle.test.ts:286
```

One hit versus three, at the moment "the fix is contained" was written.

**There was no durable tooling to widen.** #655's selector was an `rg` typed into
an issue body; #715 changed two test files and added no script, lint rule or
`make` target. That finding is the reason to build the first instrument rather
than write a sixth selector — see the next section.

Re-run on this branch:

```
=== 1. #655 original selector (no-argument abort only) ===
exit=1

=== 2. #783 widened: abort(<anything>) ===
exit=1

=== 3. shape-free: any setTimeout whose callback aborts, single- or multi-line, any receiver ===
rg -nU --pcre2 'setTimeout\([\s\S]{0,300}?\.abort\(' typescript/tests
typescript/tests/oauth/device.test.ts:1632-1640   (false positive, see below)

=== 4. population bound: every .abort( in typescript/tests ===
15 sites
```

Selector 2 returned the two hits in #783's report before this branch and returns
none after it: **the class is empty.**

Selector 3's single hit is a false positive, and reading it is the point of
having a population bound rather than a regex verdict. `device.test.ts:1632` is a
60-second display hook that never settles, and the `controller.abort()` at 1640
is a separate synchronous statement before any `await` — the timer is the thing
being *beaten*, deterministically, not the thing scheduling the abort. Selector
4's 15 hits are one comment and 14 call sites, each classified by what makes the
abort land: inside a stubbed sleep or fetch (5), inside an MSW handler (3), from
the retry hook (3), already aborted before the call (2), synchronously after
dispatch and before any `await` (1). **None is timer-scheduled.**

## The gate

`typescript/lint-rules/no-timer-scheduled-abort.js`, an **oxlint JS plugin**.

**Why not eslint:** the repo has no eslint. `npm run lint` is `oxlint`, so an
"eslint rule" would mean introducing eslint, typescript-eslint and a local-plugin
package for one rule — disproportionate scaffolding, and lockfile churn in a repo
where re-locking has bitten before. oxlint 1.78 loads local JS plugins with an
ESLint-compatible rule API, so this adds **zero dependencies** and leaves
`package-lock.json` byte-identical.

**Why not a grep in a make target:** it reads the AST, and that is not cosmetic.
It visits each `abort()` call and walks *up* the ancestor chain asking "is the
enclosing function the first argument of a `setTimeout`/`setInterval`?" — which
distinguishes a timer that *schedules* an abort from one the abort is merely
racing. Concretely: my own proximity selector flags `device.test.ts:1632-1640`
(a 60s never-settling display hook, with the abort as a separate synchronous
statement afterwards) and **the rule does not**. So no suppression is needed
there, and the rule is not blind to the shape — it reads it correctly. The
suppression path exists and is tested, for a test whose *subject* really is a
caller's own timer:

```ts
// oxlint-disable-next-line basecamp-tests/no-timer-scheduled-abort -- why
```

**Coverage bound**, stated in the rule's own header rather than claimed away: it
cannot see a renamed timer (`const later = setTimeout`), a callback passed by
reference (`setTimeout(cancel, 50)`), or a computed `.abort` access with a
non-literal key. It is scoped to `typescript/tests/` only — production code
schedules aborts on timers legitimately, and those are request timeouts. The
honest population bound is `rg -n '\.abort\(' typescript/tests`, carried into the
header with the 14-site classification.

### It is known to fail

**Reintroduce proof** — `git show origin/main:…` restored over the fixed file,
gate run, file restored by `cp` + `diff -q`:

```
tests/middleware-lifecycle.test.ts:244:41: error basecamp-tests(no-timer-scheduled-abort): …
tests/middleware-lifecycle.test.ts:286:41: error basecamp-tests(no-timer-scheduled-abort): …
REAL_EXIT=1
```

Exactly the two lines this PR removed. On the current tree it is silent,
`REAL_EXIT=0`.

**Self-test**, `typescript/lint-rules/test-no-timer-scheduled-abort.mjs` — oxlint
has no `RuleTester`, so it drives the real binary over 7 fixture files: the two
#783 shapes, the no-argument shape #715 removed, spelling variants
(`globalThis.setTimeout`, block bodies, `x["abort"]()`, nested functions), the
two in-flight seams, the `device.test.ts` racing-timer shape, and a suppression.
All 7 passed on first write, which proves nothing — so the rule was mutated:

| mutation | result |
|---|---|
| A. require a no-argument `abort()` (recreate #655's exact blind spot) | red: *"the #655 survivor: expected reports on lines [3], got []"* |
| B. accept only a bare `setTimeout` identifier | red: *"expected [2,3,4], got [3,4]"* |
| C. drop the "is this the timer's callback?" test | red on the negatives: *"in-flight seams are allowed: expected [], got [4,8]"* |
| D. plugin path renamed (failed load) | red — and the gate alone also reds |
| E. `create()` returns a visitor that never dispatches | **gate alone: `REAL_EXIT=0`. Self-test: `REAL_EXIT=1`** |

**Mutation E is why the self-test runs beside the rule rather than only when the
rule is edited.** oxlint's JS plugin API is alpha and explicitly not covered by
semver, and `oxlint` sits behind `^1.50.0`. A bump that stopped dispatching the
visitor would leave the gate green while enforcing nothing — a silent fail-open.
The self-test converts that into a build failure.

### The gate's first CI run went red, and the rule was not the reason

Worth recording, because it is the same lesson one level up. oxlint detects
`GITHUB_ACTIONS` and switches to the `##[error]…` annotation format; the
harness's line-scraping parser matched only the default format. The rule fired
on all three positive fixtures in CI — the annotations are right there in the
log — and the harness reported `got []`.

It failed closed, which is what it was built to do. But a harness that reads
differently on the machine that matters will eventually be wrong in the other
direction, so the fix is not just to match the other format:

- parse `--format json` and match on the rule **code**, so a finding also has to
  come from *this* rule rather than merely exist;
- run every case **twice**, once with `GITHUB_ACTIONS` unset and once with it
  set, putting the environment in the matrix instead of trusting the local run;
- invoke `node_modules/.bin/oxlint` directly rather than through `npx`, so
  resolution is identical everywhere.

Mutation E was re-proved against the rewritten harness: gate green under a
simulated CI environment, self-test red in **both** environments.

### Wiring

`make ts-check` gains `ts-lint-test-timers` (self-test, then gate). But
membership in a make target is **not** CI coverage in this repo — no CI job runs
`make check`, and `npm run lint` itself was only ever a CI step, never in
`ts-check`. So both also run as their own steps in the `test-typescript` job in
`.github/workflows/test.yml`, which has no path filter and runs on every PR.
`make lint-actions` (actionlint + zizmor) passes on the edited workflow.

Confirmed by running it, not by reading the YAML — from the TypeScript Tests job
on `7c91c52e9`:

```
5. Lint: success
6. Self-test the timer-scheduled-abort lint rule: success
7. Check for timer-scheduled aborts in tests: success

no-timer-scheduled-abort self-test: 14 checks passed (7 cases x 2 environments).
```

`CONTRIBUTING.md` now points at the rule as the enforcement and keeps only what
the rule cannot express — which assertion is the discriminating one, and when a
wall-clock ceiling is redundant with it — so there is one source of truth, not
two.

## Verification

- `LC_ALL=C make ts-check` — `REAL_EXIT=0`, 87 files passed, including the new
  `ts-lint-test-timers` prerequisite. (Local counts are not quoted as CI's;
  local and CI have differed here before.)
- `make lint-actions` — `REAL_EXIT=0`. `make lint-npm-lockfile-writes` —
  `REAL_EXIT=0`; `typescript/package-lock.json` is untouched.
- `LC_ALL=C make rb-check` — `REAL_EXIT=0`, 0 failures, 0 errors, rubocop clean
  across 158 files.
- `LC_ALL=C make doc-constants-check` — `REAL_EXIT=0` (`CONTRIBUTING.md` carries
  no marked spans; the note restates no constant).
Repeated runs under load, all in one session with 8 extra spinners on a 10-core
box that was already carrying a load average of 22 — it rose to **130** by the
end, which is well past the parallel-`make check` conditions that produced both
original reds:

| surface | runs | failures |
|---|---|---|
| `typescript/tests/middleware-lifecycle.test.ts` | 20 | 0 |
| Ruby `test_proxy_credentials_are_percent_decoded` alone | 20 | 0 |
| Ruby `oauth_transport_test.rb` whole file | 20 | 0 |
| full TypeScript suite (the #783 repro condition) | 5 | 0 |

### One red check, not from this branch

`Trivy (Go SDK)` fails on CVE-2026-56864 / CVE-2026-56865 in
`golang.org/x/mod v0.38.0` (fixed in 0.40.0). This PR changes no Go file —
`git diff origin/main...HEAD --name-only` is two test files, a lint rule and its
self-test, `CONTRIBUTING.md`, the `Makefile` and one workflow — and `origin/main`
carries the same `go.sum` pin. The Security workflow was green on `main` at
`270ea44d` and the advisories published since, so this is a vulnerability-DB
refresh that will red every open PR until the dependency moves. Bumping it here
would widen a de-flaking PR into a dependency one; it wants its own change.

Closes #783
Closes #739

## Review follow-up: promptness is asserted, not just named

Codex was right that the attempt ledger alone left the backoff test vacuous for its own name. A sleep that *noticed* the abort but deferred its rejection to the timer's expiry never starts attempt 2 and still rejects with the caller's reason, so `starts == [1]`, `ends == [1]` and `err === reason` all pass — two seconds late. Only a sleep ignoring cancellation entirely was caught.

The test now installs fake timers for `setTimeout`/`clearTimeout` (`setImmediate` and `Date` stay real), so the 2s backoff timer can fire only if the test advances the clock, and it never does. `expect(settled).toBe(true)`, evaluated after a barrier of five complete event-loop turns counted from the abort's delivery, is then the promptness assertion. Turns rather than milliseconds: under load a turn takes longer, but the number of turns a settlement needs does not, so no wall-clock threshold returns (#783). Five is slack — the rejection propagates through microtasks alone, measured before choosing the number.

Mutation 6, `sleep`'s `onAbort` recording the abort and letting the timer callback reject:

```
# this version
× rejects promptly when the caller aborts during a retry backoff 17ms
AssertionError: expected false to be true
REAL_EXIT=1

# the previous version of the test, same mutant
✓ rejects promptly when the caller aborts during a retry backoff   (2.77s)
REAL_EXIT=0
```

The green run's 2.77s is the vacuity itself. Table row above amended accordingly: the abort-during-backoff test now rests on the promptness assertion *and* `starts == [1]`.

Also from review (Copilot, suppressed comments — triaged in a comment below): the rule's ancestor walk compared the callback function against the timer's first argument, which is the wrapper node when type-only syntax sits in between, so `setTimeout((() => c.abort()) as () => void, 50)` and its `satisfies` / `!` spellings slipped the gate. Wrappers are erased before the comparison now, with a self-test case that reds without the fix (`expected [2,3,4], got []`). CONTRIBUTING's population bound covered dot-member access only while the rule also recognizes bare `abort()` and `c["abort"]()`; it now covers all three, and both spellings return the same 15 sites today.
