### PR TITLE
Quiet known-noise CodeQL alerts without losing coverage

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -26,12 +26,14 @@ paths-ignore:
   # hand-written files — services/_base.py and services/_async_base.py, the HTTP,
   # retry and pagination plumbing (AGENTS.md exempts them from the generator) —
   # i.e. exactly the code most worth scanning. paths-ignore has no negation, so
-  # excluding the directory would silently drop them. If generated Python turns
-  # out to be noisy, narrow it in codeql.yml's SARIF filter instead: that step is
-  # a jq test() regex and can express "generated/ but not services/_".
+  # excluding the directory would silently drop them. Generated Python did turn
+  # out to be noisy (py/unused-import in every generated service), so codeql.yml's
+  # SARIF filter now strips generated/ except services/_ — keeping both
+  # hand-written files scanned.
   # Test infrastructure
   - conformance/
   - kotlin/conformance/
+  - python/tests/
 
 query-filters:
   - exclude:
@@ -46,3 +48,8 @@ query-filters:
   # to the build would silently suppress this query there too.
   - exclude:
       id: java/class-name-matches-super-class
+  # Protocol and overload stubs use `...` as their body — idiomatic typing code
+  # that this query flags as a defect. auth.py and async_auth.py alone produced
+  # eight such alerts, and every future Protocol method adds another.
+  - exclude:
+      id: py/ineffectual-statement

--- a/.github/codeql/sarif-filter.jq
+++ b/.github/codeql/sarif-filter.jq
@@ -1,0 +1,14 @@
+# Strips generated-code results from CodeQL SARIF before upload.
+# Single source of truth: codeql.yml applies this file with `jq -f`, and
+# test-sarif-filter.sh asserts it against testdata/sarif-filter-fixture.json,
+# so the test always exercises the exact program the workflow runs.
+#
+# Generated Python is stripped with a lookahead sparing services/_ — that
+# directory's _base.py and _async_base.py are hand-written (see
+# codeql-config.yml) and paths-ignore can't express the exception.
+.runs |= map(.results |= (. // [] | map(
+  select(
+    (.locations // [])[0].physicalLocation.artifactLocation.uri // "" |
+    test("(^|/)(go/pkg/generated/|typescript/(src/generated|dist)/|ruby/lib/basecamp/generated/|swift/Sources/Basecamp/Generated/|kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/|python/src/basecamp/generated/(?!services/_))") | not
+  )
+)))

--- a/.github/codeql/test-sarif-filter.sh
+++ b/.github/codeql/test-sarif-filter.sh
@@ -1,23 +1,15 @@
 #!/usr/bin/env bash
 # Regression test for the SARIF generated-code filter used in codeql.yml.
-# Runs the same jq expression against a fixture and asserts the output.
+# Runs the workflow's actual filter program (sarif-filter.jq) against a
+# fixture and asserts the output.
 set -euo pipefail
-
-FILTER='
-  .runs |= map(.results |= (. // [] | map(
-    select(
-      (.locations // [])[0].physicalLocation.artifactLocation.uri // "" |
-      test("(^|/)(go/pkg/generated/|typescript/(src/generated|dist)/|ruby/lib/basecamp/generated/|swift/Sources/Basecamp/Generated/|kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/)") | not
-    )
-  )))
-'
 
 DIR="$(cd "$(dirname "$0")" && pwd)"
 FIXTURE="$DIR/testdata/sarif-filter-fixture.json"
 
-actual=$(jq "$FILTER" "$FIXTURE")
+actual=$(jq -f "$DIR/sarif-filter.jq" "$FIXTURE")
 kept=$(echo "$actual" | jq -c '[.runs[].results[].ruleId] | sort')
-expected='["keep-kotlin-generator","keep-no-locations","keep-null-locations","keep-real-go","keep-swift-generator"]'
+expected='["keep-kotlin-generator","keep-no-locations","keep-null-locations","keep-python-async-base","keep-python-base","keep-real-go","keep-swift-generator"]'
 
 if [ "$kept" = "$expected" ]; then
   echo "PASS: SARIF filter kept correct results"

