### PR TITLE
Make the release guide and guards tell the truth before v0.15.0

### DIFF
--- a/.github/workflows/release-github.yml
+++ b/.github/workflows/release-github.yml
@@ -164,7 +164,7 @@ jobs:
               echo ""
               echo "Read [MIGRATING.md](https://github.com/basecamp/basecamp-sdk/blob/${VERSION}/MIGRATING.md) before you bump the version — it lists the breaks a clean build will not catch: the silent ones that change behaviour with no error at all, and the ones that compile and then raise or fail to decode on one particular shape of response."
               echo ""
-              echo "MIGRATING.md is the authoritative record: the generated notes below are built from merged pull requests, so a change that merged without one appears only there."
+              echo "The notes below are generated from merged pull requests, so a change that merged without one cannot appear in them — MIGRATING.md records consumer-visible changes regardless of how they merged."
               echo ""
             fi
             echo "## Installation"

--- a/.github/workflows/release-github.yml
+++ b/.github/workflows/release-github.yml
@@ -164,6 +164,8 @@ jobs:
               echo ""
               echo "Read [MIGRATING.md](https://github.com/basecamp/basecamp-sdk/blob/${VERSION}/MIGRATING.md) before you bump the version — it lists the breaks a clean build will not catch: the silent ones that change behaviour with no error at all, and the ones that compile and then raise or fail to decode on one particular shape of response."
               echo ""
+              echo "MIGRATING.md is the authoritative record: the generated notes below are built from merged pull requests, so a change that merged without one appears only there."
+              echo ""
             fi
             echo "## Installation"
             echo ""

--- a/.github/workflows/sensitive-change-gate.yml
+++ b/.github/workflows/sensitive-change-gate.yml
@@ -12,6 +12,7 @@ jobs:
     with:
       extra-patterns: |
         scripts/bump-version.sh
+        scripts/promote-migrating.sh
         scripts/sync-api-version.sh
     permissions:
       contents: read

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -85,10 +85,14 @@ an authorization server on `localhost` or private space fails where it used to
 succeed — and, quieter, your custom TLS roots, instrumented transport, or
 proxy no longer carry that one hop (the policy client sets `Proxy: nil` by
 construction), so a proxied consumer's discovery hop 2 egresses direct unless
-redirected back. Remedies, in order of how much policy they keep:
-`WithIssuerPolicy(oauth.DefaultIssuerPolicy().AllowLoopback())` — the only
-derivation that pierces the IANA special-use tables; then
-`WithIssuerHTTPClient(hc)` to supply your own client; then
+redirected back. Remedies, in order of how much policy they keep — split by
+address class, because they do not reach the same space:
+`WithIssuerPolicy(oauth.DefaultIssuerPolicy().AllowLoopback())` re-admits
+loopback and nothing else; for RFC 1918 or other special-use space, `Allow`
+does not pierce the IANA tables — build the policy without them and admit
+exactly what you mean,
+`WithIssuerPolicy(surfguard.Policy{}.AllowAllPorts().Allow(netip.MustParsePrefix("10.4.0.0/16")))`;
+then `WithIssuerHTTPClient(hc)` to supply your own client; then
 `WithoutIssuerPolicy()` to opt out entirely.
 
 ### All SDKs: the signed download hop no longer follows redirects (#805)
@@ -218,8 +222,10 @@ memberwise initializer is `internal`, and the model emitter wrote an explicit
 `public init` only for structs with at least one required member. An
 all-optional model got none, so no code outside the module could construct
 one — which made two operations unusable, in different ways.
-`updateGaugeNeedle`'s outer request was constructible (it has a required
-member), but its all-optional `GaugeNeedleUpdatePayload` was not, so the only
+`updateGaugeNeedle`'s outer request was constructible — request models get
+their `public init` from a second emitter that always wrote one; `gaugeNeedle`
+itself is optional and nil-defaulted — but its all-optional
+`GaugeNeedleUpdatePayload` was not, so the only
 callable shape was `UpdateGaugeNeedleRequest(gaugeNeedle: nil)` — sending the
 empty `{}` bc3 rejects with a 400. `updateMyPreferences` could not be called
 from outside the module at all: its outer request *requires* a

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -61,6 +61,36 @@ is used as given; the policy is not layered on top, because it lives in the
 transport's dialer. Compose it in yourself where you can:
 `&http.Client{Transport: oauth.DefaultIssuerPolicy().RoundTripper()}`.
 
