### PR TITLE
Judge the advertised OAuth issuer's address, not just its spelling

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -1685,6 +1685,51 @@ every `fetchJSON` above MUST:
 
 Non-2xx on either hop → `api_error` (not `network`).
 
+##### 5. Judge the advertised issuer's ADDRESS, not only its spelling `[Go-first]`
+
+Requirements 1–4 apply to both hops, and hop 1 needs nothing further: its origin
+is the resource identifier the *caller* supplied. Hop 2 is different in kind.
+`discoverFromResource` lifts `authorization_servers[]` out of a parsed response
+body, and with no `expectedIssuer` the "single non-Launchpad entry wins"
+heuristic makes a remote peer's string the socket destination. `requireOriginRoot`
+is a syntax gate with no notion of what a host *resolves to*, and issuer binding
+runs only after the response comes back — so a refusal there is already too late
+to stop the connection from reporting whether an internal host and port are live.
+The exposure is bounded — fixed path, GET, no credentials, near-blind — but it is
+a working internal host/port oracle, and the discovery fetch is not where the
+selected issuer stops being used. The `Config` it returns carries
+`token_endpoint` (required) and `device_authorization_endpoint`, and those become
+the destinations of the grant itself: `performDeviceLogin` takes exactly this
+already-selected config and posts the `client_id` to one and the `device_code` to
+the other, and the token exchange and refresh post the authorization code,
+`client_secret`, or refresh token to `token_endpoint`. Those are form-body
+credentials, not an `Authorization: Bearer` header — no Bearer header is sent to
+a discovered issuer.
+
+Hop 2 therefore SHOULD refuse an advertised issuer whose **address** is in
+private, loopback, link-local, CGNAT, or IANA special-purpose space, judged at
+the moment of connection rather than by parsing the URL — which is also what
+catches a legacy-numeric spelling (`https://2130706433/` is `127.0.0.1`) and a
+name that resolves into that space. The refusal is the existing hard
+`invalid_issuer_origin`, not `as_fetch_failed`: it is a permanent verdict on the
+origin, and must not be marked retryable. It applies on **both** selection paths,
+`expectedIssuer` included — an SDK-level exemption for a caller-named issuer is
+silently wrong when the consumer computed that value from untrusted input.
+
+Because an SDK is a shared dependency, an implementation MUST expose an override
+for the policy, for the client that carries the hop, and to disable it — an
+internal deployment must be able to admit its own range without abandoning the
+rest of the deny tables.
+
+**Go is the only implementation today**, via
+`github.com/basecamp/surfguard/go`'s dial-time enforcement
+(`oauth.DefaultIssuerPolicy`, `WithIssuerPolicy` / `WithIssuerHTTPClient` /
+`WithoutIssuerPolicy`). It is written `SHOULD` and marked `[Go-first]` rather
+than folded into the `[conformance]` list above because the corpus cannot express
+it: the assertion is "no connection was attempted", which is not an observable
+of the mock-HTTP runner, and the remaining four SDKs have no equivalent
+enforcement layer to point at yet. See Appendix F.
+
 #### Injected-client fidelity tier `[static]`
 
 SDKs that accept a caller-supplied HTTP client (Ruby `http_client:`, and any
@@ -3589,6 +3634,28 @@ Every operation has a `retry` block, including non-idempotent POSTs. For non-ide
 ---
 
 ## Appendix F: Known Cross-SDK Divergences
+
+### Advertised-Issuer Address Policy (§16)
+
+§16's SSRF requirement 5 — judging the *address* an advertised
+`authorization_servers[]` entry resolves to, at connection time — is implemented
+in Go only. This is a deliberate Go-first move, not an oversight in the other
+five: the enforcement seam it needs (a dial-time `Control` hook, plus a shared
+classification table) exists cheaply in Go and does not in the others.
+
+| SDK | Advertised-issuer hop |
+|-----|----------------------|
+| Go | `oauth.DefaultIssuerPolicy()` — `surfguard.Policy{}.IANASpecialUse().AllowAllPorts()` — installed on a separate client that carries only that hop. Refused as hard `invalid_issuer_origin`, non-retryable, on both selection paths. Overrides: `WithIssuerPolicy`, `WithIssuerHTTPClient`, `WithoutIssuerPolicy` |
+| TypeScript, Ruby, Python, Kotlin | Requirements 1–4 only: origin-root syntax gate, HTTPS, bounded timeout, suppressed redirects, bounded body. An advertised issuer naming a private address is still dialed |
+| Swift | Not applicable — ships no OAuth discovery implementation |
+
+Two consequences are worth stating rather than discovering. First, this is a
+behavioral tightening, not a pure addition: a Go consumer whose BC5 issuer is
+advertised on loopback or in RFC 1918 space, and which worked before, now needs
+`WithIssuerPolicy`. Second, `Allow(prefix)` does **not** re-admit RFC 1918 under
+`IANASpecialUse()` — those tables outrank `Allow`, and `AllowLoopback()` is the
+only derivation that pierces them — so an on-premises policy is built as
+`surfguard.Policy{}.AllowAllPorts().Allow(...)` instead.
 
 ### Retry Strategy (§7)
 

--- a/go/README.md
+++ b/go/README.md
@@ -198,7 +198,7 @@ if err != nil {
     switch {
     case errors.Is(err, oauth.ErrAmbiguousIssuers):          // ≥2 non-Launchpad issuers, no expected issuer
     case errors.Is(err, oauth.ErrExpectedIssuerUnavailable): // expected issuer not advertised
-    case errors.Is(err, oauth.ErrInvalidIssuerOrigin):       // advertised issuer is not a valid origin root
+    case errors.Is(err, oauth.ErrInvalidIssuerOrigin):       // advertised issuer refused: bad origin root, or blocked address
     case errors.Is(err, oauth.ErrASFetchFailed):             // committed issuer's AS metadata unavailable
     case errors.Is(err, oauth.ErrIssuerMismatch):            // committed issuer's metadata fails issuer binding
     }
@@ -226,6 +226,39 @@ Notes:
   socket opens, HTTPS is required (localhost exempt), redirects are suppressed,
   timeouts are bounded, and bodies are read under a bounded cap. Non-2xx on
   either hop surfaces as an `api_error`.
+- **The advertised-issuer hop additionally enforces an address policy.** That
+  hop is the one whose destination comes from a parsed response body, so URL
+  syntax is not enough: `net/url` has no notion of what a host resolves to.
+  `DiscoverFromResource` judges the literal address at connection time via
+  `oauth.DefaultIssuerPolicy()`, so a syntactically valid issuer pointing at
+  private, loopback, link-local, or other special-use space is refused before a
+  socket opens — including legacy spellings like `http://2130706433/`, and
+  including a name that resolves to blocked space only at dial time. The
+  refusal surfaces as `ErrInvalidIssuerOrigin`; it also matches
+  `errors.Is(err, surfguard.ErrBlocked)` and wraps a `*surfguard.Violation` if
+  you need to tell the two causes apart. Hop 1 and `Discover` are unaffected —
+  their destinations are operator-configured.
+
+  A deployment whose issuer legitimately sits off the public internet re-admits
+  exactly the space it needs rather than switching the policy off. Mind
+  surfguard's precedence when you do: `Allow` re-admits space the default deny
+  tables refuse but **not** space the `IANASpecialUse` tables refuse, and those
+  cover all of RFC 1918.
+
+  ```go
+  // On-premises issuer in private space — build without IANASpecialUse.
+  oauth.NewDiscoverer(c, oauth.WithIssuerPolicy(
+      surfguard.Policy{}.AllowAllPorts().Allow(netip.MustParsePrefix("10.4.0.0/16"))))
+
+  // Local development — AllowLoopback does pierce those tables.
+  oauth.NewDiscoverer(c, oauth.WithIssuerPolicy(
+      oauth.DefaultIssuerPolicy().AllowLoopback()))
+  ```
+
+  `oauth.WithIssuerHTTPClient` carries the hop on your own client, which a
+  consumer egressing through a proxy needs since surfguard's transport sets
+  `Proxy: nil` by construction. `oauth.WithoutIssuerPolicy` restores the
+  pre-policy behavior outright.
 
 ### OAuth device authorization grant (RFC 8628)
 

--- a/go/README.md
+++ b/go/README.md
@@ -232,8 +232,11 @@ Notes:
   `DiscoverFromResource` judges the literal address at connection time via
   `oauth.DefaultIssuerPolicy()`, so a syntactically valid issuer pointing at
   private, loopback, link-local, or other special-use space is refused before a
-  socket opens — including legacy spellings like `http://2130706433/`, and
-  including a name that resolves to blocked space only at dial time. The
+  socket opens — including legacy spellings like `https://2130706433/`, and
+  including a name that resolves to blocked space only at dial time. (The
+  `https` here is load-bearing: on the `http` spelling of that same host the
+  origin-root profile refuses first, so it would demonstrate the pre-existing
+  scheme gate rather than the address policy.) The
   refusal surfaces as `ErrInvalidIssuerOrigin`; it also matches
   `errors.Is(err, surfguard.ErrBlocked)` and wraps a `*surfguard.Violation` if
   you need to tell the two causes apart. Hop 1 and `Discover` are unaffected —

--- a/go/go.mod
+++ b/go/go.mod
@@ -3,6 +3,7 @@ module github.com/basecamp/basecamp-sdk/go
 go 1.26
 
 require (
+	github.com/basecamp/surfguard/go v0.1.0
 	github.com/oapi-codegen/runtime v1.6.0
 	github.com/prometheus/client_golang v1.24.1
 	github.com/zalando/go-keyring v0.2.8

--- a/go/go.sum
+++ b/go/go.sum
@@ -1,6 +1,8 @@
 github.com/RaveNoX/go-jsoncommentstrip v1.0.0/go.mod h1:78ihd09MekBnJnxpICcwzCMzGrKSKYe4AqU6PDYYpjk=
 github.com/apapsch/go-jsonmerge/v2 v2.0.0 h1:axGnT1gRIfimI7gJifB699GoE/oq+F2MU7Dml6nw9rQ=
 github.com/apapsch/go-jsonmerge/v2 v2.0.0/go.mod h1:lvDnEdqiQrp0O42VQGgmlKpxL1AP2+08jFMw88y4klk=
+github.com/basecamp/surfguard/go v0.1.0 h1:JMo+MZQEOBRqnUylzD0/jS9S42Fp+XKWMG+4LWfu/XE=
+github.com/basecamp/surfguard/go v0.1.0/go.mod h1:y5MWhE5S/CZAPzUOS0LoOYGUVxTeWFByFDssE3/l4b4=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/bmatcuk/doublestar v1.1.1/go.mod h1:UD6OnuiIn0yFxxA2le/rnRU1G4RaI4UvFv1sNto9p6w=

--- a/go/pkg/basecamp/oauth/device.go
+++ b/go/pkg/basecamp/oauth/device.go
@@ -251,7 +251,12 @@ func RequestDeviceAuthorization(ctx context.Context, deviceAuthEndpoint, clientI
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.Header.Set("Accept", "application/json")
 
-	resp, err := cfg.httpClient.Do(req) // #nosec G704 -- SDK HTTP client: caller-supplied discovery endpoint
+	// The suppression is about gosec's taint rule, not a claim that this URL is
+	// trusted. DeviceAuthorizationEndpoint may be caller-configured, but it may
+	// equally come from DiscoverFromResource's metadata, in which case a remote
+	// peer chose it and NOTHING here judges the address it resolves to — see
+	// issue #806. This request carries client_id.
+	resp, err := cfg.httpClient.Do(req) // #nosec G704 -- see the note above: not address-policed (#806)
 	if err != nil {
 		// A caller cancelling (or its deadline expiring) during the POST must
 		// surface as DeviceFlowCancelled, not a retryable transport failure. The
@@ -609,7 +614,10 @@ func postDeviceToken(ctx context.Context, cfg deviceConfig, tokenEndpoint string
 	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	req.Header.Set("Accept", "application/json")
 
-	resp, err := cfg.httpClient.Do(req) // #nosec G704 -- SDK HTTP client: caller-supplied token endpoint
+	// As above: TokenEndpoint may come from discovered metadata rather than from
+	// the caller, and its address is not policed (#806). This request carries
+	// the device_code.
+	resp, err := cfg.httpClient.Do(req) // #nosec G704 -- see the note above: not address-policed (#806)
 	if err != nil {
 		// Parent cancellation ends the flow; a per-request timeout backs off.
 		if ctx.Err() != nil {

--- a/go/pkg/basecamp/oauth/discovery.go
+++ b/go/pkg/basecamp/oauth/discovery.go
@@ -11,7 +11,10 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
+
+	surfguard "github.com/basecamp/surfguard/go"
 
 	"github.com/basecamp/basecamp-sdk/go/pkg/basecamp"
 )
@@ -40,17 +43,159 @@ const (
 // socket opens, HTTPS is required (localhost exempt), redirects are suppressed,
 // timeouts are bounded, and bodies are read under a genuine bounded cap that
 // aborts before an oversized body is fully buffered.
+//
+// One fetch needs more than that. DiscoverFromResource's second hop dials an
+// origin lifted from a parsed HTTP response body — the remote resource chose
+// the string — so requireOriginRoot, a syntax gate with no notion of what a
+// host resolves to, is not enough on its own: issuer binding only runs once the
+// response is back, which is after the socket has already told the caller
+// whether an internal host and port are live. That hop therefore goes out on a
+// separate client whose transport judges the literal address of every connect
+// attempt against [DefaultIssuerPolicy]. See [NewDiscoverer] for the overrides.
 type Discoverer struct {
 	httpClient *http.Client
+	// issuerClient carries DiscoverFromResource's advertised-issuer hop, and
+	// only that hop. Every other fetch — hop 1, Discover, DiscoverLaunchpad —
+	// targets an origin the CALLER named and keeps using httpClient.
+	issuerClient *http.Client
+}
+
+// DefaultIssuerPolicy is the surfguard policy DiscoverFromResource applies to
+// the advertised-issuer hop.
+//
+// IANASpecialUse is the documented policy for advertised or discovered
+// infrastructure values — data a remote peer chose — and blocks the IANA
+// special-purpose registries on top of the default private/loopback/link-local
+// deny tables. AllowAllPorts lifts surfguard's default {80, 443} restriction
+// because the origin-root profile legitimately admits an explicit port, and
+// the address classification is what closes the exposure here; a port list
+// would refuse honest issuers without narrowing which hosts are reachable.
+func DefaultIssuerPolicy() surfguard.Policy {
+	return surfguard.Policy{}.IANASpecialUse().AllowAllPorts()
+}
+
+// DiscovererOption configures a Discoverer at construction.
+type DiscovererOption func(*discovererConfig)
+
+type discovererConfig struct {
+	policy       surfguard.Policy
+	policySet    bool
+	policyOff    bool
+	issuerClient *http.Client
+}
+
+// sharedIssuerClient is the DefaultIssuerPolicy client, built once and shared by
+// every Discoverer that did not ask for something else.
+//
+// It owns an *http.Transport, and therefore a connection pool that nothing can
+// close: a Discoverer exposes no Close, so a per-Discoverer transport would leak
+// a pool per construction. Sharing is safe precisely because nothing mutates it
+// — fetchDiscoveryDocument calls noRedirectClient, which copies the client
+// before setting CheckRedirect, so the shared instance is only ever read.
+//
+// Only the DEFAULT is shared. A caller-supplied policy gets its own transport,
+// or one caller's Allow would silently widen every other Discoverer in the
+// process.
+var sharedIssuerClient = sync.OnceValue(func() *http.Client {
+	return &http.Client{Transport: DefaultIssuerPolicy().RoundTripper()}
+})
+
+// WithIssuerPolicy replaces [DefaultIssuerPolicy] for the advertised-issuer
+// hop, so a deployment whose BC5 issuer is not on the public internet re-admits
+// exactly the space it needs rather than switching the policy off.
+//
+// Mind which layer refuses the address, because surfguard's precedence decides
+// which derivation works. Allow re-admits space the DEFAULT deny tables refuse,
+// but NOT space the IANASpecialUse tables refuse — and those tables cover all of
+// RFC 1918. So an on-premises issuer in private space is admitted by building
+// the policy without IANASpecialUse:
+//
+//	oauth.NewDiscoverer(c, oauth.WithIssuerPolicy(
+//		surfguard.Policy{}.AllowAllPorts().Allow(netip.MustParsePrefix("10.4.0.0/16"))))
+//
+// while a local-development issuer takes the one derivation that does pierce
+// those tables:
+//
+//	oauth.NewDiscoverer(c, oauth.WithIssuerPolicy(
+//		oauth.DefaultIssuerPolicy().AllowLoopback()))
+//
+// Either way the rest of the deny tables stay in force, which is the whole
+// point of preferring this over WithoutIssuerPolicy.
+//
+// It has no effect alongside WithIssuerHTTPClient, which supplies the transport
+// the policy would otherwise be installed in.
+func WithIssuerPolicy(p surfguard.Policy) DiscovererOption {
+	return func(c *discovererConfig) { c.policy, c.policySet = p, true }
+}
+
+// WithIssuerHTTPClient carries the advertised-issuer hop on the given client
+// instead of the policy-enforced one, and takes precedence over
+// WithIssuerPolicy.
+//
+// It exists because surfguard's transport sets Proxy: nil by construction — a
+// proxied request would have the proxy's address judged instead of the
+// target's — so a consumer that must egress through a proxy has no way to keep
+// both. Enforcement becomes the caller's: compose the client's transport from
+// DefaultIssuerPolicy().RoundTripper() where that is possible, and understand
+// that through a proxy no dial-time check can judge the target at all.
+func WithIssuerHTTPClient(client *http.Client) DiscovererOption {
+	return func(c *discovererConfig) { c.issuerClient = client }
+}
+
+// WithoutIssuerPolicy carries the advertised-issuer hop on the Discoverer's own
+// HTTP client with no address policy, restoring the pre-policy behavior.
+//
+// Reach for it only when the surrounding network already constrains where the
+// process may connect. Prefer WithIssuerPolicy, which keeps the rest of the
+// deny tables in force while admitting the one range a deployment needs.
+func WithoutIssuerPolicy() DiscovererOption {
+	return func(c *discovererConfig) { c.policyOff = true }
 }
 
 // NewDiscoverer creates a Discoverer with the given HTTP client.
 // If httpClient is nil, http.DefaultClient is used.
-func NewDiscoverer(httpClient *http.Client) *Discoverer {
+//
+// httpClient carries every fetch whose origin the caller named. The one fetch
+// it does not carry is DiscoverFromResource's advertised-issuer hop, which by
+// default rides a client built from [DefaultIssuerPolicy] — so a caller's
+// custom TLS roots, proxy, or instrumented transport do NOT apply there unless
+// [WithIssuerHTTPClient] passes them in explicitly.
+//
+// Constructing a Discoverer is cheap: the default issuer client is built once
+// for the process and shared, so a Discoverer per request does not accumulate
+// connection pools. A Discoverer given [WithIssuerPolicy] gets its own
+// transport, since one caller's policy must not become everyone's — reuse that
+// Discoverer rather than rebuilding it in a loop.
+func NewDiscoverer(httpClient *http.Client, opts ...DiscovererOption) *Discoverer {
 	if httpClient == nil {
 		httpClient = http.DefaultClient
 	}
-	return &Discoverer{httpClient: httpClient}
+
+	cfg := discovererConfig{policy: DefaultIssuerPolicy()}
+	for _, o := range opts {
+		o(&cfg)
+	}
+
+	var issuerClient *http.Client
+	switch {
+	case cfg.issuerClient != nil:
+		// Caller-supplied: theirs, enforcement included.
+		issuerClient = cfg.issuerClient
+	case cfg.policyOff:
+		issuerClient = httpClient
+	case cfg.policySet:
+		// A caller's own policy gets a transport of its own. Reusing the shared
+		// one would apply the default policy instead; sharing a NEW one keyed
+		// off nothing would leak this caller's Allow into every other
+		// Discoverer. RoundTripper, not Client: the discovery fetch owns its
+		// own timeout (a context deadline) and its own redirect suppression,
+		// and surfguard's Client would layer a second, coarser 30s bound and a
+		// redirect follower this code path never wants.
+		issuerClient = &http.Client{Transport: cfg.policy.RoundTripper()}
+	default:
+		issuerClient = sharedIssuerClient()
+	}
+	return &Discoverer{httpClient: httpClient, issuerClient: issuerClient}
 }
 
 // DiscoverOption configures a discovery operation.
@@ -217,11 +362,11 @@ func isLaunchpadIssuer(issuer string) bool {
 	return origin == launchpad
 }
 
-// noRedirectClient returns a shallow copy of the configured client that
-// suppresses redirects. A 3xx then surfaces as a non-2xx api_error rather than
-// the client chasing an attacker-influenced Location.
-func (d *Discoverer) noRedirectClient() *http.Client {
-	c := *d.httpClient
+// noRedirectClient returns a shallow copy of the given client that suppresses
+// redirects. A 3xx then surfaces as a non-2xx api_error rather than the client
+// chasing an attacker-influenced Location.
+func noRedirectClient(base *http.Client) *http.Client {
+	c := *base
 	c.CheckRedirect = func(*http.Request, []*http.Request) error {
 		return http.ErrUseLastResponse
 	}
@@ -261,11 +406,11 @@ func truncateBody(body []byte) string {
 	return s
 }
 
-// fetchDiscoveryDocument performs an SSRF-hardened GET of a discovery document.
-// The origin must already be validated via requireOriginRoot; this re-checks TLS,
-// suppresses redirects, bounds the timeout, reads the body under a bounded cap,
-// and maps non-2xx to api_error.
-func (d *Discoverer) fetchDiscoveryDocument(ctx context.Context, rawURL string, cfg discoverConfig) ([]byte, error) {
+// fetchDiscoveryDocument performs an SSRF-hardened GET of a discovery document
+// on the given client. The origin must already be validated via
+// requireOriginRoot; this re-checks TLS, suppresses redirects, bounds the
+// timeout, reads the body under a bounded cap, and maps non-2xx to api_error.
+func (d *Discoverer) fetchDiscoveryDocument(ctx context.Context, client *http.Client, rawURL string, cfg discoverConfig) ([]byte, error) {
 	if err := basecamp.RequireSecureEndpoint(rawURL); err != nil {
 		return nil, &basecamp.Error{
 			Code:    basecamp.CodeUsage,
@@ -290,7 +435,7 @@ func (d *Discoverer) fetchDiscoveryDocument(ctx context.Context, rawURL string, 
 	}
 	req.Header.Set("Accept", "application/json")
 
-	resp, err := d.noRedirectClient().Do(req) // #nosec G704 -- SDK HTTP client: URL is origin-root validated
+	resp, err := noRedirectClient(client).Do(req) // #nosec G704 -- SDK HTTP client: URL is origin-root validated
 	if err != nil {
 		return nil, basecamp.ErrNetwork(fmt.Errorf("OAuth discovery request failed: %w", err))
 	}
@@ -339,7 +484,11 @@ func (d *Discoverer) Discover(ctx context.Context, baseURL string, opts ...Disco
 	}
 	// Bind against the caller's raw baseURL (RFC 8414 §3.3, SPEC.md §16 "NO
 	// normalization"); the normalized origin is only for the fetch URL.
-	return d.fetchASMetadata(ctx, origin, baseURL, newDiscoverConfig(opts))
+	//
+	// httpClient, not issuerClient: baseURL is the CALLER's, so this is not the
+	// advertised-issuer hop the address policy exists for — and a local
+	// development server on http://localhost must stay reachable here.
+	return d.fetchASMetadata(ctx, d.httpClient, origin, baseURL, newDiscoverConfig(opts))
 }
 
 // rawDiscoveryResponse mirrors an RFC 8414 metadata document. Endpoint fields
@@ -360,8 +509,8 @@ type rawDiscoveryResponse struct {
 // are distinct: the resource-first flow fetches from the normalized origin yet
 // binds against the exact advertised issuer string (which may spell a trailing
 // slash or explicit default port). Public Discover passes the same value for both.
-func (d *Discoverer) fetchASMetadata(ctx context.Context, issuerOrigin, bindIssuer string, cfg discoverConfig) (*Config, error) {
-	body, err := d.fetchDiscoveryDocument(ctx, issuerOrigin+wellKnownAS, cfg)
+func (d *Discoverer) fetchASMetadata(ctx context.Context, client *http.Client, issuerOrigin, bindIssuer string, cfg discoverConfig) (*Config, error) {
+	body, err := d.fetchDiscoveryDocument(ctx, client, issuerOrigin+wellKnownAS, cfg)
 	if err != nil {
 		return nil, err
 	}
@@ -478,7 +627,9 @@ func (d *Discoverer) DiscoverProtectedResource(ctx context.Context, resourceOrig
 // caller supplied — with NO normalization (SPEC.md §16). DiscoverProtectedResource
 // and DiscoverFromResource pass the raw resourceOrigin.
 func (d *Discoverer) fetchProtectedResource(ctx context.Context, origin, bindResource string, cfg discoverConfig) (*ProtectedResourceMetadata, error) {
-	body, err := d.fetchDiscoveryDocument(ctx, origin+wellKnownResource, cfg)
+	// Always httpClient: the resource origin is the caller's own identifier on
+	// both paths into here, never an advertised one.
+	body, err := d.fetchDiscoveryDocument(ctx, d.httpClient, origin+wellKnownResource, cfg)
 	if err != nil {
 		return nil, err
 	}
@@ -599,10 +750,42 @@ func (d *Discoverer) DiscoverFromResource(ctx context.Context, resourceOrigin st
 
 	// Fetch from the normalized origin, but bind the metadata issuer against the
 	// exact advertised string (selectedIssuer), not the normalized origin.
-	config, err := d.fetchASMetadata(ctx, issuerOrigin, selectedIssuer, cfg)
+	//
+	// issuerClient, not httpClient: this is the one hop whose destination a
+	// remote peer chose. The policy applies on BOTH selection paths, the
+	// expected-issuer one included. Strictly, an issuer the caller named in
+	// WithExpectedIssuer is caller-determined and could be exempt — but "the
+	// policy applies sometimes" is the branch that grows a bypass, and the
+	// exemption is silently wrong for a consumer that computed its expected
+	// issuer from untrusted input.
+	config, err := d.fetchASMetadata(ctx, d.issuerClient, issuerOrigin, selectedIssuer, cfg)
 	if err != nil {
 		if errors.Is(err, errIssuerBindingMismatch) {
 			return nil, newSelectionError(ErrIssuerMismatch, err.Error(), err)
+		}
+		// A policy refusal is a verdict on the origin itself, so it joins the
+		// existing invalid_issuer_origin case rather than minting a sixth
+		// sentinel: requireOriginRoot judged the spelling, the address policy
+		// judged what it resolves to, and a consumer's remedy is the same for
+		// both — this issuer is not one to talk to. It is deliberately NOT
+		// as_fetch_failed, which callers may reasonably read as transient.
+		// errors.Is sees through net/http's url.Error and net.OpError wrapping
+		// and through basecamp.Error's Cause, so this catches a dial-time
+		// refusal (including one after a DNS rebind, or a redirect hop) as well
+		// as a malformed host refused before the transport.
+		if errors.Is(err, surfguard.ErrBlocked) {
+			msg := fmt.Sprintf("advertised issuer %q resolves to an address refused by the issuer policy", selectedIssuer)
+			// Re-code the cause before handing it to SelectionError, which
+			// inherits HTTPStatus and Retryable from the innermost
+			// *basecamp.Error it finds. fetchDiscoveryDocument classified the
+			// dial failure as a retryable network error before anything had
+			// looked at WHY the dial failed, and a policy refusal is the
+			// opposite of retryable — surfguard's contract is that blocked
+			// means deactivate the target, unresolvable means retry later.
+			// The original error stays in the chain, so errors.Is still
+			// reaches surfguard.ErrBlocked and the *Violation.
+			cause := &basecamp.Error{Code: basecamp.CodeAPI, Message: msg, Cause: err}
+			return nil, newSelectionError(ErrInvalidIssuerOrigin, msg, cause)
 		}
 		// A caller cancelling (or its deadline expiring) during the committed AS
 		// fetch must surface as cancellation, not a misclassified as_fetch_failed

--- a/go/pkg/basecamp/oauth/discovery.go
+++ b/go/pkg/basecamp/oauth/discovery.go
@@ -125,7 +125,11 @@ var sharedIssuerClient = sync.OnceValue(func() *http.Client {
 // It has no effect alongside WithIssuerHTTPClient, which supplies the transport
 // the policy would otherwise be installed in.
 func WithIssuerPolicy(p surfguard.Policy) DiscovererOption {
-	return func(c *discovererConfig) { c.policy, c.policySet = p, true }
+	// Clears policyOff: these two are mutually exclusive, so the LAST one wins
+	// rather than the most permissive one. A wrapper appending a required
+	// WithIssuerPolicy after caller-supplied defaults must be able to override
+	// a WithoutIssuerPolicy sitting in those defaults.
+	return func(c *discovererConfig) { c.policy, c.policySet, c.policyOff = p, true, false }
 }
 
 // WithIssuerHTTPClient carries the advertised-issuer hop on the given client
@@ -149,7 +153,9 @@ func WithIssuerHTTPClient(client *http.Client) DiscovererOption {
 // process may connect. Prefer WithIssuerPolicy, which keeps the rest of the
 // deny tables in force while admitting the one range a deployment needs.
 func WithoutIssuerPolicy() DiscovererOption {
-	return func(c *discovererConfig) { c.policyOff = true }
+	// Clears policySet for the same reason WithIssuerPolicy clears policyOff:
+	// last one wins. See that option's note.
+	return func(c *discovererConfig) { c.policyOff, c.policySet = true, false }
 }
 
 // NewDiscoverer creates a Discoverer with the given HTTP client.

--- a/go/pkg/basecamp/oauth/exchange.go
+++ b/go/pkg/basecamp/oauth/exchange.go
@@ -114,7 +114,13 @@ func (e *Exchanger) doTokenRequest(ctx context.Context, tokenEndpoint string, da
 	httpReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	httpReq.Header.Set("Accept", "application/json")
 
-	resp, err := e.httpClient.Do(httpReq) // #nosec G704 -- SDK HTTP client: URL is caller-configured
+	// The suppression is about gosec's taint rule, not a claim that this URL is
+	// trusted. TokenEndpoint may be caller-configured, but it may equally come
+	// from DiscoverFromResource's metadata, in which case a remote peer chose it
+	// and NOTHING here judges the address it resolves to — see issue #806. This
+	// request carries the authorization code, the client secret, or a refresh
+	// token, so it is the highest-value of the three such call sites.
+	resp, err := e.httpClient.Do(httpReq) // #nosec G704 -- see the note above: not address-policed (#806)
 	if err != nil {
 		return nil, fmt.Errorf("token request failed: %w", err)
 	}

--- a/go/pkg/basecamp/oauth/issuer_policy_test.go
+++ b/go/pkg/basecamp/oauth/issuer_policy_test.go
@@ -299,6 +299,45 @@ func TestWithoutIssuerPolicy_RestoresPrePolicyBehavior(t *testing.T) {
 	}
 }
 
+// TestIssuerPolicyTogglesAreLastWins pins the composition semantics of the two
+// mutually exclusive toggles. Options are appended by wrappers that cannot see
+// each other, so the resolution must depend on ORDER rather than on which
+// option is more permissive — otherwise a WithoutIssuerPolicy buried in a
+// shared default silently defeats a WithIssuerPolicy a wrapper appends after
+// it, and the hop runs unprotected while the code reads as though it is not.
+func TestIssuerPolicyTogglesAreLastWins(t *testing.T) {
+	// Off then on: the policy must be back in force, so the loopback issuer is
+	// refused and never contacted.
+	t.Run("policy_last_wins", func(t *testing.T) {
+		bc5, counter := bc5OnLoopback(t)
+		resourceOrigin := resourceAdvertising(t, bc5)
+
+		_, err := NewDiscoverer(nil, WithoutIssuerPolicy(), WithIssuerPolicy(DefaultIssuerPolicy())).
+			DiscoverFromResource(context.Background(), resourceOrigin)
+		assertBlockedIssuer(t, err, counter)
+	})
+
+	// On then off: the later WithoutIssuerPolicy must win, so the same issuer
+	// is reached. Without this direction the test would pass under a rule of
+	// "the strictest option wins", which is not the semantics being pinned.
+	t.Run("off_last_wins", func(t *testing.T) {
+		bc5, counter := bc5OnLoopback(t)
+		resourceOrigin := resourceAdvertising(t, bc5)
+
+		result, err := NewDiscoverer(nil, WithIssuerPolicy(DefaultIssuerPolicy()), WithoutIssuerPolicy()).
+			DiscoverFromResource(context.Background(), resourceOrigin)
+		if err != nil {
+			t.Fatalf("DiscoverFromResource() error = %v, want nil", err)
+		}
+		if result.Issuer != bc5 {
+			t.Fatalf("want the loopback issuer selected, got %+v", result)
+		}
+		if counter.hits.Load() != 1 {
+			t.Errorf("issuer hits = %d, want 1", counter.hits.Load())
+		}
+	})
+}
+
 // TestDefaultIssuerClientIsShared pins the resource invariant: the default
 // issuer client owns a transport, and a Discoverer has no Close, so building one
 // per Discoverer would leak a connection pool per construction.

--- a/go/pkg/basecamp/oauth/issuer_policy_test.go
+++ b/go/pkg/basecamp/oauth/issuer_policy_test.go
@@ -1,0 +1,421 @@
+package oauth
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/netip"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	surfguard "github.com/basecamp/surfguard/go"
+
+	"github.com/basecamp/basecamp-sdk/go/pkg/basecamp"
+)
+
+// These tests cover the address policy on DiscoverFromResource's
+// advertised-issuer hop — the one fetch whose destination a remote peer chose.
+//
+// The hit counters are the load-bearing part. An assertion that discovery
+// returned an error proves only that discovery failed; it does not prove the
+// issuer was never contacted, and "the internal host answered, then binding
+// rejected it" is exactly the outcome the policy exists to prevent. Every
+// blocked case therefore asserts the target's handler ran zero times.
+
+// hitCounter is an http.Handler that records how many requests reached it and
+// serves usable AS metadata, so a policy that failed to block would produce a
+// SUCCESSFUL discovery rather than a differently-worded failure.
+type hitCounter struct {
+	hits   atomic.Int64
+	issuer string
+}
+
+func (h *hitCounter) ServeHTTP(w http.ResponseWriter, _ *http.Request) {
+	h.hits.Add(1)
+	w.Header().Set("Content-Type", "application/json")
+	_, _ = w.Write([]byte(`{"issuer":"` + h.issuer + `","token_endpoint":"` + h.issuer + `/oauth/token"}`))
+}
+
+// resourceAdvertising starts a hop-1 resource server whose metadata advertises
+// the given authorization server, and returns its origin.
+func resourceAdvertising(t *testing.T, advertised string) string {
+	t.Helper()
+	var origin string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"resource":"` + origin + `","authorization_servers":["` + advertised + `"]}`))
+	}))
+	t.Cleanup(srv.Close)
+	origin = srv.URL
+	return origin
+}
+
+// bc5OnLoopback starts a hop-2 issuer server on loopback — which the default
+// policy refuses — and returns its origin plus its hit counter.
+func bc5OnLoopback(t *testing.T) (string, *hitCounter) {
+	t.Helper()
+	counter := &hitCounter{}
+	srv := httptest.NewServer(counter)
+	t.Cleanup(srv.Close)
+	counter.issuer = srv.URL
+	return srv.URL, counter
+}
+
+func assertBlockedIssuer(t *testing.T, err error, counter *hitCounter) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("expected the advertised issuer to be refused, got nil error")
+	}
+	if !errors.Is(err, ErrInvalidIssuerOrigin) {
+		t.Errorf("errors.Is(err, ErrInvalidIssuerOrigin) = false; err = %v", err)
+	}
+	if !errors.Is(err, surfguard.ErrBlocked) {
+		t.Errorf("errors.Is(err, surfguard.ErrBlocked) = false; err = %v", err)
+	}
+	if errors.Is(err, ErrASFetchFailed) {
+		t.Errorf("a policy refusal must not read as the transient as_fetch_failed; err = %v", err)
+	}
+	var se *SelectionError
+	if !errors.As(err, &se) {
+		t.Errorf("expected a *SelectionError, got %T", err)
+	}
+	var be *basecamp.Error
+	if !errors.As(err, &be) || be.Code != basecamp.CodeAPI {
+		t.Errorf("expected the api_error taxonomy code, got %v (%T)", err, err)
+	}
+	// A policy refusal is permanent. The dial failure is classified as a
+	// retryable network error deep in the fetch, before anything knows why it
+	// failed, and SelectionError inherits Retryable from its cause — so without
+	// re-coding, callers would be told to retry a target they must stop talking
+	// to.
+	if be != nil && be.Retryable {
+		t.Errorf("Retryable = true; a policy refusal must not read as transient (err = %v)", err)
+	}
+	if counter != nil && counter.hits.Load() != 0 {
+		t.Errorf("the blocked issuer was contacted %d time(s); the policy must refuse before any connect", counter.hits.Load())
+	}
+}
+
+// TestDiscoverFromResource_BlockedIssuerIsNeverContacted is the core case: a
+// resource advertises an issuer in blocked space and the SDK must refuse it
+// without ever opening a connection to it.
+func TestDiscoverFromResource_BlockedIssuerIsNeverContacted(t *testing.T) {
+	bc5, counter := bc5OnLoopback(t)
+	resourceOrigin := resourceAdvertising(t, bc5)
+
+	// The hop-1 client is the httptest one; the hop-2 client is the default,
+	// policy-enforced one. That asymmetry is the feature under test.
+	_, err := NewDiscoverer(nil).DiscoverFromResource(context.Background(), resourceOrigin)
+	assertBlockedIssuer(t, err, counter)
+}
+
+// TestDiscoverFromResource_BlockedIssuerNamedByHostname is the same case one
+// layer further out. The literal-address form above is refused by the shape
+// check before the transport resolves anything; a NAME can only be judged after
+// resolution, which is the path that has to hold for a real advertised issuer
+// like "internal-sso.corp". "localhost" is the one name whose resolution is
+// dependable in a test, and it lands in exactly the blocked space.
+func TestDiscoverFromResource_BlockedIssuerNamedByHostname(t *testing.T) {
+	bc5, counter := bc5OnLoopback(t)
+	named := strings.Replace(bc5, "127.0.0.1", "localhost", 1)
+	if named == bc5 {
+		t.Fatalf("httptest origin %q is not the expected loopback form", bc5)
+	}
+	resourceOrigin := resourceAdvertising(t, named)
+
+	_, err := NewDiscoverer(nil).DiscoverFromResource(context.Background(), resourceOrigin)
+	assertBlockedIssuer(t, err, counter)
+}
+
+// TestDiscoverFromResource_RefusesLegacyNumericIssuer covers the spelling a
+// syntax gate cannot see through: "2130706433" is 127.0.0.1 written as a bare
+// integer, and it is a perfectly well-formed origin root.
+func TestDiscoverFromResource_RefusesLegacyNumericIssuer(t *testing.T) {
+	// https, so requireOriginRoot admits it and the refusal has to come from
+	// the address policy rather than the pre-existing HTTPS gate.
+	t.Run("https", func(t *testing.T) {
+		resourceOrigin := resourceAdvertising(t, "https://2130706433/")
+		_, err := NewDiscoverer(nil).DiscoverFromResource(context.Background(), resourceOrigin)
+		assertBlockedIssuer(t, err, nil)
+	})
+
+	// http on the same spelling is refused one layer earlier, by the origin-root
+	// profile: "2130706433" is not a localhost spelling, so plain http is out.
+	// Asserted so the two refusals stay distinguishable — this one is NOT
+	// evidence that the address policy works.
+	t.Run("http_refused_by_origin_root_not_the_policy", func(t *testing.T) {
+		resourceOrigin := resourceAdvertising(t, "http://2130706433/")
+		_, err := NewDiscoverer(nil).DiscoverFromResource(context.Background(), resourceOrigin)
+		if !errors.Is(err, ErrInvalidIssuerOrigin) {
+			t.Fatalf("errors.Is(err, ErrInvalidIssuerOrigin) = false; err = %v", err)
+		}
+		if errors.Is(err, surfguard.ErrBlocked) {
+			t.Errorf("expected the origin-root HTTPS gate, not the address policy; err = %v", err)
+		}
+	})
+}
+
+// TestDiscoverFromResource_ExpectedIssuerIsPoliciedToo pins the deliberate
+// decision to apply the policy uniformly. WithExpectedIssuer names an issuer
+// the caller chose, which could have been exempted — but a consumer may have
+// computed that value from untrusted input, and a policy that applies only on
+// one branch is the shape a bypass grows out of.
+func TestDiscoverFromResource_ExpectedIssuerIsPoliciedToo(t *testing.T) {
+	bc5, counter := bc5OnLoopback(t)
+	resourceOrigin := resourceAdvertising(t, bc5)
+
+	_, err := NewDiscoverer(nil).
+		DiscoverFromResource(context.Background(), resourceOrigin, WithExpectedIssuer(bc5))
+	assertBlockedIssuer(t, err, counter)
+}
+
+// TestDiscoverFromResource_TwoNonLaunchpadIssuersStillAmbiguous guards the
+// order of operations: the policy runs AFTER selection, so it must not quietly
+// turn an ambiguous advertisement into a single surviving candidate.
+func TestDiscoverFromResource_TwoNonLaunchpadIssuersStillAmbiguous(t *testing.T) {
+	blocked, blockedCounter := bc5OnLoopback(t)
+
+	var resourceOrigin string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"resource":"` + resourceOrigin +
+			`","authorization_servers":["` + blocked + `","https://bc5.example"]}`))
+	}))
+	defer srv.Close()
+	resourceOrigin = srv.URL
+
+	_, err := NewDiscoverer(nil).DiscoverFromResource(context.Background(), resourceOrigin)
+	if !errors.Is(err, ErrAmbiguousIssuers) {
+		t.Errorf("errors.Is(err, ErrAmbiguousIssuers) = false; err = %v", err)
+	}
+	if blockedCounter.hits.Load() != 0 {
+		t.Errorf("an ambiguous advertisement must contact nothing; got %d hit(s)", blockedCounter.hits.Load())
+	}
+}
+
+// TestWithIssuerPolicy_AdmitsLoopback exercises the first escape hatch, in the
+// spelling the docs prescribe: AllowLoopback is the one derivation that pierces
+// the IANASpecialUse tables.
+func TestWithIssuerPolicy_AdmitsLoopback(t *testing.T) {
+	bc5, counter := bc5OnLoopback(t)
+	resourceOrigin := resourceAdvertising(t, bc5)
+
+	result, err := NewDiscoverer(nil, WithIssuerPolicy(DefaultIssuerPolicy().AllowLoopback())).
+		DiscoverFromResource(context.Background(), resourceOrigin)
+	if err != nil {
+		t.Fatalf("DiscoverFromResource() error = %v, want nil", err)
+	}
+	if result.Config == nil || result.Issuer != bc5 {
+		t.Fatalf("want the loopback issuer selected, got %+v", result)
+	}
+	if counter.hits.Load() != 1 {
+		t.Errorf("issuer hits = %d, want 1", counter.hits.Load())
+	}
+}
+
+// TestWithIssuerPolicy_AllowUnderSpecialUseDoesNotReadmitPrivateSpace pins the
+// surfguard precedence the WithIssuerPolicy doc turns on, because it is the
+// thing an operator would most plausibly get wrong: Allow re-admits space the
+// DEFAULT tables refuse, not space the IANASpecialUse tables refuse, and all of
+// RFC 1918 is in the latter. An on-premises deployment that reached for
+// DefaultIssuerPolicy().Allow(...) would be silently still-blocked.
+func TestWithIssuerPolicy_AllowUnderSpecialUseDoesNotReadmitPrivateSpace(t *testing.T) {
+	private := netip.MustParseAddr("10.4.1.2")
+	prefix := netip.MustParsePrefix("10.4.0.0/16")
+
+	if !DefaultIssuerPolicy().Allow(prefix).Blocked(private) {
+		t.Error("DefaultIssuerPolicy().Allow(10.4.0.0/16) admits 10.4.1.2; the WithIssuerPolicy doc must be corrected")
+	}
+	// The spelling the doc prescribes instead: drop IANASpecialUse, keep the
+	// default deny tables, allow the one range.
+	onPrem := surfguard.Policy{}.AllowAllPorts().Allow(prefix)
+	if onPrem.Blocked(private) {
+		t.Error("the documented on-premises policy refuses 10.4.1.2; the WithIssuerPolicy doc must be corrected")
+	}
+	if !onPrem.Blocked(netip.MustParseAddr("10.9.9.9")) {
+		t.Error("the documented on-premises policy admits private space outside the allowed prefix")
+	}
+}
+
+// TestWithIssuerHTTPClient_CarriesHopTwo exercises the second escape hatch: the
+// caller's own client carries hop 2, and enforcement travels with it.
+func TestWithIssuerHTTPClient_CarriesHopTwo(t *testing.T) {
+	bc5, counter := bc5OnLoopback(t)
+	resourceOrigin := resourceAdvertising(t, bc5)
+
+	// A plain client — no surfguard transport at all. This is the "enforcement
+	// becomes yours" contract stated in the option's doc.
+	result, err := NewDiscoverer(nil, WithIssuerHTTPClient(&http.Client{})).
+		DiscoverFromResource(context.Background(), resourceOrigin)
+	if err != nil {
+		t.Fatalf("DiscoverFromResource() error = %v, want nil", err)
+	}
+	if result.Config == nil || result.Issuer != bc5 {
+		t.Fatalf("want the loopback issuer selected, got %+v", result)
+	}
+	if counter.hits.Load() != 1 {
+		t.Errorf("issuer hits = %d, want 1", counter.hits.Load())
+	}
+}
+
+// TestWithIssuerHTTPClient_TakesPrecedenceOverPolicy pins the documented
+// precedence, so a caller passing both cannot read the combination as additive.
+func TestWithIssuerHTTPClient_TakesPrecedenceOverPolicy(t *testing.T) {
+	bc5, counter := bc5OnLoopback(t)
+	resourceOrigin := resourceAdvertising(t, bc5)
+
+	// The policy here would block loopback; the client does not. The client wins.
+	result, err := NewDiscoverer(nil,
+		WithIssuerPolicy(DefaultIssuerPolicy()),
+		WithIssuerHTTPClient(&http.Client{}),
+	).DiscoverFromResource(context.Background(), resourceOrigin)
+	if err != nil {
+		t.Fatalf("DiscoverFromResource() error = %v, want nil (the client supersedes the policy)", err)
+	}
+	if result.Config == nil || counter.hits.Load() != 1 {
+		t.Errorf("want the issuer contacted once through the supplied client; hits = %d, result = %+v", counter.hits.Load(), result)
+	}
+}
+
+// TestWithoutIssuerPolicy_RestoresPrePolicyBehavior exercises the third escape
+// hatch and, with it, the pre-change baseline: without the policy, a loopback
+// issuer advertised by a remote peer is contacted and selected.
+func TestWithoutIssuerPolicy_RestoresPrePolicyBehavior(t *testing.T) {
+	bc5, counter := bc5OnLoopback(t)
+	resourceOrigin := resourceAdvertising(t, bc5)
+
+	result, err := NewDiscoverer(nil, WithoutIssuerPolicy()).
+		DiscoverFromResource(context.Background(), resourceOrigin)
+	if err != nil {
+		t.Fatalf("DiscoverFromResource() error = %v, want nil", err)
+	}
+	if result.Config == nil || result.Issuer != bc5 {
+		t.Fatalf("want the loopback issuer selected, got %+v", result)
+	}
+	if counter.hits.Load() != 1 {
+		t.Errorf("issuer hits = %d, want 1", counter.hits.Load())
+	}
+}
+
+// TestDefaultIssuerClientIsShared pins the resource invariant: the default
+// issuer client owns a transport, and a Discoverer has no Close, so building one
+// per Discoverer would leak a connection pool per construction.
+func TestDefaultIssuerClientIsShared(t *testing.T) {
+	a := NewDiscoverer(nil)
+	b := NewDiscoverer(&http.Client{})
+	if a.issuerClient != b.issuerClient {
+		t.Error("two default Discoverers hold different issuer clients; the default must be shared")
+	}
+
+	// A caller-supplied policy must NOT land on the shared client, or one
+	// caller's Allow would widen every other Discoverer in the process.
+	own := NewDiscoverer(nil, WithIssuerPolicy(DefaultIssuerPolicy().AllowLoopback()))
+	if own.issuerClient == a.issuerClient {
+		t.Error("WithIssuerPolicy reused the shared issuer client; a caller policy must get its own transport")
+	}
+}
+
+// TestSharedIssuerClientIsNeverMutated is the safety property that makes sharing
+// legal. fetchDiscoveryDocument needs redirects suppressed, and it gets there by
+// COPYING the client — if it ever set CheckRedirect in place, every Discoverer
+// in the process would be reconfigured by whichever one ran first.
+func TestSharedIssuerClientIsNeverMutated(t *testing.T) {
+	shared := NewDiscoverer(nil).issuerClient
+	if shared.CheckRedirect != nil || shared.Timeout != 0 {
+		t.Fatalf("shared issuer client did not start clean: CheckRedirect=%v Timeout=%v", shared.CheckRedirect != nil, shared.Timeout)
+	}
+
+	// Drive a real discovery through it (blocked, but it reaches the fetch).
+	bc5, _ := bc5OnLoopback(t)
+	resourceOrigin := resourceAdvertising(t, bc5)
+	_, _ = NewDiscoverer(nil).DiscoverFromResource(context.Background(), resourceOrigin)
+
+	if shared.CheckRedirect != nil {
+		t.Error("the shared issuer client was mutated in place; noRedirectClient must copy")
+	}
+}
+
+// TestIssuerPolicyIsolationAcrossDiscoverers is the behavioral form of the same
+// concern, and the one that would catch aliasing that pointer identity cannot:
+// a Discoverer that widened its policy must not widen a default one built either
+// before or after it.
+func TestIssuerPolicyIsolationAcrossDiscoverers(t *testing.T) {
+	bc5, counter := bc5OnLoopback(t)
+	resourceOrigin := resourceAdvertising(t, bc5)
+
+	before := NewDiscoverer(nil)
+	permissive := NewDiscoverer(nil, WithIssuerPolicy(DefaultIssuerPolicy().AllowLoopback()))
+
+	if _, err := permissive.DiscoverFromResource(context.Background(), resourceOrigin); err != nil {
+		t.Fatalf("the permissive Discoverer should reach loopback: %v", err)
+	}
+	if counter.hits.Load() != 1 {
+		t.Fatalf("permissive issuer hits = %d, want 1", counter.hits.Load())
+	}
+
+	after := NewDiscoverer(nil)
+	for name, d := range map[string]*Discoverer{"before": before, "after": after} {
+		t.Run(name, func(t *testing.T) {
+			hitsBefore := counter.hits.Load()
+			_, err := d.DiscoverFromResource(context.Background(), resourceOrigin)
+			assertBlockedIssuer(t, err, nil)
+			if got := counter.hits.Load(); got != hitsBefore {
+				t.Errorf("a default Discoverer contacted the issuer (%d new hit(s)); the permissive policy leaked", got-hitsBefore)
+			}
+		})
+	}
+}
+
+// TestIssuerPolicyDoesNotReachCallerNamedOrigins is the regression guard on the
+// scope of the change. Hop 1 and Discover target origins the CALLER named, so
+// they keep the caller's client and must still reach loopback with the policy
+// at its default.
+func TestIssuerPolicyDoesNotReachCallerNamedOrigins(t *testing.T) {
+	t.Run("discover", func(t *testing.T) {
+		var origin string
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			_, _ = w.Write([]byte(`{"issuer":"` + origin + `","token_endpoint":"` + origin + `/oauth/token"}`))
+		}))
+		defer srv.Close()
+		origin = srv.URL
+
+		cfg, err := NewDiscoverer(srv.Client()).Discover(context.Background(), origin)
+		if err != nil {
+			t.Fatalf("Discover() on loopback error = %v, want nil", err)
+		}
+		if cfg.Issuer != origin {
+			t.Errorf("Issuer = %q, want %q", cfg.Issuer, origin)
+		}
+	})
+
+	// Hop 1 of DiscoverFromResource: reaching a loopback resource server is
+	// proven by the soft fallback, which is only reachable once hop 1 has
+	// returned parsed metadata.
+	t.Run("hop1", func(t *testing.T) {
+		resourceOrigin := resourceAdvertising(t, LaunchpadBaseURL)
+
+		result, err := NewDiscoverer(nil).DiscoverFromResource(context.Background(), resourceOrigin)
+		if err != nil {
+			t.Fatalf("DiscoverFromResource() error = %v, want nil", err)
+		}
+		if result.FallbackReason != FallbackNoASAdvertised {
+			t.Errorf("fallback reason = %q, want %q — hop 1 did not reach the loopback resource server",
+				result.FallbackReason, FallbackNoASAdvertised)
+		}
+	})
+
+	t.Run("protected_resource", func(t *testing.T) {
+		resourceOrigin := resourceAdvertising(t, LaunchpadBaseURL)
+
+		md, err := NewDiscoverer(nil).DiscoverProtectedResource(context.Background(), resourceOrigin)
+		if err != nil {
+			t.Fatalf("DiscoverProtectedResource() on loopback error = %v, want nil", err)
+		}
+		if md.Resource != resourceOrigin {
+			t.Errorf("Resource = %q, want %q", md.Resource, resourceOrigin)
+		}
+	})
+}

--- a/go/pkg/basecamp/oauth/resource_discovery_test.go
+++ b/go/pkg/basecamp/oauth/resource_discovery_test.go
@@ -17,6 +17,8 @@ import (
 	"testing"
 	"time"
 
+	surfguard "github.com/basecamp/surfguard/go"
+
 	"github.com/basecamp/basecamp-sdk/go/pkg/basecamp"
 )
 
@@ -134,6 +136,27 @@ func (t *countingTransport) RoundTrip(req *http.Request) (*http.Response, error)
 		}, nil
 	}
 	return t.base.RoundTrip(req)
+}
+
+// testIssuerPolicy is DefaultIssuerPolicy with loopback re-admitted, so httptest
+// servers — which bind random 127.0.0.1 ports — can stand in for a BC5 issuer
+// while every other address class stays exactly as strict as production.
+func testIssuerPolicy() surfguard.Policy {
+	return DefaultIssuerPolicy().AllowLoopback()
+}
+
+// issuerClientFor builds the advertised-issuer (hop-2) client the harness hands
+// to NewDiscoverer, counting Launchpad traffic on the SAME counter as hop 1.
+//
+// It has to be built here rather than left to the default. NewDiscoverer's
+// default hop-2 client is constructed inside the constructor, so a
+// countingTransport installed only on the client passed as hop 1's would no
+// longer be on hop 2's path — and every launchpadContacted:false fixture would
+// keep passing while no longer watching the hop that could break it. The
+// surfguard round tripper is kept underneath so the policy is still live on
+// this lane; only loopback is re-admitted.
+func issuerClientFor(count *int) *http.Client {
+	return &http.Client{Transport: &countingTransport{base: testIssuerPolicy().RoundTripper(), count: count}}
 }
 
 func sentinelFor(name string) error {
@@ -254,7 +277,7 @@ func runFixture(t *testing.T, path string) {
 
 	launchpadHits := 0
 	client := &http.Client{Transport: &countingTransport{base: http.DefaultTransport, count: &launchpadHits}}
-	d := NewDiscoverer(client)
+	d := NewDiscoverer(client, WithIssuerHTTPClient(issuerClientFor(&launchpadHits)))
 
 	opts := []DiscoverOption{}
 	if fx.ExpectedIssuer != "" {
@@ -544,7 +567,8 @@ func TestDiscoverFromResource_ASFetchFailurePreservesStatus(t *testing.T) {
 	defer resource.Close()
 	resourceOrigin = resource.URL
 
-	_, err := NewDiscoverer(resource.Client()).DiscoverFromResource(context.Background(), resourceOrigin)
+	_, err := NewDiscoverer(resource.Client(), WithIssuerPolicy(testIssuerPolicy())).
+		DiscoverFromResource(context.Background(), resourceOrigin)
 	if err == nil {
 		t.Fatal("expected an error")
 	}
@@ -586,7 +610,8 @@ func TestDiscoverFromResource_CallerCancellationPropagates(t *testing.T) {
 	launchpadHits := 0
 	client := &http.Client{Transport: &countingTransport{base: resource.Client().Transport, count: &launchpadHits}}
 
-	result, err := NewDiscoverer(client).DiscoverFromResource(ctx, resource.URL)
+	result, err := NewDiscoverer(client, WithIssuerHTTPClient(issuerClientFor(&launchpadHits))).
+		DiscoverFromResource(ctx, resource.URL)
 	if err == nil {
 		t.Fatalf("expected cancellation error, got soft fallback result: %+v", result)
 	}
@@ -651,7 +676,8 @@ func TestDiscoverFromResource_ASStageCancellationPropagates(t *testing.T) {
 		cancel()
 	}()
 
-	result, err := NewDiscoverer(resource.Client()).DiscoverFromResource(ctx, resourceOrigin)
+	result, err := NewDiscoverer(resource.Client(), WithIssuerPolicy(testIssuerPolicy())).
+		DiscoverFromResource(ctx, resourceOrigin)
 	if err == nil {
 		t.Fatalf("expected cancellation error, got result: %+v", result)
 	}

--- a/go/pkg/basecamp/oauth/types.go
+++ b/go/pkg/basecamp/oauth/types.go
@@ -104,8 +104,30 @@ var (
 	// provided but is not advertised by the resource.
 	ErrExpectedIssuerUnavailable = errors.New("expected issuer not advertised")
 	// ErrInvalidIssuerOrigin is returned when a selected advertised issuer is
-	// not a valid origin root.
-	ErrInvalidIssuerOrigin = errors.New("advertised issuer is not a valid origin root")
+	// refused as a destination. It covers two distinct checks, both permanent
+	// verdicts on the origin — neither is worth retrying, and the consumer's
+	// remedy is the same for both: stop treating this issuer as usable.
+	//
+	//  1. The issuer is not a valid origin root — the syntactic profile
+	//     (https, or http on localhost; a host; no path, query, fragment, or
+	//     userinfo; a port in range).
+	//  2. The issuer's ADDRESS is refused by the discoverer's issuer policy
+	//     (see [DefaultIssuerPolicy]) — it resolves into private, loopback,
+	//     link-local, or IANA special-purpose space. This check exists because
+	//     an advertised issuer is chosen by a remote peer, and a well-formed
+	//     origin root can still name an internal host. In this case the error
+	//     also matches errors.Is(err, surfguard.ErrBlocked), and wraps a
+	//     *surfguard.Violation carrying the reason; discriminate on that if the
+	//     two need telling apart.
+	//
+	// Case 2 is newer than case 1. Code written against the earlier meaning
+	// still matches — an issuer refused on address grounds is one this SDK will
+	// not talk to, which is what the sentinel has always signalled — but a
+	// consumer that logs "malformed issuer URL" on this sentinel should widen
+	// that wording, and one that reached an internal issuer before will now see
+	// this error instead. [WithIssuerPolicy] and [WithoutIssuerPolicy] adjust
+	// or remove the second check.
+	ErrInvalidIssuerOrigin = errors.New("advertised issuer is refused as a destination")
 	// ErrASFetchFailed is returned when the authorization-server metadata fetch
 	// fails (5xx / network) for a committed BC5 issuer.
 	ErrASFetchFailed = errors.New("authorization server metadata fetch failed")


### PR DESCRIPTION
Closes one real SSRF exposure in the Go OAuth discovery path, at one call site.

## The exposure

`DiscoverFromResource` hop 2 dials an origin lifted out of a **parsed HTTP response body**. `authorization_servers[]` is chosen by the remote resource, and without `WithExpectedIssuer` the "single non-Launchpad entry wins" heuristic makes that string the socket destination.

`requireOriginRoot` is a syntax gate — it has no notion of what a host *resolves to*. Issuer binding runs only after the response comes back, which is after the connection has already reported whether an internal host and port are live. `SPEC.md` §16 already calls advertised AS URLs untrusted input (RFC 9728 §7.7).

The discovery fetch itself is bounded: fixed path, GET, no credentials, near-blind. But it is a working internal host/port oracle, and it is not where the selected issuer stops being used. The `Config` it returns carries `TokenEndpoint` (required) and `DeviceAuthorizationEndpoint`, and those become the destinations of the grant itself — `PerformDeviceLogin` takes exactly this already-selected `*Config` and posts the `client_id` and `device_code` to them; exchange and refresh post the authorization code, client secret, or refresh token to `TokenEndpoint`.

Those are **form-body credentials, not an `Authorization: Bearer` header.** An earlier revision of this description claimed the selected issuer is handed to calls that attach a Bearer token. That was an overclaim and it is retracted. Tracing it: the only two Bearer sites in the Go SDK are `BearerAuth.Authenticate` (`auth_strategy.go:31`), which authenticates the generated API client's requests to the operator-configured `cfg.BaseURL`, and `AuthorizationService.GetInfo` (`authorization.go:197`), which targets a hardcoded Launchpad URL or a caller-supplied `opts.Endpoint`. Neither is reachable from a discovered issuer. Nothing in this repo constructs a `Credentials{TokenEndpoint: ...}` or references `DiscoveryResult` outside the `oauth` package at all — the discovery-to-credential-store wiring lives in consumers such as `basecamp-cli`, so a Bearer claim is not demonstrable here and is not made.

Demonstrated, not asserted. Reverting hop 2 to the unpoliced client makes the new tests fail like this:

```
--- FAIL: TestDiscoverFromResource_BlockedIssuerIsNeverContacted
    expected the advertised issuer to be refused, got nil error
--- FAIL: TestDiscoverFromResource_BlockedIssuerNamedByHostname
    the blocked issuer was contacted 1 time(s); the policy must refuse before any connect
--- FAIL: TestDiscoverFromResource_RefusesLegacyNumericIssuer/https
    err = ... Get "https://2130706433/.well-known/oauth-authorization-server": dial tcp 127.0.0.1:443: connect: connection refused
```

That third line is the whole problem in one string: a well-formed `https` origin root, admitted by every syntax check, dialing loopback.

## The change

One hop moves onto a client whose transport judges the literal address of every connect attempt, via `surfguard`'s `IANASpecialUse` policy — the one its docs name for "advertised or discovered infrastructure values".

```go
func DefaultIssuerPolicy() surfguard.Policy   // IANASpecialUse().AllowAllPorts()
func NewDiscoverer(httpClient *http.Client, opts ...DiscovererOption) *Discoverer
// WithIssuerPolicy / WithIssuerHTTPClient / WithoutIssuerPolicy
```

Scope is deliberately narrow. Hop 1, `Discover`, and `DiscoverLaunchpad` all target an origin the **caller** named; they keep the caller's client and still reach loopback. Three other candidate sites were checked and left alone — see below.

A refusal maps onto the **existing** `ErrInvalidIssuerOrigin` rather than a sixth sentinel: `requireOriginRoot` judged the spelling, the policy judged what it resolves to, and the consumer's remedy is identical. It is re-coded **non-retryable** — the dial failure is classified as a retryable network error deep in the fetch, before anything knows *why* it failed, and `SelectionError` inherits its cause's retryability, so without this callers would be told to retry a target they must stop talking to.

## Decisions worth flagging

**The policy applies uniformly, `WithExpectedIssuer` included.** Strictly that path is caller-determined and could be exempt. It isn't, on purpose: "the policy applies sometimes" is the branch a bypass grows out of, and the exemption is silently wrong for a consumer that computed its expected issuer from untrusted input. Pinned by `TestDiscoverFromResource_ExpectedIssuerIsPoliciedToo`.

**This is a behavioral tightening, not a pure addition.** A consumer whose BC5 issuer is advertised on loopback or in RFC 1918 space, and which worked before, now needs `WithIssuerPolicy`. That is the point of the change, but it is a break and it is recorded as one in Appendix F.

**`Allow(prefix)` does NOT re-admit RFC 1918 under `IANASpecialUse()`.** This one contradicts the plan this PR was written from, which said an internal deployment "fixes itself with one `Allow(prefix)`". It does not: surfguard's precedence puts the special-use tables *above* `Allow`, and `AllowLoopback()` is the only derivation that pierces them. Verified directly:

```
10.4.1.2   default=true  Allow(10.4.0.0/16)=true  AllowLoopback=true
127.0.0.1  default=true  Allow(10.4.0.0/16)=true  AllowLoopback=false
```

The correct on-premises spelling is `surfguard.Policy{}.AllowAllPorts().Allow(...)` — dropping `IANASpecialUse`, keeping the default deny tables. The docs say so, and `TestWithIssuerPolicy_AllowUnderSpecialUseDoesNotReadmitPrivateSpace` fails if either half of that claim stops being true.

**`AllowAllPorts`** — the origin-root profile legitimately admits an explicit port, and address classification is what closes the exposure. A `{80, 443}` list would refuse honest issuers without narrowing which *hosts* are reachable.

**`ErrInvalidIssuerOrigin` now means two things.** Mapping `ErrBlocked` onto the existing sentinel avoids a sixth public error, but it widens what that sentinel signals for every consumer — so its doc comment now spells out both checks, notes that an address refusal also matches `errors.Is(err, surfguard.ErrBlocked)` for anyone who needs to tell them apart, and warns that code logging "malformed issuer URL" on it should widen that wording.

**The default issuer client is shared.** It owns a transport, and a `Discoverer` has no `Close`, so building one per construction would leak a connection pool nothing can reclaim. `sync.OnceValue` builds it once per process. Sharing is legal only because nothing mutates it — `noRedirectClient` copies before setting `CheckRedirect` — and **only the default is shared**: `WithIssuerPolicy` gets its own transport, or one caller's `Allow` would silently widen every other `Discoverer` in the process. Three tests pin this, each mutation-verified: shared identity for defaults, a distinct client under `WithIssuerPolicy`, the shared client still unmutated after a real discovery, and a behavioral isolation check that a permissive `Discoverer` does not widen defaults built before *or* after it.

**API break.** `NewDiscoverer` gains a variadic parameter. Source-compatible for every direct call, but `apidiff` will report it as incompatible, so this needs the `breaking` label.

## The existing security assertion stayed live

`resource_discovery_test.go` wraps a `countingTransport` to assert `launchpadContacted: false`. Hop 2 moving to a client built *inside* `NewDiscoverer` would have taken it off that transport's path — the assertion would have kept passing while no longer watching the hop that could break it.

Verified rather than reasoned about. Temporarily pointing hop 2 at Launchpad, with the harness fixed:

```
--- FAIL: .../07-issuer-binding-mismatch.json
    Launchpad was contacted 1 time(s); hard/selected case must not touch Launchpad
```

And the same mutation with the harness left on the default hop-2 client:

```
ok — 07-issuer-binding-mismatch.json PASSED
```

That is the vacuous pass, reproduced. The harness now builds the hop-2 client explicitly, keeping the surfguard round tripper underneath so the policy is still live on that lane with only loopback re-admitted.

## Scope: three sites checked and left alone

- **`download.go`** — hop 1 rewrites the URL to keep only path and query, pinning the host to `cfg.BaseURL`. Hop 2 follows a `Location` chosen by that same operator-configured API host. Gating it would break on-prem object stores for no gain. *(One correction to the brief: it is hop 1 that does the rewriting; `fetchSignedDownload` takes the Location as given. The conclusion holds — the Location's author is the trusted API host — but see the filed issue.)*
- **`eventfeed`** — the cable URL is minted by the trusted, already-token-holding API host, and `ws://localhost` is a specified §9 carve-out. *(Not present on `main` — it lives on the unmerged `event-feed-go-connector` branch.)*
- **main API client** — URL is operator-configured.

## Coordination

`SPEC.md` §1658's SSRF block enumerates hardening for five SDKs; this is a Go-only divergence, so it is **not** merged silently.

`COORDINATION.md` is exclusively about SDK ↔ BC3 API parity — the wrong home. The repo's convention for cross-SDK language divergences is `SPEC.md` plus **Appendix F: Known Cross-SDK Divergences**, so it is raised there as a spec requirement:

- §16 gains requirement **5**, marked `[Go-first]` and written `SHOULD`. Deliberately not `[conformance]`: the assertion is "no connection was attempted", which the mock-HTTP runner cannot observe, and the other four SDKs have no equivalent enforcement layer to point at yet.
- Appendix F records the per-SDK state, the behavioral tightening, and the `Allow`/`IANASpecialUse` precedence trap.

## Verification

- `go test ./...`, `go vet ./...`, `gofmt -s -l`, `golangci-lint` — all clean in the `go` module; `conformance/runner/go` and `scripts/check-wrapper-drift` still build and pass; `go.mod`/`go.sum` tidy.
- `same_origin_test.go` and `download_test.go` pass **unedited** (`TestBuildURL_RejectsForeignOriginAbsoluteURL` and all 23 `TestDownload*`).
- Every blocked-issuer test asserts the target handler ran **zero times** — an error alone would not prove the issuer was never contacted, and "the internal host answered, then binding rejected it" is precisely the outcome being prevented. The mock serves *usable* metadata, so a policy that failed to block yields a **successful** discovery rather than a differently-worded failure.
- Both new guarantees mutation-tested: removing the policy, and removing the retryability re-coding, each make the intended assertion fail.


## Scope of the claim, and the residual it leaves

This PR closes the **advertised-issuer metadata GET**. It does not close the discovery SSRF surface in general, and the distinction matters enough to state rather than leave to inference.

**Still open — #806.** An attacker-controlled issuer on *public* space passes this policy, is selected, and returns issuer-bound metadata whose `token_endpoint` / `device_authorization_endpoint` point anywhere. Those endpoints are neither origin-constrained (`discovery.go:545` checks only non-empty; `:558` copies verbatim) nor address-judged, and the credential-bearing POSTs go through `http.DefaultClient` (`device.go:137`, `exchange.go:25`). So the indirect route reaches private space at the cost of one public host — and delivers real credentials rather than a blind GET.

Pre-existing, and unchanged by this PR. Not fixed here because every SDK has device and exchange flows, so a Go-only patch would close one spelling and leave four open — the same cross-SDK shape as #805. Whether to constrain endpoints to the issuer origin, address-police the endpoint requests, or both is a specification decision.

**Also open — #805.** Download hop 2 follows redirects in four SDKs.

Read this PR as "the metadata hop is now policed", not "discovery is SSRF-safe".