--- a/.github/codeql/testdata/sarif-filter-fixture.json
+++ b/.github/codeql/testdata/sarif-filter-fixture.json
@@ -44,6 +44,22 @@
           "locations": [{"physicalLocation": {"artifactLocation": {"uri": "ruby/lib/basecamp/generated/types.rb"}}}]
         },
         {
+          "ruleId": "drop-python-generated-service",
+          "locations": [{"physicalLocation": {"artifactLocation": {"uri": "python/src/basecamp/generated/services/lineup.py"}}}]
+        },
+        {
+          "ruleId": "drop-python-generated-model",
+          "locations": [{"physicalLocation": {"artifactLocation": {"uri": "python/src/basecamp/generated/models.py"}}}]
+        },
+        {
+          "ruleId": "keep-python-base",
+          "locations": [{"physicalLocation": {"artifactLocation": {"uri": "python/src/basecamp/generated/services/_base.py"}}}]
+        },
+        {
+          "ruleId": "keep-python-async-base",
+          "locations": [{"physicalLocation": {"artifactLocation": {"uri": "python/src/basecamp/generated/services/_async_base.py"}}}]
+        },
+        {
           "ruleId": "keep-no-locations",
           "locations": []
         },

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -171,7 +171,10 @@ jobs:
       # paths-ignore in codeql-config.yml only governs source extraction
       # (effective for JS/Ruby). For compiled languages the extractor traces
       # the build, so generated code enters the database. Strip those results
-      # from SARIF before upload.
+      # from SARIF before upload. Generated Python is stripped here too, but
+      # with a lookahead sparing services/_: that directory's _base.py and
+      # _async_base.py are hand-written (see codeql-config.yml) and paths-ignore
+      # can't express the exception.
 
       - name: Filter generated-code alerts from SARIF
         if: always() && matrix.language != 'actions'
@@ -183,7 +186,7 @@ jobs:
               .runs |= map(.results |= (. // [] | map(
                 select(
                   (.locations // [])[0].physicalLocation.artifactLocation.uri // "" |
-                  test("(^|/)(go/pkg/generated/|typescript/(src/generated|dist)/|ruby/lib/basecamp/generated/|swift/Sources/Basecamp/Generated/|kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/)") | not
+                  test("(^|/)(go/pkg/generated/|typescript/(src/generated|dist)/|ruby/lib/basecamp/generated/|swift/Sources/Basecamp/Generated/|kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/|python/src/basecamp/generated/(?!services/_))") | not
                 )
               )))
             ' "$sarif" > "${sarif}.tmp" && mv "${sarif}.tmp" "$sarif"
@@ -248,7 +251,7 @@ jobs:
               .runs |= map(.results |= (. // [] | map(
                 select(
                   (.locations // [])[0].physicalLocation.artifactLocation.uri // "" |
-                  test("(^|/)(go/pkg/generated/|typescript/(src/generated|dist)/|ruby/lib/basecamp/generated/|swift/Sources/Basecamp/Generated/|kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/)") | not
+                  test("(^|/)(go/pkg/generated/|typescript/(src/generated|dist)/|ruby/lib/basecamp/generated/|swift/Sources/Basecamp/Generated/|kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/|python/src/basecamp/generated/(?!services/_))") | not
                 )
               )))
             ' "$sarif" > "${sarif}.tmp" && mv "${sarif}.tmp" "$sarif"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -170,11 +170,11 @@ jobs:
       # --- Filter generated-code alerts ---
       # paths-ignore in codeql-config.yml only governs source extraction
       # (effective for JS/Ruby). For compiled languages the extractor traces
-      # the build, so generated code enters the database. Strip those results
-      # from SARIF before upload. Generated Python is stripped here too, but
-      # with a lookahead sparing services/_: that directory's _base.py and
-      # _async_base.py are hand-written (see codeql-config.yml) and paths-ignore
-      # can't express the exception.
+      # the build, so generated code enters the database — and generated
+      # Python stays extracted on purpose (see codeql-config.yml). Strip those
+      # results from SARIF before upload. The filter lives in
+      # .github/codeql/sarif-filter.jq so test-sarif-filter.sh exercises the
+      # exact program this workflow runs.
 
       - name: Filter generated-code alerts from SARIF
         if: always() && matrix.language != 'actions'