+### Go: resource-first discovery judges the advertised issuer's address (#804)
+
+**The compile error, if you get one:** none for direct calls. `NewDiscoverer`
+gained a variadic `...DiscovererOption` — a stored function value
+(`var f func(*http.Client) *oauth.Discoverer = oauth.NewDiscoverer`) no longer
+compiles, the same shape as #806's `NewExchanger` above.
+
+**The behaviour change:** `DiscoverFromResource`'s second hop — the metadata
+fetch of the issuer a protected-resource document *advertised* — used to ride
+the client you gave `NewDiscoverer`. It now rides a shared client built from
+`oauth.DefaultIssuerPolicy()` that judges the endpoint's literal address at
+dial time: an advertised issuer in loopback, RFC 1918, link-local, CGNAT, or
+any IANA special-purpose space is refused before a connection opens, with a
+**non-retryable** `ErrInvalidIssuerOrigin` that also matches
+`errors.Is(err, surfguard.ErrBlocked)`. The policy applies on both selection
+paths, `WithExpectedIssuer` included — deliberately no exemption. Hop 1,
+`Discover`, and `DiscoverLaunchpad` are unchanged: your client, loopback
+included.
+
+**Wrong behaviour you get if you ignore it:** resource-first discovery against
+an authorization server on `localhost` or private space fails where it used to
+succeed — and, quieter, your custom TLS roots, instrumented transport, or
+proxy no longer carry that one hop (the policy client sets `Proxy: nil` by
+construction), so a proxied consumer's discovery hop 2 egresses direct unless
+redirected back. Remedies, in order of how much policy they keep:
+`WithIssuerPolicy(oauth.DefaultIssuerPolicy().AllowLoopback())` — the only
+derivation that pierces the IANA special-use tables; then
+`WithIssuerHTTPClient(hc)` to supply your own client; then
+`WithoutIssuerPolicy()` to opt out entirely.
+
 ### All SDKs: the signed download hop no longer follows redirects (#805)
 
 `DownloadURL` (`downloadURL`, `download_url`, `UploadsService.Download` and its
@@ -3886,16 +3916,16 @@ oversight, and it should be stated rather than assumed.
 
 # Not in this release
 
-Every change the `# Unreleased` section describes was merged by `8fcb39ab9`,
+Every change the `# Unreleased` section describes was merged by `fa15fc126`,
 and the in-flight set below was surveyed at that commit; the historical
 sections' counts keep the baselines they themselves state (v0.13.0's totals
 were measured at `9a819e44d`, as that section says). In flight at
 that commit, and therefore **not** in this release: the event-feed connector
 stack (#777, #705, #778 — SPEC §23's Go reference implementation and its
-conformance driver), the OAuth issuer address policy (#804), a CodeQL alert
-triage (#807), and two long-running drafts (#802, SPEC §9's peer-derived-text
-boundary; #238, the API-disabled 404 `Reason` header). The record below dates
-from this guide's v0.13.0 drafts and remains true as written.
+conformance driver) and two long-running drafts (#802, SPEC §9's
+peer-derived-text boundary; #238, the API-disabled 404 `Reason` header). The
+record below dates from this guide's v0.13.0 drafts and remains true as
+written.
 
 For the record, since the earlier drafts named them and reviewers may be looking
 for them:

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -112,10 +112,13 @@ so existing array-typed reads keep compiling.
 memberwise initializer is `internal`, and the model emitter wrote an explicit
 `public init` only for structs with at least one required member. An
 all-optional model got none, so no code outside the module could construct
-one — which made two operations uncallable in practice: `updateGaugeNeedle`
-and `updateMyPreferences` take all-optional request payloads, and the only
-body a consumer could pass was the `nil` that sends the empty `{}` bc3
-rejects with a 400.
+one — which made two operations unusable, in different ways.
+`updateGaugeNeedle`'s outer request was constructible (it has a required
+member), but its all-optional `GaugeNeedleUpdatePayload` was not, so the only
+callable shape was `UpdateGaugeNeedleRequest(gaugeNeedle: nil)` — sending the
+empty `{}` bc3 rejects with a 400. `updateMyPreferences` could not be called
+from outside the module at all: its outer request *requires* a
+`PreferencesPayload`, and that payload was unconstructible.
 
 Every generated model now carries the same-shaped `public init` the
 required-member models always had — required parameters take no default,
@@ -138,8 +141,9 @@ Swift's `let`, Python's frozen dataclass. The other two only looked capped:
   `#private` field read directly by both pagination loops, with a `protected`
   getter preserving the supported subclass read. The escape hatch stops
   working: in strict-mode code the assignment throws a `TypeError` (the
-  property is a getter with no setter), and in sloppy mode it lands on an own
-  property the loops never read.
+  property is a getter with no setter), and in sloppy mode it is silently
+  ignored — `[[Set]]` on an inherited getter-only accessor creates no own
+  property.
 - **Ruby**: `Config#max_pages` was a bare `attr_accessor`, and the HTTP layer
   reads the config live at every page boundary, so `config.max_pages = -1`
   took effect on the next page fetch. The writer now validates with the same
@@ -151,6 +155,25 @@ Swift's `let`, Python's frozen dataclass. The other two only looked capped:
 the cap through one of those two holes to defeat the bound — pass the value
 at construction (`maxPages` in the service options, `max_pages` on the config
 before use) instead.
+
+### Ruby: three crash classes on server-supplied URLs became `ApiError` refusals (`2f21c9de7`, `328153020`, `478514642`)
+
+Three bare commits, one class: a malformed or non-dialable server-supplied
+URL used to escape as a raw exception from inside `URI`/`Net::HTTP` instead
+of being refused. Pagination's `<mailto:>; rel="next"` Link header and a
+`Location: mailto:` redirect raised `URI::InvalidComponentError`; a signed
+download whose hop-2 target was `mailto:` raised the same thing one frame
+later; a hostless `http:foo` redirect `Location` crashed with a raw
+`ArgumentError` ("no host component for URI") from `Net::HTTP::Get`. All
+three now raise the SDK's `ApiError` with a legible refusal message,
+matching the refusals Go and TypeScript already surfaced on their dial
+paths. No request is made in any of these cases — each error fires before
+anything is sent, so this was illegibility, not exposure.
+
+**Wrong behaviour you get if you ignore it:** none, but a `rescue` for the
+raw classes (`URI::InvalidComponentError`, `ArgumentError`) around
+pagination or downloads stops seeing them raised from those paths — rescue
+`Basecamp::ApiError` instead.
 
 ### TypeScript: `Retry-After` parsing is strict, and values it used to honour now back off instead (#564)
 
@@ -3784,8 +3807,10 @@ oversight, and it should be stated rather than assumed.
 
 # Not in this release
 