@@ -182,14 +182,7 @@ jobs:
           for sarif in sarif-results/*.sarif; do
             [ -f "$sarif" ] || continue
             before=$(jq '[.runs[].results // [] | length] | add // 0' "$sarif")
-            jq '
-              .runs |= map(.results |= (. // [] | map(
-                select(
-                  (.locations // [])[0].physicalLocation.artifactLocation.uri // "" |
-                  test("(^|/)(go/pkg/generated/|typescript/(src/generated|dist)/|ruby/lib/basecamp/generated/|swift/Sources/Basecamp/Generated/|kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/|python/src/basecamp/generated/(?!services/_))") | not
-                )
-              )))
-            ' "$sarif" > "${sarif}.tmp" && mv "${sarif}.tmp" "$sarif"
+            jq -f .github/codeql/sarif-filter.jq "$sarif" > "${sarif}.tmp" && mv "${sarif}.tmp" "$sarif"
             after=$(jq '[.runs[].results | length] | add // 0' "$sarif")
             filtered=$((before - after))
             echo "$(basename "$sarif"): $before findings, filtered $filtered generated-code alerts, $after remaining"
@@ -247,14 +240,7 @@ jobs:
           for sarif in sarif-results/*.sarif; do
             [ -f "$sarif" ] || continue
             before=$(jq '[.runs[].results // [] | length] | add // 0' "$sarif")
-            jq '
-              .runs |= map(.results |= (. // [] | map(
-                select(
-                  (.locations // [])[0].physicalLocation.artifactLocation.uri // "" |
-                  test("(^|/)(go/pkg/generated/|typescript/(src/generated|dist)/|ruby/lib/basecamp/generated/|swift/Sources/Basecamp/Generated/|kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/|python/src/basecamp/generated/(?!services/_))") | not
-                )
-              )))
-            ' "$sarif" > "${sarif}.tmp" && mv "${sarif}.tmp" "$sarif"
+            jq -f .github/codeql/sarif-filter.jq "$sarif" > "${sarif}.tmp" && mv "${sarif}.tmp" "$sarif"
             after=$(jq '[.runs[].results | length] | add // 0' "$sarif")
             filtered=$((before - after))
             echo "$(basename "$sarif"): $before findings, filtered $filtered generated-code alerts, $after remaining"


### PR DESCRIPTION
The security-alert cleanup sweep found 58 of this repo's 66 open CodeQL alerts came from three noise sources, none of them defects. This mutes each at the source rather than by perpetual dismissal:

- **Generated Python** (24× `py/unused-import`, all in `generated/services/`): handled exactly as the config file's own comment prescribes — the SARIF filter now strips `python/src/basecamp/generated/` with a `(?!services/_)` lookahead, so the hand-written `services/_base.py` and `services/_async_base.py` stay scanned. Regex verified against representative paths (generated files stripped, the two `_` files and `auth.py` untouched).
- **`python/tests/`** (26 alerts: empty excepts, unreachable statements, unused locals, plus two false-positive `py/incomplete-url-substring-sanitization` highs on `\"https://3.basecamp.com\" in url` assertions): added to `paths-ignore` under the existing test-infrastructure entries.
- **`py/ineffectual-statement`** (8 alerts): every hit is a `...` Protocol/overload stub body in `auth.py`/`async_auth.py` — idiomatic typing code the query mistakes for a defect, growing with every future Protocol method. Excluded via `query-filters`, mirroring the existing `java/class-name-matches-super-class` precedent.

The existing open alerts in these categories were already dismissed with matching reasons; this change keeps them from coming back. The remaining 8 open alerts (Scorecard process findings) are untouched.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Quiets 58 known-noise CodeQL alerts without losing coverage of the hand-written Python service bases. Previously, generated Python, tests, and the `py/ineffectual-statement` query reopened false positives; now they are filtered or excluded.

- SARIF filter: centralized in `.github/codeql/sarif-filter.jq` and used by the workflow; the test now runs the same program. Drops `python/src/basecamp/generated/` results except `generated/services/_` via a lookahead so `_base.py` and `_async_base.py` stay scanned; fixture asserts both are kept.
- Ignore tests: add `python/tests/` to `paths-ignore`.
- Query exclusion: add `py/ineffectual-statement` to `query-filters` to avoid Protocol/overload `...` stub false positives.
- Existing dismissed alerts in these categories will not return; the remaining 8 Scorecard alerts are unchanged. No migration required.

<sup>Written for commit 2a41aab33422b2baa2ddf2585bfb3ee7795a17e5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-sdk/pull/807?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