-Every change this guide describes was merged by `8fcb39ab9`, and every count
-above is a measurement at that commit rather than a projection. In flight at
+Every change the `# Unreleased` section describes was merged by `8fcb39ab9`,
+and the in-flight set below was surveyed at that commit; the historical
+sections' counts keep the baselines they themselves state (v0.13.0's totals
+were measured at `9a819e44d`, as that section says). In flight at
 that commit, and therefore **not** in this release: the event-feed connector
 stack (#777, #705, #778 — SPEC §23's Go reference implementation and its
 conformance driver), the OAuth issuer address policy (#804), a CodeQL alert

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -167,8 +167,10 @@ later; a hostless `http:foo` redirect `Location` crashed with a raw
 `ArgumentError` ("no host component for URI") from `Net::HTTP::Get`. All
 three now raise the SDK's `ApiError` with a legible refusal message,
 matching the refusals Go and TypeScript already surfaced on their dial
-paths. No request is made in any of these cases — each error fires before
-anything is sent, so this was illegibility, not exposure.
+paths. No request is ever made *to the rejected target* — each error fires
+before that follow-up is sent, so this was illegibility, not exposure. The
+request that returned the offending header has of course already happened,
+and still counts in hooks and request tallies.
 
 **Wrong behaviour you get if you ignore it:** none, but a `rescue` for the
 raw classes (`URI::InvalidComponentError`, `ArgumentError`) around

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -125,7 +125,8 @@ required-member models always had — required parameters take no default,
 optional ones default to `nil` — and no existing initializer changed its
 signature, so there is nothing to migrate. This entry exists because the fix
 is consumer-visible where the SDK's own test suite could not see it: every
-test file uses `@testable import`, which raises `internal` to visible, so
+test file that imports the SDK module imports it `@testable`, which raises
+`internal` to visible, so
 constructing these models passed in tests against a surface no consumer had.
 A plain-`import` consumer target now builds in CI to keep it that way.
 
@@ -394,10 +395,11 @@ if errors.As(err, &apiErr) && apiErr.RetryAfter > 0 {
 
 ### Go: a body that never arrived is no longer stamped as permanently malformed (#773)
 
-**Nothing to change, but two error classifications move** on the merge-safe
-Documents composites (`Update`, `Edit`) and the carve-out-aware ScheduleEntry
-composites (`UpdateEntry`, `EditEntry`) — the paths that read a response body
-by hand.
+**Nothing to change, but two error classifications move** on the paths that
+read a response body by hand: `Documents.Get` and the merge-safe `Update`/
+`Edit` built on it, and `Schedules.GetEntry` and the carve-out-aware
+`UpdateEntry`/`EditEntry` built on that — direct getter calls are in scope,
+not just the composites.
 
 Go streams response bodies, so the `io.ReadAll` inside the generated parser is
 where a truncated body, a reset connection or an expired deadline actually

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -77,6 +77,81 @@ non-retryable `api_error` Ruby and Python already raised there, with the
 `SyntaxError` around a paginated call stops matching; a `catch` on
 `BasecampError` starts.
 
+### TypeScript: four paginated methods now declare the `ListResult` they already returned (#737)
+
+```typescript
+// before
+async listGauges(options?: ListGaugesGaugeOptions): Promise<components["schemas"]["ListGaugesResponseContent"]>
+// after
+async listGauges(options?: ListGaugesGaugeOptions): Promise<ListResult<components["schemas"]["Gauge"]>>
+```
+
+`search.search`, `gauges.listGauges`, `gauges.listGaugeNeedles` and
+`checkins.reminders` are paginated, and at runtime every one has always
+returned the `ListResult` the pagination loop builds — their own JSDoc already
+promised `.meta.totalCount`. But the generator resolved element type names
+only through the hand-maintained `TYPE_ALIASES` map, and these four entities
+(`SearchResult`, `Gauge`, `GaugeNeedle`, `QuestionReminder`) were not in it,
+so the declared type fell back to the bare `*ResponseContent` array and
+dropped the wrapper. `result.meta.totalCount` was a type error on exactly
+these four methods while every sibling allowed it. The fix is the fallback
+becoming pagination-aware rather than the map growing four entries, so the
+next unaliased paginated entity cannot repeat this.
+
+**Wrong behaviour you get if you ignore it:** none at runtime — the returned
+object did not change, only the type telling the truth about it. What can stop
+compiling: a test double or wrapper typed to the old declared signature no
+longer satisfies the service's, since a bare array is not a `ListResult`.
+Reading code only gains: `.meta` is reachable without the `instanceof`
+laundering the old signature forced, and `ListResult<T>` extends `Array<T>`,
+so existing array-typed reads keep compiling.
+
+### Swift: every generated model now has a `public init` (#735)
+
+**Not a break — 35 models stop being unconstructible.** Swift's implicit
+memberwise initializer is `internal`, and the model emitter wrote an explicit
+`public init` only for structs with at least one required member. An
+all-optional model got none, so no code outside the module could construct
+one — which made two operations uncallable in practice: `updateGaugeNeedle`
+and `updateMyPreferences` take all-optional request payloads, and the only
+body a consumer could pass was the `nil` that sends the empty `{}` bc3
+rejects with a 400.
+
+Every generated model now carries the same-shaped `public init` the
+required-member models always had — required parameters take no default,
+optional ones default to `nil` — and no existing initializer changed its
+signature, so there is nothing to migrate. This entry exists because the fix
+is consumer-visible where the SDK's own test suite could not see it: every
+test file uses `@testable import`, which raises `internal` to visible, so
+constructing these models passed in tests against a surface no consumer had.
+A plain-`import` consumer target now builds in CI to keep it that way.
+
+### TypeScript and Ruby: the validated `maxPages` cap can no longer be replaced after construction (`1919e77f7`)
+
+Four SDKs already stored the validated pagination cap where nothing can
+replace it after construction — Go's unexported options copy, Kotlin's `val`,
+Swift's `let`, Python's frozen dataclass. The other two only looked capped:
+
+- **TypeScript**: `maxPages` was `protected readonly`, which is compile-time
+  only, so `(svc as any).maxPages = Infinity` replaced the validated cap and
+  made the pagination bound unreachable. The cap now lives in a native
+  `#private` field read directly by both pagination loops, with a `protected`
+  getter preserving the supported subclass read. The escape hatch stops
+  working: in strict-mode code the assignment throws a `TypeError` (the
+  property is a getter with no setter), and in sloppy mode it lands on an own
+  property the loops never read.
+- **Ruby**: `Config#max_pages` was a bare `attr_accessor`, and the HTTP layer
+  reads the config live at every page boundary, so `config.max_pages = -1`
+  took effect on the next page fetch. The writer now validates with the same
+  predicate `validate!` uses, so an invalid assignment raises `ArgumentError`
+  immediately. Assigning a *valid* cap still works — the config deliberately
+  stays mutable for the builder-style `from_file` → `load_from_env` flow.
+
+**Wrong behaviour you get if you ignore it:** none, unless you were mutating
+the cap through one of those two holes to defeat the bound — pass the value
+at construction (`maxPages` in the service options, `max_pages` on the config
+before use) instead.
+
 ### TypeScript: `Retry-After` parsing is strict, and values it used to honour now back off instead (#564)
 
 **Nothing to change, but a throttled client may now wait differently** — usually
@@ -292,6 +367,79 @@ if errors.As(err, &apiErr) && apiErr.RetryAfter > 0 {
 }
 ```
 
+### Go: a body that never arrived is no longer stamped as permanently malformed (#773)
+
+**Nothing to change, but two error classifications move** on the merge-safe
+Documents composites (`Update`, `Edit`) and the carve-out-aware ScheduleEntry
+composites (`UpdateEntry`, `EditEntry`) — the paths that read a response body
+by hand.
+
+Go streams response bodies, so the `io.ReadAll` inside the generated parser is
+where a truncated body, a reset connection or an expired deadline actually
+surfaces — and these paths rendered every parser failure as the SPEC §6
+malformed-body shape: a statusless `*basecamp.Error` with `CodeAPI` and
+`Retryable: false`. A transient network failure read as a permanently
+malformed body. The body read is now marked at the transport layer, and a
+failure there returns the transport's own error verbatim — the way every
+other transport failure on these paths already did.
+
+**Wrong behaviour you get if you ignore it:** none, but two things you may
+have matched on move. `errors.As(err, &apiErr)` no longer matches a mid-body
+network failure on these paths — reach for `net.Error`,
+`context.DeadlineExceeded` or `io.ErrUnexpectedEOF`, whichever you actually
+mean — and a retry policy keyed on the SDK error's `Retryable` field no
+longer sees a hard `false` for a failure that was never the body's fault. A
+genuinely malformed body is unchanged: still the statusless `api_error`, with
+the JSON error reachable through `Cause`.
+
+### Go: an absent expiry reads as absent, not as an instant (#662)
+
+Two silent behavior changes on `AuthorizationInfo.ExpiresAt` (`FlexTime`), and
+neither gives you a compile error:
+
+- **A wire `expires_at: 0` now decodes to the zero time.** Previously it
+  decoded to `time.Unix(0, 0)` — a *valid* 1970 date with `IsZero() == false`,
+  so "no expiry" read as "expired 56 years ago". No production issuer has ever
+  sent `0` (BC3 tokens validate presence; legacy Signal tokens self-default an
+  expiry), so this is hardening against the RFC 7591 collision — `0` means
+  "never expires" in bc3's own `client_secret_expires_at` — not a live-bug fix.
+  Code that deliberately round-tripped `0` through `FlexTime` gets the zero
+  time back instead.
+- **A zero `FlexTime` marshals as `null`.** Previously it marshaled as the
+  fabricated instant `"0001-01-01T00:00:00Z"`, indistinguishable from data the
+  server sent. If you re-serialize `AuthorizationInfo` and consume `expires_at`
+  downstream, expect `null` where that sentinel used to be.
+
+New, not breaking: `info.Expiry() (time.Time, bool)` is the documented front
+door — `ok` is false when the document stated no expiry (absent field, explicit
+`null`, or a wire `0` alike; all defensive, per the above — no production
+issuer emits any of them). Prefer it over reading `ExpiresAt` directly.
+
+### Go: `TimelineEventData.StartsAt`/`EndsAt` became `*types.FlexibleTime`
+
+The same class as v0.13.0's [four Go pointer entries](#go): the generated
+counterpart is `*types.FlexibleTime` (the bounds are required-and-nullable —
+`schedule_entry_*` events always carry them, but the value may be `null`), and
+the hand-written struct flattened them to value types, fabricating
+`0001-01-01T00:00:00Z` for a null bound on re-marshal.
+
+**This compiles unchanged and panics at runtime on the wrong payload.** Go
+promotes value-receiver methods through the pointer, so
+`ev.Data.StartsAt.IsZero()` still builds — and nil-panics when the API sent
+`null`. Nil-check first:
+
+```go
+// Before
+if !ev.Data.StartsAt.IsZero() { start := ev.Data.StartsAt.Time; ... }
+
+// After
+if ev.Data.StartsAt != nil { start := ev.Data.StartsAt.Time; ... }
+```
+
+A nil bound re-marshals as `null` (the key stays, matching the wire contract);
+a null bound previously decoded to the zero time, so `IsZero()`-based absence
+checks translate to nil checks.
+
 ### Kotlin: `search.search` returns `ListResult<SearchResult>`, not `ListResult<JsonElement>` (#717)
 
 ```kotlin
@@ -355,8 +503,10 @@ git show v0.14.0:openapi.json | jq '.components.schemas.Tool | {required, props:
 jq '.components.schemas.Tool | {required, props: (.properties|keys|length)}' openapi.json
 ```
 
-Three of the seven are conditional on the wire, and the conditions are not
-guesses — they are the partial's own `if`s:
+Three of the emitted keys are conditional on the wire — two of the seven new
+ones (`subscription_url`, `parent`) plus `position`, which the spec modeled
+before this change — and the conditions are not guesses: they are the
+partial's own `if`s:
 
 - **`subscription_url`** — only when the recordable is subscribable.
   `Chat::Transcript`, `Todoset` and `Kanban::Board` override
@@ -425,7 +575,7 @@ hand.
 
 | SDK | was | now |
 |---|---|---|
-| Kotlin | `kotlinx.serialization.SerializationException` (incl. `MissingFieldException`) | `BasecampException.Api` with `httpStatus == null`, `retryable == false`, and the `SerializationException` as `cause` |
+| Kotlin | `kotlinx.serialization.SerializationException` (incl. `MissingFieldException`) | `BasecampException.Api` with `httpStatus == null`, `retryable == false`, and the `SerializationException` in `decodeFailure` — the discriminator (#750); mirrored in `cause`, which is explicitly not one |
 | Swift | `DecodingError` — and, on the wrapped-list path, a raw `NSError` from `JSONSerialization` for a body that is not JSON at all | `BasecampError.api(message:httpStatus:hint:requestId:decodeFailure:)` with `httpStatus == nil` (so `isRetryable == false`), the underlying error's description interpolated into `message` and the error itself in `decodeFailure` (see above) |
 | Go, TypeScript, Ruby, Python | unchanged | unchanged |
 
@@ -708,54 +858,6 @@ default goes.
 Add a `limit_exceeded` branch that surfaces the limit to the user and does not
 retry. This SDK's own Kotlin test suite hit the compile error, which is what the
 exhaustive `when` in `ErrorTest` exists to produce.
-
-### Go: an absent expiry reads as absent, not as an instant (#662)
-
-Two silent behavior changes on `AuthorizationInfo.ExpiresAt` (`FlexTime`), and
-neither gives you a compile error:
-
-- **A wire `expires_at: 0` now decodes to the zero time.** Previously it
-  decoded to `time.Unix(0, 0)` — a *valid* 1970 date with `IsZero() == false`,
-  so "no expiry" read as "expired 56 years ago". No production issuer has ever
-  sent `0` (BC3 tokens validate presence; legacy Signal tokens self-default an
-  expiry), so this is hardening against the RFC 7591 collision — `0` means
-  "never expires" in bc3's own `client_secret_expires_at` — not a live-bug fix.
-  Code that deliberately round-tripped `0` through `FlexTime` gets the zero
-  time back instead.
-- **A zero `FlexTime` marshals as `null`.** Previously it marshaled as the
-  fabricated instant `"0001-01-01T00:00:00Z"`, indistinguishable from data the
-  server sent. If you re-serialize `AuthorizationInfo` and consume `expires_at`
-  downstream, expect `null` where that sentinel used to be.
-
-New, not breaking: `info.Expiry() (time.Time, bool)` is the documented front
-door — `ok` is false when the document stated no expiry (absent field, explicit
-`null`, or a wire `0` alike; all defensive, per the above — no production
-issuer emits any of them). Prefer it over reading `ExpiresAt` directly.
-
-### Go: `TimelineEventData.StartsAt`/`EndsAt` became `*types.FlexibleTime`
-
-The same class as v0.13.0's [four Go pointer entries](#go): the generated
-counterpart is `*types.FlexibleTime` (the bounds are required-and-nullable —
-`schedule_entry_*` events always carry them, but the value may be `null`), and
-the hand-written struct flattened them to value types, fabricating
-`0001-01-01T00:00:00Z` for a null bound on re-marshal.
-
-**This compiles unchanged and panics at runtime on the wrong payload.** Go
-promotes value-receiver methods through the pointer, so
-`ev.Data.StartsAt.IsZero()` still builds — and nil-panics when the API sent
-`null`. Nil-check first:
-
-```go
-// Before
-if !ev.Data.StartsAt.IsZero() { start := ev.Data.StartsAt.Time; ... }
-
-// After
-if ev.Data.StartsAt != nil { start := ev.Data.StartsAt.Time; ... }
-```
-
-A nil bound re-marshals as `null` (the key stays, matching the wire contract);
-a null bound previously decoded to the zero time, so `IsZero()`-based absence
-checks translate to nil checks.
 
 ---
 
@@ -3682,10 +3784,14 @@ oversight, and it should be stated rather than assumed.
 
 # Not in this release
 
-**Nothing is in flight.** Every change this guide describes is merged at
-`9a819e44d`, and every count above is a measurement at that commit rather than a
-projection. Earlier drafts carried an "if it lands" list; all of it landed, and
-the counts were re-derived rather than incremented.
+Every change this guide describes was merged by `8fcb39ab9`, and every count
+above is a measurement at that commit rather than a projection. In flight at
+that commit, and therefore **not** in this release: the event-feed connector
+stack (#777, #705, #778 — SPEC §23's Go reference implementation and its
+conformance driver), the OAuth issuer address policy (#804), a CodeQL alert
+triage (#807), and two long-running drafts (#802, SPEC §9's peer-derived-text
+boundary; #238, the API-disabled 404 `Reason` header). The record below dates
+from this guide's v0.13.0 drafts and remains true as written.
 
 For the record, since the earlier drafts named them and reviewers may be looking
 for them:

--- a/Makefile
+++ b/Makefile
@@ -272,15 +272,15 @@ endif
 	@# Verify lockfiles are frozen against their manifests
 	@test "$$(jq -r '.version' typescript/package-lock.json)" = "$(VERSION)" -a "$$(jq -r '.packages[""].version' typescript/package-lock.json)" = "$(VERSION)" || \
 		{ echo "ERROR: typescript/package-lock.json records a stale SDK version. Run 'make bump VERSION=$(VERSION)' first."; exit 1; }
-	@grep -qF 'basecamp-sdk ($(VERSION))' ruby/Gemfile.lock || \
-		{ echo "ERROR: ruby/Gemfile.lock records a stale SDK version. Run 'make bump VERSION=$(VERSION)' first."; exit 1; }
+	@grep -qxF '    basecamp-sdk ($(VERSION))' ruby/Gemfile.lock || \
+		{ echo "ERROR: ruby/Gemfile.lock's PATH spec records a stale SDK version. Run 'make bump VERSION=$(VERSION)' first."; exit 1; }
 	@cd python && uv lock --check || \
 		{ echo "ERROR: python/uv.lock is stale. Run 'make bump VERSION=$(VERSION)' first."; exit 1; }
 	@test "$$(jq -r '.packages["../../../typescript"].version' conformance/runner/typescript/package-lock.json)" = "$(VERSION)" || \
 		{ echo "ERROR: conformance/runner/typescript/package-lock.json records a stale SDK version. Run 'make bump VERSION=$(VERSION)' first."; exit 1; }
 	@# The conformance Ruby/Python runner lockfiles are tracked (#670), so they
 	@# are always present; a stale one breaks the frozen conformance installs (#671).
-	@grep -qF 'basecamp-sdk ($(VERSION))' conformance/runner/ruby/Gemfile.lock || \
+	@grep -qxF '    basecamp-sdk ($(VERSION))' conformance/runner/ruby/Gemfile.lock || \
 		{ echo "ERROR: conformance/runner/ruby/Gemfile.lock records a stale SDK version. Run 'make bump VERSION=$(VERSION)' first."; exit 1; }
 	@(cd conformance/runner/python && uv lock --check) || \
 		{ echo "ERROR: conformance/runner/python/uv.lock is stale. Run 'make bump VERSION=$(VERSION)' first."; exit 1; }

--- a/Makefile
+++ b/Makefile
@@ -265,11 +265,15 @@ endif
 		{ echo "ERROR: Kotlin Gradle project version does not match $(VERSION). Run 'make bump VERSION=$(VERSION)' first."; exit 1; }
 	@grep -qF 'public static let version = "$(VERSION)"' swift/Sources/Basecamp/BasecampConfig.swift || \
 		{ echo "ERROR: Swift version does not match $(VERSION). Run 'make bump VERSION=$(VERSION)' first."; exit 1; }
-	@grep -q '^version = "$(VERSION)"' python/pyproject.toml || \
+	@grep -qxF 'version = "$(VERSION)"' python/pyproject.toml || \
 		{ echo "ERROR: Python pyproject.toml version does not match $(VERSION). Run 'make bump VERSION=$(VERSION)' first."; exit 1; }
 	@grep -qF 'VERSION = "$(VERSION)"' python/src/basecamp/_version.py || \
 		{ echo "ERROR: Python version does not match $(VERSION). Run 'make bump VERSION=$(VERSION)' first."; exit 1; }
 	@# Verify lockfiles are frozen against their manifests
+	@test "$$(jq -r '.version' typescript/package-lock.json)" = "$(VERSION)" -a "$$(jq -r '.packages[""].version' typescript/package-lock.json)" = "$(VERSION)" || \
+		{ echo "ERROR: typescript/package-lock.json records a stale SDK version. Run 'make bump VERSION=$(VERSION)' first."; exit 1; }
+	@grep -qF 'basecamp-sdk ($(VERSION))' ruby/Gemfile.lock || \
+		{ echo "ERROR: ruby/Gemfile.lock records a stale SDK version. Run 'make bump VERSION=$(VERSION)' first."; exit 1; }
 	@cd python && uv lock --check || \
 		{ echo "ERROR: python/uv.lock is stale. Run 'make bump VERSION=$(VERSION)' first."; exit 1; }
 	@test "$$(jq -r '.packages["../../../typescript"].version' conformance/runner/typescript/package-lock.json)" = "$(VERSION)" || \

--- a/Makefile
+++ b/Makefile
@@ -249,11 +249,11 @@ ifndef VERSION
 endif
 	@echo "Releasing v$(VERSION)..."
 	@# Verify version constants match — every file scripts/bump-version.sh writes
-	@grep -qF '"version": "$(VERSION)"' package.json || \
+	@test "$$(jq -r '.version' package.json)" = "$(VERSION)" || \
 		{ echo "ERROR: Root package.json version does not match $(VERSION). Run 'make bump VERSION=$(VERSION)' first."; exit 1; }
 	@grep -qF 'Version = "$(VERSION)"' go/pkg/basecamp/version.go || \
 		{ echo "ERROR: Go version does not match $(VERSION). Run 'make bump VERSION=$(VERSION)' first."; exit 1; }
-	@grep -qF '"version": "$(VERSION)"' typescript/package.json || \
+	@test "$$(jq -r '.version' typescript/package.json)" = "$(VERSION)" || \
 		{ echo "ERROR: TypeScript version does not match $(VERSION). Run 'make bump VERSION=$(VERSION)' first."; exit 1; }
 	@grep -qF 'export const VERSION = "$(VERSION)"' typescript/src/client.ts || \
 		{ echo "ERROR: TypeScript client VERSION constant does not match $(VERSION). Run 'make bump VERSION=$(VERSION)' first."; exit 1; }
@@ -274,6 +274,8 @@ endif
 		{ echo "ERROR: typescript/package-lock.json records a stale SDK version. Run 'make bump VERSION=$(VERSION)' first."; exit 1; }
 	@grep -qxF '    basecamp-sdk ($(VERSION))' ruby/Gemfile.lock || \
 		{ echo "ERROR: ruby/Gemfile.lock's PATH spec records a stale SDK version. Run 'make bump VERSION=$(VERSION)' first."; exit 1; }
+	@grep -qxF '  basecamp-sdk ($(VERSION))' ruby/Gemfile.lock || \
+		{ echo "ERROR: ruby/Gemfile.lock's CHECKSUMS entry records a stale SDK version. Run 'make bump VERSION=$(VERSION)' first."; exit 1; }
 	@cd python && uv lock --check || \
 		{ echo "ERROR: python/uv.lock is stale. Run 'make bump VERSION=$(VERSION)' first."; exit 1; }
 	@test "$$(jq -r '.packages["../../../typescript"].version' conformance/runner/typescript/package-lock.json)" = "$(VERSION)" || \
@@ -282,6 +284,8 @@ endif
 	@# are always present; a stale one breaks the frozen conformance installs (#671).
 	@grep -qxF '    basecamp-sdk ($(VERSION))' conformance/runner/ruby/Gemfile.lock || \
 		{ echo "ERROR: conformance/runner/ruby/Gemfile.lock records a stale SDK version. Run 'make bump VERSION=$(VERSION)' first."; exit 1; }
+	@grep -qxF '  basecamp-sdk ($(VERSION))' conformance/runner/ruby/Gemfile.lock || \
+		{ echo "ERROR: conformance/runner/ruby/Gemfile.lock's CHECKSUMS entry records a stale SDK version. Run 'make bump VERSION=$(VERSION)' first."; exit 1; }
 	@(cd conformance/runner/python && uv lock --check) || \
 		{ echo "ERROR: conformance/runner/python/uv.lock is stale. Run 'make bump VERSION=$(VERSION)' first."; exit 1; }
 	@git diff --quiet && git diff --cached --quiet || \

--- a/Makefile
+++ b/Makefile
@@ -255,7 +255,7 @@ endif
 		{ echo "ERROR: Go version does not match $(VERSION). Run 'make bump VERSION=$(VERSION)' first."; exit 1; }
 	@test "$$(jq -r '.version' typescript/package.json)" = "$(VERSION)" || \
 		{ echo "ERROR: TypeScript version does not match $(VERSION). Run 'make bump VERSION=$(VERSION)' first."; exit 1; }
-	@grep -qF 'export const VERSION = "$(VERSION)"' typescript/src/client.ts || \
+	@grep -qxF 'export const VERSION = "$(VERSION)";' typescript/src/client.ts || \
 		{ echo "ERROR: TypeScript client VERSION constant does not match $(VERSION). Run 'make bump VERSION=$(VERSION)' first."; exit 1; }
 	@grep -qF 'VERSION = "$(VERSION)"' ruby/lib/basecamp/version.rb || \
 		{ echo "ERROR: Ruby version does not match $(VERSION). Run 'make bump VERSION=$(VERSION)' first."; exit 1; }
@@ -269,6 +269,10 @@ endif
 		{ echo "ERROR: Python pyproject.toml [project].version does not match $(VERSION). Run 'make bump VERSION=$(VERSION)' first."; exit 1; }
 	@grep -qF 'VERSION = "$(VERSION)"' python/src/basecamp/_version.py || \
 		{ echo "ERROR: Python version does not match $(VERSION). Run 'make bump VERSION=$(VERSION)' first."; exit 1; }
+	@grep -qxF '# v$(VERSION)' MIGRATING.md || \
+		{ echo "ERROR: MIGRATING.md has no '# v$(VERSION)' heading. Run 'make bump VERSION=$(VERSION)' first."; exit 1; }
+	@! grep -qxF '# Unreleased' MIGRATING.md || \
+		{ echo "ERROR: MIGRATING.md still has an '# Unreleased' section — its notes would miss the release. Run 'make bump VERSION=$(VERSION)' first."; exit 1; }
 	@# Verify lockfiles are frozen against their manifests
 	@test "$$(jq -r '.version' typescript/package-lock.json)" = "$(VERSION)" -a "$$(jq -r '.packages[""].version' typescript/package-lock.json)" = "$(VERSION)" || \
 		{ echo "ERROR: typescript/package-lock.json records a stale SDK version. Run 'make bump VERSION=$(VERSION)' first."; exit 1; }

--- a/Makefile
+++ b/Makefile
@@ -265,8 +265,8 @@ endif
 		{ echo "ERROR: Kotlin Gradle project version does not match $(VERSION). Run 'make bump VERSION=$(VERSION)' first."; exit 1; }
 	@grep -qF 'public static let version = "$(VERSION)"' swift/Sources/Basecamp/BasecampConfig.swift || \
 		{ echo "ERROR: Swift version does not match $(VERSION). Run 'make bump VERSION=$(VERSION)' first."; exit 1; }
-	@grep -qxF 'version = "$(VERSION)"' python/pyproject.toml || \
-		{ echo "ERROR: Python pyproject.toml version does not match $(VERSION). Run 'make bump VERSION=$(VERSION)' first."; exit 1; }
+	@awk -v want='version = "$(VERSION)"' '/^\[/ { inproj = ($$0 == "[project]") } inproj && $$0 == want { found = 1 } END { exit !found }' python/pyproject.toml || \
+		{ echo "ERROR: Python pyproject.toml [project].version does not match $(VERSION). Run 'make bump VERSION=$(VERSION)' first."; exit 1; }
 	@grep -qF 'VERSION = "$(VERSION)"' python/src/basecamp/_version.py || \
 		{ echo "ERROR: Python version does not match $(VERSION). Run 'make bump VERSION=$(VERSION)' first."; exit 1; }
 	@# Verify lockfiles are frozen against their manifests

--- a/Makefile
+++ b/Makefile
@@ -248,11 +248,15 @@ ifndef VERSION
 	$(error VERSION is required. Usage: make release VERSION=x.y.z)
 endif
 	@echo "Releasing v$(VERSION)..."
-	@# Verify version constants match
+	@# Verify version constants match — every file scripts/bump-version.sh writes
+	@grep -qF '"version": "$(VERSION)"' package.json || \
+		{ echo "ERROR: Root package.json version does not match $(VERSION). Run 'make bump VERSION=$(VERSION)' first."; exit 1; }
 	@grep -qF 'Version = "$(VERSION)"' go/pkg/basecamp/version.go || \
 		{ echo "ERROR: Go version does not match $(VERSION). Run 'make bump VERSION=$(VERSION)' first."; exit 1; }
 	@grep -qF '"version": "$(VERSION)"' typescript/package.json || \
 		{ echo "ERROR: TypeScript version does not match $(VERSION). Run 'make bump VERSION=$(VERSION)' first."; exit 1; }
+	@grep -qF 'export const VERSION = "$(VERSION)"' typescript/src/client.ts || \
+		{ echo "ERROR: TypeScript client VERSION constant does not match $(VERSION). Run 'make bump VERSION=$(VERSION)' first."; exit 1; }
 	@grep -qF 'VERSION = "$(VERSION)"' ruby/lib/basecamp/version.rb || \
 		{ echo "ERROR: Ruby version does not match $(VERSION). Run 'make bump VERSION=$(VERSION)' first."; exit 1; }
 	@grep -qF 'const val VERSION = "$(VERSION)"' kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/BasecampConfig.kt || \
@@ -261,6 +265,8 @@ endif
 		{ echo "ERROR: Kotlin Gradle project version does not match $(VERSION). Run 'make bump VERSION=$(VERSION)' first."; exit 1; }
 	@grep -qF 'public static let version = "$(VERSION)"' swift/Sources/Basecamp/BasecampConfig.swift || \
 		{ echo "ERROR: Swift version does not match $(VERSION). Run 'make bump VERSION=$(VERSION)' first."; exit 1; }
+	@grep -q '^version = "$(VERSION)"' python/pyproject.toml || \
+		{ echo "ERROR: Python pyproject.toml version does not match $(VERSION). Run 'make bump VERSION=$(VERSION)' first."; exit 1; }
 	@grep -qF 'VERSION = "$(VERSION)"' python/src/basecamp/_version.py || \
 		{ echo "ERROR: Python version does not match $(VERSION). Run 'make bump VERSION=$(VERSION)' first."; exit 1; }
 	@# Verify lockfiles are frozen against their manifests

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -59,6 +59,10 @@ sedi "s/^version = \".*\"/version = \"$VERSION\"/" python/pyproject.toml
 # 10. Python _version.py
 sedi "s/^VERSION = \".*\"/VERSION = \"$VERSION\"/" python/src/basecamp/_version.py
 
+# 11. MIGRATING.md — promote "# Unreleased" to "# v$VERSION" (make release
+# guards the promoted heading, so skipping this cannot reach a tag)
+"$(dirname "$0")/promote-migrating.sh" "$VERSION"
+
 # Sync TypeScript lockfile
 echo "Syncing TypeScript lockfile..."
 (cd typescript && npm install --package-lock-only --ignore-scripts)

--- a/scripts/promote-migrating.sh
+++ b/scripts/promote-migrating.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Promotes MIGRATING.md's "# Unreleased" heading to "# v<version>".
+# Called by bump-version.sh; `make release` guards the result, so a bump that
+# skips this (or a hand-rolled bump) cannot tag with notes still unpromoted.
+set -euo pipefail
+
+VERSION="${1:?usage: $0 <version> [file]}"
+FILE="${2:-MIGRATING.md}"
+
+if grep -qxF "# v$VERSION" "$FILE"; then
+  if grep -qxF "# Unreleased" "$FILE"; then
+    echo "ERROR: $FILE carries both '# v$VERSION' and '# Unreleased' — resolve by hand." >&2
+    exit 1
+  fi
+  echo "$FILE already promoted to v$VERSION"
+  exit 0
+fi
+
+if ! grep -qxF "# Unreleased" "$FILE"; then
+  echo "ERROR: $FILE has neither '# Unreleased' nor '# v$VERSION' — nothing to promote." >&2
+  exit 1
+fi
+
+awk -v v="# v$VERSION" 'BEGIN { done = 0 }
+  !done && $0 == "# Unreleased" { print v; done = 1; next }
+  { print }' "$FILE" > "$FILE.tmp" && mv "$FILE.tmp" "$FILE"
+echo "Promoted '# Unreleased' -> '# v$VERSION' in $FILE"


### PR DESCRIPTION
The release surface carried nine catalogued defects under the standing rule "don't tag before fixing". This PR repairs the seven that live in the tree; the other two happen at tag time (`# Unreleased` → `# v0.15.0` promotion with `make bump`; the version-specific release-body line). Doc + tooling only — no SDK behaviour. While it was in review, `main` moved by four merges (#804, #807, #809, #810); those are absorbed too.

## What this fixes

1. **Two post-tag entries re-filed** out of `# v0.14.0` into `# Unreleased`: the #662 absent-expiry changes and the `TimelineEventData` retype (both landed in #703, after the tag — `git show go/v0.14.0:MIGRATING.md` contains neither heading).

2. **Five missing entries written** (four from the original catalogue, one found by review):
   - **#773** (PR #779): the Documents/ScheduleEntry read paths — `Get`/`GetEntry` and the composites built on them — return a transport failure verbatim instead of stamping it permanently malformed.
   - **#737** (PR #754): four TS paginated methods now declare the `ListResult` they always returned.
   - **#735** (PR #749): Swift public inits — **recorded as not a break** (verified: no existing initializer changed shape; `updateMyPreferences` was uncallable outright, `updateGaugeNeedle` callable only as the nil-payload `{}` bc3 400s).
   - **`1919e77f7`** (bare commit): maxPages enforced at runtime in TS/Ruby.
   - **Ruby crash-to-`ApiError` class** (bare commits `2f21c9de7`, `328153020`, `478514642`, surfaced by Codex): `mailto:`/hostless server-supplied URLs in Link headers, redirects, and the download hop used to crash with raw `URI`/`ArgumentError` exceptions; all three now refuse with `ApiError`. One combined entry records the class and the rescue that stops matching.

3. **#650 recount** re-derived from both schemas (two of the seven new keys conditional, plus `position`, which was already modeled).

4. **#604's Kotlin row** now names `decodeFailure` as the discriminator, matching the KDoc.

5. **Trailer rewritten**: verification commit and the true in-flight set (now `fa15fc126`; the event-feed stack and two drafts).

6. **`make release` guard gap closed, then hardened by review**: the target originally grepped seven of the ten files `scripts/bump-version.sh` writes. Now: root and TS `package.json` read via `jq` field access; TS client constant exact; `python/pyproject.toml` parsed from its `[project]` table (awk section-scoped); both `Gemfile.lock` records (PATH spec + CHECKSUMS) exact whole-line matched in both lockfiles; TS `package-lock.json` both fields via `jq`. **Every guard mutation-proven**, including the literal bypasses (nested JSON `"version"` field; a `version =` assignment in a foreign TOML table) demonstrated against the old checks and refused by the new ones. Restore by copy, `diff -q` clean, real exit codes captured.

7. **Release bodies state the notes' blind spot**: generated notes are built from merged PRs and cannot see bare commits; MIGRATING.md records consumer-visible changes regardless of how they merged.

8. **Main-merge absorption** (#804/#807/#809/#810): #809/#810 wrote their own entries and carry `breaking`; #807 is CI-internal; **#804 was breaking-labeled with no entry** — its entry is added (address-policed discovery hop 2, the variadic `NewDiscoverer` compile note, remedies in policy order).

## Labels

`breaking` applied to: #703, #716, #723, #725, #726, #754, #779, #782, #796 (joining #772; #804/#809/#810 arrived already labeled). Declined in writing: #749 (not a break), #781, #727, #751 (rationales in the thread history).

## Verification

- `LC_ALL=C make doc-constants-check` green (REAL_EXIT captured) after every MIGRATING edit.
- Every `# Unreleased` entry cross-checked against `git log go/v0.14.0..origin/main`; #770/#771 ruled out as unentried breaks by inspection.
- All guard proofs as above.

Not doing (declined in writing): a CHANGELOG — MIGRATING.md plus label-generated notes is the convention; a third surface is a third thing to drift.