### PR TITLE
Police the endpoints a discovered issuer names, not only the issuer

### DIFF
--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -13,6 +13,54 @@ what wrong behaviour you get if you ignore one. This file is that half.
 
 # Unreleased
 
+### Go: device-flow and token-exchange requests are address-policed by default (#806)
+
+**The compile error, if you get one:** none for direct calls. `NewExchanger`
+gained a variadic `...ExchangerOption`, which is source-compatible everywhere
+except a function value — `var f func(*http.Client) *oauth.Exchanger =
+oauth.NewExchanger` no longer compiles. `apidiff` reports it as incompatible
+for that reason.
+
+**The behaviour change:** `PerformDeviceLogin`, `RequestDeviceAuthorization`,
+`PollDeviceToken`, and an `Exchanger` built with a nil client used to post on
+`http.DefaultClient`. They now post on a client that judges the endpoint's
+literal address at dial time against `oauth.DefaultIssuerPolicy()` — the same
+policy #804 put on the advertised-issuer metadata fetch — because the
+`token_endpoint` and `device_authorization_endpoint` those requests target may
+be the ones a discovered issuer's metadata named, and nothing constrains those
+to the issuer's origin. An endpoint in loopback, RFC 1918, link-local, CGNAT,
+or IANA special-purpose space is refused before any connection opens, with a
+non-retryable `*basecamp.Error` (`api_error`) that also matches
+`errors.Is(err, surfguard.ErrBlocked)`. In the poll loop the refusal ends the
+flow on the first attempt; it is not a timeout and is never backed off.
+
+**Wrong behaviour you get if you ignore it:** a login or exchange against a
+hand-configured authorization server on `localhost` or a private address fails
+where it used to succeed, and the error names the address policy. Three
+remedies, in order of preference:
+
+```go
+// Re-admit exactly the space you need. AllowLoopback is the only derivation
+// that pierces the IANASpecialUse tables; for RFC 1918 build without them.
+oauth.PerformDeviceLogin(ctx, cfg, clientID, display,
+    oauth.WithDevicePolicy(oauth.DefaultIssuerPolicy().AllowLoopback()))
+oauth.NewExchanger(nil, oauth.WithExchangerPolicy(
+    surfguard.Policy{}.AllowAllPorts().Allow(netip.MustParsePrefix("10.4.0.0/16"))))
+
+// Carry the requests on your own client — yours, enforcement included.
+oauth.PerformDeviceLogin(ctx, cfg, clientID, display, oauth.WithDeviceHTTPClient(hc))
+oauth.NewExchanger(hc)
+
+// Restore the old behaviour outright.
+oauth.NewExchanger(http.DefaultClient)
+```
+
+**If you already pass your own client, nothing changed for you — including
+the protection.** A client handed to `WithDeviceHTTPClient` or `NewExchanger`
+is used as given; the policy is not layered on top, because it lives in the
+transport's dialer. Compose it in yourself where you can:
+`&http.Client{Transport: oauth.DefaultIssuerPolicy().RoundTripper()}`.
+
 ### All SDKs: the signed download hop no longer follows redirects (#805)
 
 `DownloadURL` (`downloadURL`, `download_url`, `UploadsService.Download` and its

--- a/SPEC.md
+++ b/SPEC.md
@@ -2087,6 +2087,65 @@ it: the assertion is "no connection was attempted", which is not an observable
 of the mock-HTTP runner, and the remaining four SDKs have no equivalent
 enforcement layer to point at yet. See Appendix F.
 
+##### 6. Judge the ADDRESS of the endpoints the selected metadata names `[Go-first]`
+
+Requirement 5 closes the metadata GET and leaves an indirect route open
+(#806). An attacker-controlled issuer on *public* space passes the policy, is
+selected, and returns correctly issuer-bound metadata whose `token_endpoint`
+and `device_authorization_endpoint` point wherever it likes — the metadata
+parser checks only that `token_endpoint` is non-empty and copies it verbatim.
+`requireSecureEndpoint` then admits any `https` host, private space included.
+So the cost of reaching private space is one public host, and what arrives
+there is the `client_id`, the `device_code`, the authorization code, the
+`client_secret`, or the refresh token — real credentials, where requirement 5's
+exposure was a blind GET. That is strictly worse than the one it closes.
+
+Two remedies that look sufficient are not, and the reasons are worth keeping:
+
+- **Same-origin is not the control.** RFC 8414 §2 requires the endpoint fields
+  to be URLs and says nothing about their origin, and RFC 8705 §5's
+  `mtls_endpoint_aliases` exists precisely so a server can publish endpoints
+  *off* the issuer origin. A same-origin rule is a departure from the standard,
+  not a tightening of it. It also does not survive DNS rebinding: the rule
+  compares hostname strings, and the hostname is resolved twice — once during
+  discovery, once at the later credential POST — so a name that resolves
+  publicly at discovery can resolve privately when the credentials go out.
+  Same-origin MAY be added as BC5 profile policy once fleet compatibility is
+  confirmed — BC5's metadata controller mints every endpoint from its own
+  route helpers next to `issuer: canonical_issuer_url`, but whether those share
+  an origin in every deployment is the check to run first — and even then it is
+  defence in depth, not the closure.
+- **Scheme alone is not the control.** `https` is satisfied by any private host.
+
+The control is the same one as requirement 5: **dial-time address enforcement
+on every device-authorization and token endpoint request**, judging the literal
+address at the moment each socket opens, so there is no check-to-use gap for a
+rebind to exploit and no assumption about what the AS chose to publish.
+
+The device and exchange functions cannot tell a discovered endpoint from a
+hand-configured one — `performDeviceLogin` takes a `Config`, `exchangeCode` and
+`refreshToken` take a string — so the policy applies to every request those
+functions make on their default client. That is the same uniformity decision as
+requirement 5's `expectedIssuer` rule, for the same reason: a provenance flag on
+the config is a marker that a consumer round-tripping the config through
+storage silently drops. The overrides are therefore the consumer's, and an
+implementation MUST expose the same three as requirement 5 — a replacement
+policy, a replacement client for the request, and a way to disable it (handing
+over a plain client counts). A refusal is coded `api_error`, is NOT retryable,
+and in the poll loop terminates the flow on the first attempt rather than
+backing off — surfguard's `unresolvable` (retry later) and `blocked` (stop)
+are distinct verdicts and must stay distinct here.
+
+**Go is the only implementation today** (`oauth.DefaultIssuerPolicy` on the
+device flow's and `Exchanger`'s default client; `WithDevicePolicy`,
+`WithExchangerPolicy`, `WithDeviceHTTPClient`, a non-nil `NewExchanger`
+client). Written `SHOULD` and `[Go-first]` for requirement 5's reasons. A
+caller-supplied client is the caller's, enforcement included: the policy is not
+layered on top of it, because the enforcement seam is the client's own dialer.
+That contract is what makes a consumer that passes its general-purpose client
+into these functions (as `basecamp-cli` does) responsible for composing the
+policy into that client's transport. See Appendix F.
+
 #### Injected-client fidelity tier `[static]`
 
 SDKs that accept a caller-supplied HTTP client (Ruby `http_client:`, and any
@@ -2171,7 +2230,10 @@ dark-launched (`issuance_enabled` off), the device authorization endpoint
 answers **503** — surfaced as `api_error` with that status, meaning "not yet
 enabled here", not a protocol failure.*
 
-Three functions per SDK. All device-auth + token requests are TLS-guarded (§9).
+Three functions per SDK. All device-auth + token requests are TLS-guarded (§9),
+and — Go only, today — address-policed at dial time on the default client (§16
+SSRF hardening, requirement 6), since the endpoints they POST credentials to may
+be the ones a discovered issuer's metadata named.
 
 ```
 FUNCTION requestDeviceAuthorization(deviceAuthEndpoint, clientId, scope?) → DeviceAuthorization
@@ -4067,6 +4129,45 @@ advertised on loopback or in RFC 1918 space, and which worked before, now needs
 `IANASpecialUse()` — those tables outrank `Allow`, and `AllowLoopback()` is the
 only derivation that pierces them — so an on-premises policy is built as
 `surfguard.Policy{}.AllowAllPorts().Allow(...)` instead.
+
+### Device and Token Endpoint Address Policy (§16)
+
+§16's SSRF requirement 6 — judging the address of the `token_endpoint` and
+`device_authorization_endpoint` the selected metadata names, at connection
+time, on every credential-bearing POST — is likewise implemented in Go only,
+with the same policy and the same override shape as the issuer hop. The
+per-SDK state, and the seam each SDK would need, so the follow-ups are
+specified rather than rediscovered:
+
+| SDK | Device-authorization and token endpoint POSTs |
+|-----|-----------------------------------------------|
+| Go | `oauth.DefaultIssuerPolicy()` on the device flow's and `Exchanger`'s default client, shared with the issuer hop. Refused as `api_error`, non-retryable; the poll loop terminates on the first attempt. Overrides: `WithDevicePolicy` / `WithDeviceHTTPClient`; `WithExchangerPolicy` / a non-nil `NewExchanger` client. A caller-supplied client is the caller's, enforcement included |
+| Ruby | Scheme gate, bounded timeout, suppressed redirects, bounded body. The `surfguard` gem (the shared classification tables, resolve-only by design) exists; enforcement would mean pinning a resolved address into `Net::HTTP#ipaddr=` under the default `Fetcher` transport, which the injected-Faraday lane cannot do |
+| TypeScript | Scheme gate, bounded timeout, `redirect: "manual"`, bounded body. No classification tables in the ecosystem; the seam is an undici `Agent` with a `connect.lookup` hook, which the SDK's global-`fetch` contract does not reach |
+| Python | Scheme gate, bounded timeout, `follow_redirects=False` (httpx default), bounded body. No classification tables; the seam is a custom `httpx` transport over a resolving `httpcore` backend |
+| Kotlin | Scheme gate, bounded timeout, `followRedirects = false`, bounded body. No classification tables; the JVM seam is OkHttp's `Dns` interface (OkHttp connects to exactly the addresses it returns, so filtering there is connect-time judgement), with no multiplatform equivalent |
+| Swift | Not applicable — ships no OAuth device flow or discovery |
+
+Three things hold in every SDK, policy or not, and are not what this
+divergence is about: the scheme gate, the bounded timeout, and the bounded
+body. Redirect suppression is NOT uniform on the exchange path: Go's
+`Exchanger` and Kotlin's `exchangeCode`/`refreshToken` follow redirects (TS's
+exchange passes no `redirect:` option, so it follows too), where the device
+flow suppresses them in all four — a 307 re-POSTs the credentials to the
+`Location`. Under Go's policy client each redirect hop's dial is judged, so the
+address policy holds across a redirect; the public-host re-POST does not need
+the policy to be exploitable and is the same cross-SDK shape as #805.
+
+The behavioral tightening is the same as the issuer hop's, and it reaches one
+more consumer shape: a Go caller that hand-configures a loopback or RFC 1918
+authorization server and relied on `NewExchanger(nil)` or a device-flow call
+with no `WithDeviceHTTPClient` now needs `WithExchangerPolicy` /
+`WithDevicePolicy` (with `AllowLoopback()` for local development), or passes
+`http.DefaultClient` to restore the old behavior outright. A caller that
+already passes its own client — `basecamp-cli` passes its general-purpose
+client to all three entry points — sees no change, and is also not protected
+by this: the policy lives in the transport, and that consumer owns its
+transport.
 
 ### Retry Strategy (§7)
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -2118,9 +2118,10 @@ Two remedies that look sufficient are not, and the reasons are worth keeping:
 - **Scheme alone is not the control.** `https` is satisfied by any private host.
 
 The control is the same one as requirement 5: **dial-time address enforcement
-on every device-authorization and token endpoint request**, judging the literal
-address at the moment each socket opens, so there is no check-to-use gap for a
-rebind to exploit and no assumption about what the AS chose to publish.
+on every device-authorization and token endpoint request the device flow and
+the token exchanger make**, judging the literal address at the moment each
+socket opens, so there is no check-to-use gap for a rebind to exploit and no
+assumption about what the AS chose to publish.
 
 The device and exchange functions cannot tell a discovered endpoint from a
 hand-configured one — `performDeviceLogin` takes a `Config`, `exchangeCode` and
@@ -2135,6 +2136,19 @@ over a plain client counts). A refusal is coded `api_error`, is NOT retryable,
 and in the poll loop terminates the flow on the first attempt rather than
 backing off — surfguard's `unresolvable` (retry later) and `blocked` (stop)
 are distinct verdicts and must stay distinct here.
+
+The boundary stops at those functions, and one SDK path sits outside it by
+construction: a refresh driven by **stored credentials** — Go's `AuthManager`
+posting to `Credentials.TokenEndpoint` on the client its constructor was
+handed — is caller-configured territory even when the stored endpoint was
+originally discovered. The documented device-login bridge copies
+`result.Config.TokenEndpoint` into the credential store, and that round trip
+through storage is exactly the provenance loss described above: the endpoint
+re-enters the SDK as caller configuration, on a caller-owned client, and the
+enforcement is that client's. Consumers persisting discovered endpoints MUST
+NOT infer that later automatic refreshes receive this requirement's default
+policy; they compose the policy into the client they hand `AuthManager`, the
+same as any caller-supplied client here. See Appendix F.
 
 **Go is the only implementation today** (`oauth.DefaultIssuerPolicy` on the
 device flow's and `Exchanger`'s default client; `WithDevicePolicy`,
@@ -4148,15 +4162,23 @@ specified rather than rediscovered:
 | Kotlin | Scheme gate, bounded timeout, `followRedirects = false`, bounded body. No classification tables; the JVM seam is OkHttp's `Dns` interface (OkHttp connects to exactly the addresses it returns, so filtering there is connect-time judgement), with no multiplatform equivalent |
 | Swift | Not applicable — ships no OAuth device flow or discovery |
 
-Three things hold in every SDK, policy or not, and are not what this
-divergence is about: the scheme gate, the bounded timeout, and the bounded
-body. Redirect suppression is NOT uniform on the exchange path: Go's
-`Exchanger` and Kotlin's `exchangeCode`/`refreshToken` follow redirects (TS's
-exchange passes no `redirect:` option, so it follows too), where the device
-flow suppresses them in all four — a 307 re-POSTs the credentials to the
-`Location`. Under Go's policy client each redirect hop's dial is judged, so the
-address policy holds across a redirect; the public-host re-POST does not need
-the policy to be exploitable and is the same cross-SDK shape as #805.
+Two things hold in every SDK, policy or not, and are not what this divergence
+is about: the scheme gate and the bounded body. Two more are NOT uniform on
+the exchange path, and listing them as universal is how a reader infers a
+guarantee nobody implemented. The bounded timeout holds on the device flow in
+all four, but Go's `doTokenRequest` bounds nothing itself — the caller's
+context is the only deadline, and the shared policy client deliberately
+carries no client timeout — and Kotlin's `postTokenRequest` builds its default
+client without `HttpTimeout`; TS (30 s), Python (`_TOKEN_TIMEOUT`), and Ruby
+(Faraday timeouts) do bound theirs. Redirect suppression: Go's `Exchanger` and
+Kotlin's `exchangeCode`/`refreshToken` follow redirects (TS's exchange passes
+no `redirect:` option, so it follows too), where the device flow suppresses
+them in all four — a 307 re-POSTs the credentials to the `Location`. Under
+Go's policy client each redirect hop's dial is judged, so the address policy
+holds across a redirect; the public-host re-POST does not need the policy to
+be exploitable. This is the same cross-SDK shape #805 had on the download's
+signed hop before #809 closed it there — the exchange path is now the
+remaining redirect-following exception.
 
 The behavioral tightening is the same as the issuer hop's, and it reaches one
 more consumer shape: a Go caller that hand-configures a loopback or RFC 1918
@@ -4168,6 +4190,16 @@ already passes its own client — `basecamp-cli` passes its general-purpose
 client to all three entry points — sees no change, and is also not protected
 by this: the policy lives in the transport, and that consumer owns its
 transport.
+
+The same boundary holds one function further out, and is worth recording so
+nobody infers otherwise: Go's `AuthManager.refreshLocked` posts a stored
+refresh token to `Credentials.TokenEndpoint` on the client `NewAuthManager`
+was handed, and the documented device-login bridge stores
+`result.Config.TokenEndpoint` — a discovered endpoint — into those
+credentials. Later automatic refreshes therefore do NOT receive the new
+default policy; the endpoint re-enters the SDK as caller configuration on a
+caller-owned client, and the enforcement is that client's to compose (§16
+requirement 6).
 
 ### Retry Strategy (§7)
 

--- a/go/README.md
+++ b/go/README.md
@@ -263,6 +263,19 @@ Notes:
   `Proxy: nil` by construction. `oauth.WithoutIssuerPolicy` restores the
   pre-policy behavior outright.
 
+- **The same policy governs where the credentials go next.** The selected
+  `Config` carries the `token_endpoint` and `device_authorization_endpoint`
+  the issuer's metadata named, and nothing constrains those to the issuer's
+  origin — so a public issuer that passes the policy could still steer the
+  `client_id`, `device_code`, authorization code, client secret, or refresh
+  token into private space. `PerformDeviceLogin`, `RequestDeviceAuthorization`,
+  `PollDeviceToken`, and an `Exchanger` therefore judge the endpoint's address
+  at dial time by default, on the same shared `oauth.DefaultIssuerPolicy()`
+  client. A refusal is a non-retryable `*basecamp.Error` (`api_error`) that
+  matches `errors.Is(err, surfguard.ErrBlocked)`; in the poll loop it ends the
+  flow on the first attempt rather than backing off. See the device-flow
+  section below for the overrides.
+
 ### OAuth device authorization grant (RFC 8628)
 
 For CLIs and other input-constrained clients, the `oauth` package implements the
@@ -345,6 +358,34 @@ cancellation. The clock (`oauth.WithDeviceClock`) and inter-poll wait
 (`oauth.WithDeviceSleep`) are injectable for deterministic tests; scope is
 omitted from the authorization request unless set with `oauth.WithDeviceScope`,
 so the server applies its default (`read`) — prefer pinning it explicitly.
+
+**Both endpoints are address-policed by default**, and so is the token endpoint
+an `oauth.Exchanger` posts to: the flow cannot tell a discovered endpoint from
+a hand-configured one, so every request on the default client is judged by
+`oauth.DefaultIssuerPolicy()` at dial time. The precedence is the same on every
+surface of the package — a client you hand in is yours, enforcement included;
+otherwise your policy; otherwise the default:
+
+```go
+// Local development against an AS on loopback — AllowLoopback pierces the
+// IANASpecialUse tables; plain Allow does not (see the discovery notes above).
+devPolicy := oauth.WithDevicePolicy(oauth.DefaultIssuerPolicy().AllowLoopback())
+token, err := oauth.PerformDeviceLogin(ctx, cfg, "basecamp-cli", display, devPolicy)
+ex := oauth.NewExchanger(nil, oauth.WithExchangerPolicy(oauth.DefaultIssuerPolicy().AllowLoopback()))
+
+// Your own client carries the requests instead, policy and all. To keep the
+// policy on a custom transport, build the transport from it:
+hc := &http.Client{Transport: oauth.DefaultIssuerPolicy().RoundTripper()}
+oauth.PerformDeviceLogin(ctx, cfg, "basecamp-cli", display, oauth.WithDeviceHTTPClient(hc))
+oauth.NewExchanger(hc)
+
+// http.DefaultClient restores the pre-policy behavior outright.
+oauth.NewExchanger(http.DefaultClient)
+```
+
+`WithDevicePolicy` builds its transport once, when the option is constructed,
+so build it once and reuse it; an `Exchanger` given `WithExchangerPolicy` owns
+its transport the same way. Neither has a `Close`.
 
 ### Persisting device-login credentials (RFC 8707 resource echo)
 

--- a/go/pkg/basecamp/oauth/device.go
+++ b/go/pkg/basecamp/oauth/device.go
@@ -13,6 +13,8 @@ import (
 	"strings"
 	"time"
 
+	surfguard "github.com/basecamp/surfguard/go"
+
 	"github.com/basecamp/basecamp-sdk/go/pkg/basecamp"
 )
 
@@ -74,25 +76,58 @@ type DeviceAuthorization struct {
 
 // deviceConfig holds the resolved options for a device-flow operation.
 type deviceConfig struct {
+	// httpClient carries every device-flow POST. Resolved by newDeviceConfig:
+	// a caller-supplied client, else a caller-supplied policy's client, else
+	// the shared DefaultIssuerPolicy client.
 	httpClient *http.Client
-	scope      string
-	hasScope   bool
-	timeout    time.Duration
-	clock      func() time.Time
-	sleep      func(ctx context.Context, d time.Duration) error
+	// policyClient is WithDevicePolicy's client, used only when no client was
+	// supplied directly.
+	policyClient *http.Client
+	scope        string
+	hasScope     bool
+	timeout      time.Duration
+	clock        func() time.Time
+	sleep        func(ctx context.Context, d time.Duration) error
 }
 
 // DeviceOption configures a device-flow operation.
 type DeviceOption func(*deviceConfig)
 
-// WithDeviceHTTPClient sets the HTTP client used for device-flow requests.
-// Nil leaves http.DefaultClient.
+// WithDeviceHTTPClient carries every device-flow request on the given client
+// instead of the policy-enforced default, and takes precedence over
+// WithDevicePolicy. Nil leaves the default.
+//
+// The client is the caller's, enforcement included: no address policy is
+// applied on top of it. A consumer that must egress through a proxy has no
+// other way to keep both, since surfguard's transport sets Proxy: nil by
+// construction — compose the client's transport from
+// DefaultIssuerPolicy().RoundTripper() where that is possible. Passing
+// http.DefaultClient restores the pre-policy behavior outright.
 func WithDeviceHTTPClient(c *http.Client) DeviceOption {
 	return func(cfg *deviceConfig) {
 		if c != nil {
 			cfg.httpClient = c
 		}
 	}
+}
+
+// WithDevicePolicy replaces [DefaultIssuerPolicy] for the device-authorization
+// and token endpoint POSTs, so a deployment whose authorization server is not
+// on the public internet re-admits exactly the space it needs rather than
+// switching the policy off. The derivations and the precedence trap are the
+// ones documented on [WithIssuerPolicy]: AllowLoopback for a local server,
+// surfguard.Policy{}.AllowAllPorts().Allow(...) for private space.
+//
+// It has no effect alongside WithDeviceHTTPClient, which supplies the transport
+// the policy would otherwise be installed in.
+//
+// The option builds its transport once, when it is constructed, and every
+// device-flow call it is passed to reuses it — so construct it once and keep
+// it, rather than rebuilding it per call, or each call leaks a connection
+// pool nothing can close.
+func WithDevicePolicy(p surfguard.Policy) DeviceOption {
+	client := newPolicyClient(p)
+	return func(cfg *deviceConfig) { cfg.policyClient = client }
 }
 
 // WithDeviceScope sets the requested scope. When omitted, scope is left out of
@@ -134,10 +169,9 @@ func WithDeviceSleep(sleep func(ctx context.Context, d time.Duration) error) Dev
 
 func newDeviceConfig(opts []DeviceOption) deviceConfig {
 	cfg := deviceConfig{
-		httpClient: http.DefaultClient,
-		timeout:    defaultDeviceRequestTimeout,
-		clock:      time.Now,
-		sleep:      defaultDeviceSleep,
+		timeout: defaultDeviceRequestTimeout,
+		clock:   time.Now,
+		sleep:   defaultDeviceSleep,
 	}
 	for _, o := range opts {
 		o(&cfg)
@@ -147,8 +181,23 @@ func newDeviceConfig(opts []DeviceOption) deviceConfig {
 	if cfg.timeout <= 0 || cfg.timeout > maxDeviceRequestTimeout {
 		cfg.timeout = defaultDeviceRequestTimeout
 	}
+	// Client precedence, the same on every surface of this package: a client
+	// the caller handed us is theirs, enforcement included; else a caller's
+	// policy; else the shared DefaultIssuerPolicy client. The default is
+	// policed because the endpoints these POSTs target may come from
+	// DiscoverFromResource's metadata, and nothing here can tell a discovered
+	// endpoint from a hand-configured one — "the policy applies sometimes" is
+	// the branch a bypass grows out of.
+	switch {
+	case cfg.httpClient != nil:
+	case cfg.policyClient != nil:
+		cfg.httpClient = cfg.policyClient
+	default:
+		cfg.httpClient = sharedPolicyClient()
+	}
 	// Suppress redirects on every device-flow POST so a 3xx surfaces as a non-2xx
 	// api_error rather than the client chasing an attacker-influenced Location.
+	// This copies, which is what keeps sharing the default client legal.
 	cfg.httpClient = suppressRedirects(cfg.httpClient)
 	return cfg
 }
@@ -254,9 +303,10 @@ func RequestDeviceAuthorization(ctx context.Context, deviceAuthEndpoint, clientI
 	// The suppression is about gosec's taint rule, not a claim that this URL is
 	// trusted. DeviceAuthorizationEndpoint may be caller-configured, but it may
 	// equally come from DiscoverFromResource's metadata, in which case a remote
-	// peer chose it and NOTHING here judges the address it resolves to — see
-	// issue #806. This request carries client_id.
-	resp, err := cfg.httpClient.Do(req) // #nosec G704 -- see the note above: not address-policed (#806)
+	// peer chose it — so by default the client judges the address it resolves
+	// to at dial time (DefaultIssuerPolicy, #806). This request carries
+	// client_id.
+	resp, err := cfg.httpClient.Do(req) // #nosec G704 -- see the note above: address-policed by default
 	if err != nil {
 		// A caller cancelling (or its deadline expiring) during the POST must
 		// surface as DeviceFlowCancelled, not a retryable transport failure. The
@@ -264,6 +314,12 @@ func RequestDeviceAuthorization(ctx context.Context, deviceAuthEndpoint, clientI
 		// per-request timeout is the child reqCtx, whose expiry stays transport.
 		if ctxErr := ctx.Err(); ctxErr != nil {
 			return nil, &DeviceFlowError{Reason: DeviceFlowCancelled, Err: ctxErr}
+		}
+		// A policy refusal is a permanent verdict on the endpoint, not a
+		// transport fault: classify it before the retryable transport case, or
+		// the consumer is told to retry a target it must stop talking to.
+		if errors.Is(err, surfguard.ErrBlocked) {
+			return nil, blockedEndpointError("device authorization endpoint", deviceAuthEndpoint, err)
 		}
 		return nil, &DeviceFlowError{Reason: DeviceFlowTransport, Err: fmt.Errorf("device authorization request failed: %w", err)}
 	}
@@ -487,6 +543,8 @@ func pollDeviceTokenUntil(ctx context.Context, cfg deviceConfig, tokenEndpoint, 
 		case pollInvalidResponse:
 			// Malformed 2xx token response — api_error, not a retryable transport.
 			return nil, basecamp.ErrAPI(result.status, result.err.Error())
+		case pollBlocked:
+			return nil, blockedEndpointError("token endpoint", tokenEndpoint, result.err)
 		case pollOAuthError:
 			// Any completed round-trip resets the timeout backoff to the
 			// server-driven interval.
@@ -542,6 +600,9 @@ const (
 	// 3xx (redirects are suppressed, never a valid token response), or any
 	// response whose body exceeds the size cap.
 	pollInvalidResponse
+	// pollBlocked is the address policy refusing the token endpoint before any
+	// connection opened (api_error, NOT retryable, and never backed off).
+	pollBlocked
 )
 
 type pollResult struct {
@@ -615,13 +676,20 @@ func postDeviceToken(ctx context.Context, cfg deviceConfig, tokenEndpoint string
 	req.Header.Set("Accept", "application/json")
 
 	// As above: TokenEndpoint may come from discovered metadata rather than from
-	// the caller, and its address is not policed (#806). This request carries
-	// the device_code.
-	resp, err := cfg.httpClient.Do(req) // #nosec G704 -- see the note above: not address-policed (#806)
+	// the caller, so by default its address is judged at dial time
+	// (DefaultIssuerPolicy, #806). This request carries the device_code.
+	resp, err := cfg.httpClient.Do(req) // #nosec G704 -- see the note above: address-policed by default
 	if err != nil {
 		// Parent cancellation ends the flow; a per-request timeout backs off.
 		if ctx.Err() != nil {
 			return pollResult{kind: pollCancelled, err: ctx.Err()}
+		}
+		// A policy refusal terminates the flow. It is classified ahead of the
+		// timeout and transport cases so the loop can neither back off and
+		// re-dial a target it must stop talking to, nor report it as a
+		// retryable transport failure.
+		if errors.Is(err, surfguard.ErrBlocked) {
+			return pollResult{kind: pollBlocked, err: err}
 		}
 		if errors.Is(err, context.DeadlineExceeded) || isTimeout(err) {
 			return pollResult{kind: pollTimeout, err: err}

--- a/go/pkg/basecamp/oauth/discovery.go
+++ b/go/pkg/basecamp/oauth/discovery.go
@@ -60,8 +60,22 @@ type Discoverer struct {
 	issuerClient *http.Client
 }
 
-// DefaultIssuerPolicy is the surfguard policy DiscoverFromResource applies to
-// the advertised-issuer hop.
+// DefaultIssuerPolicy is the surfguard policy applied, by default, to every
+// request whose destination an authorization server's metadata may have chosen:
+// DiscoverFromResource's advertised-issuer hop, and the device-authorization and
+// token endpoint POSTs made by the device flow and the [Exchanger].
+//
+// The endpoints are policed for the same reason as the issuer. A public issuer
+// that passes the policy returns issuer-bound metadata whose token_endpoint
+// and device_authorization_endpoint it chose freely — nothing in RFC 8414
+// constrains them to the issuer's origin — and those are where the
+// client_id, device_code, authorization code, client secret, and refresh
+// token are posted. Policing the metadata GET alone would leave that indirect
+// route open at the cost of one public host (#806). A same-origin rule is not
+// the control either: RFC 8705 publishes endpoints off the issuer origin by
+// design, and an origin comparison judges a hostname string, which can resolve
+// publicly during discovery and privately at the later POST. Dial-time
+// enforcement judges the literal address at the moment each socket opens.
 //
 // IANASpecialUse is the documented policy for advertised or discovered
 // infrastructure values — data a remote peer chose — and blocks the IANA
@@ -74,6 +88,39 @@ func DefaultIssuerPolicy() surfguard.Policy {
 	return surfguard.Policy{}.IANASpecialUse().AllowAllPorts()
 }
 
+// newPolicyClient builds a client whose transport enforces p on every connect.
+//
+// RoundTripper, not Client: the discovery fetch and the device flow each own
+// their timeout (a context deadline) and their redirect suppression, and
+// surfguard's Client would layer a second, coarser 30s bound and a redirect
+// follower those paths never want. Each call owns a transport, and therefore a
+// connection pool; callers that build one per request leak a pool per request,
+// which is why the default is shared (sharedPolicyClient) and the option
+// constructors build theirs once.
+func newPolicyClient(p surfguard.Policy) *http.Client {
+	return &http.Client{Transport: p.RoundTripper()}
+}
+
+// blockedEndpointError is the verdict on a device or token endpoint the
+// address policy refused. It is coded api_error and NOT retryable: surfguard's
+// contract is that blocked means stop talking to the target, and
+// ErrUnresolvable — the retry-later case — deliberately does not match
+// ErrBlocked. The original error stays in the chain, so errors.Is still reaches
+// surfguard.ErrBlocked and errors.As the *surfguard.Violation.
+//
+// api_error rather than usage, because the control exists for the endpoint a
+// remote peer chose: the SDK cannot tell a discovered endpoint from a
+// hand-configured one at this point, and the discovered case is the one the
+// refusal is for. It mirrors the advertised-issuer refusal, which is the hard
+// invalid_issuer_origin, also coded api_error.
+func blockedEndpointError(label, endpoint string, err error) *basecamp.Error {
+	return &basecamp.Error{
+		Code:    basecamp.CodeAPI,
+		Message: fmt.Sprintf("%s %q resolves to an address refused by the address policy (see oauth.DefaultIssuerPolicy)", label, endpoint),
+		Cause:   err,
+	}
+}
+
 // DiscovererOption configures a Discoverer at construction.
 type DiscovererOption func(*discovererConfig)
 
@@ -84,20 +131,22 @@ type discovererConfig struct {
 	issuerClient *http.Client
 }
 
-// sharedIssuerClient is the DefaultIssuerPolicy client, built once and shared by
-// every Discoverer that did not ask for something else.
+// sharedPolicyClient is the DefaultIssuerPolicy client, built once and shared by
+// every Discoverer, device-flow call, and Exchanger that did not ask for
+// something else.
 //
 // It owns an *http.Transport, and therefore a connection pool that nothing can
-// close: a Discoverer exposes no Close, so a per-Discoverer transport would leak
-// a pool per construction. Sharing is safe precisely because nothing mutates it
-// — fetchDiscoveryDocument calls noRedirectClient, which copies the client
-// before setting CheckRedirect, so the shared instance is only ever read.
+// close: a Discoverer exposes no Close, and a device-flow call has no handle at
+// all, so a per-construction transport would leak a pool per construction.
+// Sharing is safe precisely because nothing mutates it — fetchDiscoveryDocument
+// calls noRedirectClient and newDeviceConfig calls suppressRedirects, both of
+// which copy the client before setting CheckRedirect, so the shared instance is
+// only ever read.
 //
 // Only the DEFAULT is shared. A caller-supplied policy gets its own transport,
-// or one caller's Allow would silently widen every other Discoverer in the
-// process.
-var sharedIssuerClient = sync.OnceValue(func() *http.Client {
-	return &http.Client{Transport: DefaultIssuerPolicy().RoundTripper()}
+// or one caller's Allow would silently widen every other caller in the process.
+var sharedPolicyClient = sync.OnceValue(func() *http.Client {
+	return newPolicyClient(DefaultIssuerPolicy())
 })
 
 // WithIssuerPolicy replaces [DefaultIssuerPolicy] for the advertised-issuer
@@ -193,13 +242,10 @@ func NewDiscoverer(httpClient *http.Client, opts ...DiscovererOption) *Discovere
 		// A caller's own policy gets a transport of its own. Reusing the shared
 		// one would apply the default policy instead; sharing a NEW one keyed
 		// off nothing would leak this caller's Allow into every other
-		// Discoverer. RoundTripper, not Client: the discovery fetch owns its
-		// own timeout (a context deadline) and its own redirect suppression,
-		// and surfguard's Client would layer a second, coarser 30s bound and a
-		// redirect follower this code path never wants.
-		issuerClient = &http.Client{Transport: cfg.policy.RoundTripper()}
+		// Discoverer.
+		issuerClient = newPolicyClient(cfg.policy)
 	default:
-		issuerClient = sharedIssuerClient()
+		issuerClient = sharedPolicyClient()
 	}
 	return &Discoverer{httpClient: httpClient, issuerClient: issuerClient}
 }

--- a/go/pkg/basecamp/oauth/endpoint_policy_test.go
+++ b/go/pkg/basecamp/oauth/endpoint_policy_test.go
@@ -1,0 +1,350 @@
+package oauth
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	surfguard "github.com/basecamp/surfguard/go"
+
+	"github.com/basecamp/basecamp-sdk/go/pkg/basecamp"
+)
+
+// These tests cover the address policy on the device-authorization and token
+// endpoint POSTs — the requests that carry the client_id, device_code,
+// authorization code, client secret, and refresh token to endpoints an
+// authorization server's metadata may have chosen (#806).
+//
+// As in issuer_policy_test.go, the hit counters are the load-bearing part: an
+// error alone proves the flow failed, not that the endpoint was never
+// contacted, and "the internal host received the credentials, then something
+// downstream complained" is precisely the outcome being prevented. Every
+// endpoint serves a USABLE response, so a policy that failed to block would
+// produce a successful login or exchange rather than a differently-worded
+// failure.
+
+// endpointHits counts requests to a mock authorization server's two endpoints.
+type endpointHits struct {
+	device atomic.Int64
+	token  atomic.Int64
+}
+
+// bc5Endpoints starts a loopback authorization server — which the default
+// policy refuses — serving a usable device-authorization response at /device
+// and a usable token at /token, and returns its origin plus its counters.
+func bc5Endpoints(t *testing.T) (string, *endpointHits) {
+	t.Helper()
+	hits := &endpointHits{}
+	mux := http.NewServeMux()
+	mux.HandleFunc("/device", func(w http.ResponseWriter, _ *http.Request) {
+		hits.device.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(deviceAuthBody)
+	})
+	mux.HandleFunc("/token", func(w http.ResponseWriter, _ *http.Request) {
+		hits.token.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"access_token":"tok","token_type":"Bearer","expires_in":3600}`))
+	})
+	srv := httptest.NewServer(mux)
+	t.Cleanup(srv.Close)
+	return srv.URL, hits
+}
+
+// loopbackConfig is the already-selected *Config DiscoverFromResource would
+// return for an issuer whose metadata named the mock server's endpoints.
+func loopbackConfig(origin string) *Config {
+	device := origin + "/device"
+	return &Config{
+		Issuer:                      origin,
+		TokenEndpoint:               origin + "/token",
+		DeviceAuthorizationEndpoint: &device,
+		GrantTypesSupported:         []string{DeviceCodeGrantType},
+	}
+}
+
+func noDisplay(DeviceAuthorization) {}
+
+func noSleep(context.Context, time.Duration) error { return nil }
+
+// assertBlockedEndpoint checks the refusal's shape: it matches surfguard's
+// ErrBlocked, is coded api_error and not retryable, and is NOT a device-flow
+// transport error (which would be retryable) — and the endpoint was never
+// contacted.
+func assertBlockedEndpoint(t *testing.T, err error, hits *atomic.Int64) {
+	t.Helper()
+	if err == nil {
+		t.Fatal("expected the endpoint to be refused, got nil error")
+	}
+	if !errors.Is(err, surfguard.ErrBlocked) {
+		t.Errorf("errors.Is(err, surfguard.ErrBlocked) = false; err = %v", err)
+	}
+	var be *basecamp.Error
+	if !errors.As(err, &be) {
+		t.Fatalf("expected a *basecamp.Error in the chain, got %T: %v", err, err)
+	}
+	if be.Code != basecamp.CodeAPI {
+		t.Errorf("Code = %q, want %q", be.Code, basecamp.CodeAPI)
+	}
+	if be.Retryable {
+		t.Errorf("Retryable = true; a policy refusal must not read as transient (err = %v)", err)
+	}
+	var dfe *DeviceFlowError
+	if errors.As(err, &dfe) {
+		t.Errorf("refusal was classified as device-flow %q; it must be the terminal policy verdict", dfe.Reason)
+	}
+	if hits != nil && hits.Load() != 0 {
+		t.Errorf("the blocked endpoint was contacted %d time(s); the policy must refuse before any connect", hits.Load())
+	}
+}
+
+// TestPerformDeviceLogin_BlockedEndpointIsNeverContacted is the core case: a
+// selected config names endpoints in blocked space, and the flow must refuse
+// them without opening a connection — before the client_id goes anywhere.
+func TestPerformDeviceLogin_BlockedEndpointIsNeverContacted(t *testing.T) {
+	origin, hits := bc5Endpoints(t)
+
+	_, err := PerformDeviceLogin(context.Background(), loopbackConfig(origin), "basecamp-cli", noDisplay,
+		WithDeviceSleep(noSleep))
+	assertBlockedEndpoint(t, err, &hits.device)
+	if hits.token.Load() != 0 {
+		t.Errorf("token endpoint contacted %d time(s) after the device endpoint was refused", hits.token.Load())
+	}
+}
+
+// TestPollDeviceToken_BlockedTokenEndpointTerminates guards the poll loop's
+// classification. A dial refusal is neither a timeout (→ backoff and re-dial
+// until the code expires) nor a transport failure (→ retryable): it must end
+// the flow on the first attempt. The injected clock advances by each sleep, so
+// a loop that wrongly kept polling would run out to expiry and fail with a
+// recognizably wrong reason instead of hanging.
+func TestPollDeviceToken_BlockedTokenEndpointTerminates(t *testing.T) {
+	origin, hits := bc5Endpoints(t)
+
+	now := time.Now()
+	var sleeps int
+	clock := func() time.Time { return now }
+	sleep := func(_ context.Context, d time.Duration) error {
+		sleeps++
+		now = now.Add(d)
+		return nil
+	}
+
+	_, err := PollDeviceToken(context.Background(), origin+"/token", "basecamp-cli", testDeviceCode, 5, 900,
+		WithDeviceClock(clock), WithDeviceSleep(sleep))
+	assertBlockedEndpoint(t, err, &hits.token)
+	// One wait precedes the first POST; a second would mean the loop backed off
+	// and tried again.
+	if sleeps != 1 {
+		t.Errorf("the loop slept %d time(s); a policy refusal must terminate after the first attempt", sleeps)
+	}
+}
+
+// TestExchanger_BlockedTokenEndpointIsNeverContacted covers the highest-value
+// request: the one carrying the authorization code and client secret, or the
+// refresh token.
+func TestExchanger_BlockedTokenEndpointIsNeverContacted(t *testing.T) {
+	origin, hits := bc5Endpoints(t)
+	e := NewExchanger(nil)
+
+	t.Run("exchange", func(t *testing.T) {
+		_, err := e.Exchange(context.Background(), ExchangeRequest{
+			TokenEndpoint: origin + "/token",
+			Code:          "code",
+			RedirectURI:   "http://localhost/callback",
+			ClientID:      "client",
+			ClientSecret:  "secret",
+		})
+		assertBlockedEndpoint(t, err, &hits.token)
+	})
+
+	t.Run("refresh", func(t *testing.T) {
+		_, err := e.Refresh(context.Background(), RefreshRequest{
+			TokenEndpoint: origin + "/token",
+			RefreshToken:  "refresh",
+		})
+		assertBlockedEndpoint(t, err, &hits.token)
+	})
+}
+
+// TestEndpointPolicy_RefusesLegacyNumericSpelling covers the spelling the
+// scheme gate cannot see through: "2130706433" is 127.0.0.1 as a bare integer,
+// and https on it satisfies RequireSecureEndpoint. No server is needed — the
+// point is that nothing is dialed.
+func TestEndpointPolicy_RefusesLegacyNumericSpelling(t *testing.T) {
+	const endpoint = "https://2130706433/oauth/token"
+
+	t.Run("device", func(t *testing.T) {
+		_, err := RequestDeviceAuthorization(context.Background(), endpoint, "basecamp-cli")
+		assertBlockedEndpoint(t, err, nil)
+	})
+
+	t.Run("exchange", func(t *testing.T) {
+		_, err := NewExchanger(nil).Refresh(context.Background(), RefreshRequest{
+			TokenEndpoint: endpoint,
+			RefreshToken:  "refresh",
+		})
+		assertBlockedEndpoint(t, err, nil)
+	})
+}
+
+// TestWithDevicePolicy_AdmitsLoopback exercises the device-flow escape hatch in
+// the spelling the docs prescribe, and proves the whole grant runs through it:
+// both endpoints are reached exactly once and a token comes back.
+func TestWithDevicePolicy_AdmitsLoopback(t *testing.T) {
+	origin, hits := bc5Endpoints(t)
+
+	token, err := PerformDeviceLogin(context.Background(), loopbackConfig(origin), "basecamp-cli", noDisplay,
+		WithDevicePolicy(DefaultIssuerPolicy().AllowLoopback()), WithDeviceSleep(noSleep))
+	if err != nil {
+		t.Fatalf("PerformDeviceLogin() error = %v, want nil", err)
+	}
+	if token == nil || token.AccessToken != "tok" {
+		t.Fatalf("token = %+v, want the mock's", token)
+	}
+	if hits.device.Load() != 1 || hits.token.Load() != 1 {
+		t.Errorf("hits = device:%d token:%d, want 1 and 1", hits.device.Load(), hits.token.Load())
+	}
+}
+
+// TestWithExchangerPolicy_AdmitsLoopback is the Exchanger's escape hatch.
+func TestWithExchangerPolicy_AdmitsLoopback(t *testing.T) {
+	origin, hits := bc5Endpoints(t)
+
+	token, err := NewExchanger(nil, WithExchangerPolicy(DefaultIssuerPolicy().AllowLoopback())).
+		Refresh(context.Background(), RefreshRequest{TokenEndpoint: origin + "/token", RefreshToken: "refresh"})
+	if err != nil {
+		t.Fatalf("Refresh() error = %v, want nil", err)
+	}
+	if token.AccessToken != "tok" || hits.token.Load() != 1 {
+		t.Errorf("token = %+v, hits = %d; want the mock's token reached once", token, hits.token.Load())
+	}
+}
+
+// TestEndpointPolicy_CallerClientTakesPrecedence pins the documented precedence
+// on both surfaces: a client the caller hands us is theirs, enforcement
+// included, and a policy passed alongside it is not additive.
+func TestEndpointPolicy_CallerClientTakesPrecedence(t *testing.T) {
+	origin, hits := bc5Endpoints(t)
+
+	t.Run("device", func(t *testing.T) {
+		// The policy here would block loopback; the plain client does not.
+		_, err := PerformDeviceLogin(context.Background(), loopbackConfig(origin), "basecamp-cli", noDisplay,
+			WithDevicePolicy(DefaultIssuerPolicy()), WithDeviceHTTPClient(&http.Client{}), WithDeviceSleep(noSleep))
+		if err != nil {
+			t.Fatalf("PerformDeviceLogin() error = %v, want nil (the client supersedes the policy)", err)
+		}
+		if hits.device.Load() != 1 {
+			t.Errorf("device hits = %d, want 1 through the supplied client", hits.device.Load())
+		}
+	})
+
+	t.Run("exchanger", func(t *testing.T) {
+		before := hits.token.Load()
+		_, err := NewExchanger(&http.Client{}, WithExchangerPolicy(DefaultIssuerPolicy())).
+			Refresh(context.Background(), RefreshRequest{TokenEndpoint: origin + "/token", RefreshToken: "refresh"})
+		if err != nil {
+			t.Fatalf("Refresh() error = %v, want nil (the client supersedes the policy)", err)
+		}
+		if hits.token.Load() != before+1 {
+			t.Errorf("token hits = %d, want %d through the supplied client", hits.token.Load(), before+1)
+		}
+	})
+
+	// And http.DefaultClient is the documented spelling of "no policy".
+	t.Run("default_client_disables", func(t *testing.T) {
+		before := hits.token.Load()
+		_, err := NewExchanger(http.DefaultClient).
+			Refresh(context.Background(), RefreshRequest{TokenEndpoint: origin + "/token", RefreshToken: "refresh"})
+		if err != nil {
+			t.Fatalf("Refresh() on http.DefaultClient error = %v, want nil", err)
+		}
+		if hits.token.Load() != before+1 {
+			t.Errorf("token hits = %d, want %d", hits.token.Load(), before+1)
+		}
+	})
+}
+
+// TestDefaultPolicyClientIsSharedAcrossSurfaces pins the resource invariant
+// from #804 now that three surfaces default to the policy client: neither a
+// device-flow call nor an Exchanger has a Close, so each must reuse the one
+// shared transport rather than own a pool nothing can reclaim — and a
+// caller's own policy must NOT land on that shared transport.
+func TestDefaultPolicyClientIsSharedAcrossSurfaces(t *testing.T) {
+	shared := sharedPolicyClient()
+
+	// suppressRedirects copies the client, so compare the transport, which is
+	// what owns the pool.
+	if got := newDeviceConfig(nil).httpClient.Transport; got != shared.Transport {
+		t.Error("a default device-flow config does not ride the shared policy transport")
+	}
+	if NewExchanger(nil).httpClient != shared {
+		t.Error("a default Exchanger does not hold the shared policy client")
+	}
+	if NewDiscoverer(nil).issuerClient != shared {
+		t.Error("a default Discoverer does not hold the shared policy client")
+	}
+
+	// A caller's policy gets its own transport, and exactly one per option
+	// value: PerformDeviceLogin hands the same opts to RequestDeviceAuthorization
+	// and to the poll, so a transport per newDeviceConfig would be two pools
+	// per login.
+	opt := WithDevicePolicy(DefaultIssuerPolicy().AllowLoopback())
+	first := newDeviceConfig([]DeviceOption{opt}).httpClient.Transport
+	second := newDeviceConfig([]DeviceOption{opt}).httpClient.Transport
+	if first == shared.Transport {
+		t.Error("WithDevicePolicy reused the shared transport; a caller policy must get its own")
+	}
+	if first != second {
+		t.Error("WithDevicePolicy built a transport per call; it must build one per option")
+	}
+	if NewExchanger(nil, WithExchangerPolicy(DefaultIssuerPolicy().AllowLoopback())).httpClient == shared {
+		t.Error("WithExchangerPolicy reused the shared client; a caller policy must get its own")
+	}
+}
+
+// TestSharedPolicyClientIsNeverMutatedByEndpointFlows is the safety property
+// that makes sharing legal on the new surfaces: the device flow needs redirects
+// suppressed, and it gets there by copying — if suppressRedirects ever set
+// CheckRedirect in place, every Discoverer and Exchanger in the process would
+// be reconfigured by whichever device login ran first.
+func TestSharedPolicyClientIsNeverMutatedByEndpointFlows(t *testing.T) {
+	shared := sharedPolicyClient()
+	if shared.CheckRedirect != nil || shared.Timeout != 0 {
+		t.Fatalf("shared policy client did not start clean: CheckRedirect=%v Timeout=%v", shared.CheckRedirect != nil, shared.Timeout)
+	}
+
+	origin, _ := bc5Endpoints(t)
+	_, _ = PerformDeviceLogin(context.Background(), loopbackConfig(origin), "basecamp-cli", noDisplay,
+		WithDeviceSleep(noSleep))
+	_, _ = NewExchanger(nil).Refresh(context.Background(),
+		RefreshRequest{TokenEndpoint: origin + "/token", RefreshToken: "refresh"})
+
+	if shared.CheckRedirect != nil || shared.Timeout != 0 {
+		t.Error("the shared policy client was mutated in place; the endpoint flows must copy before configuring")
+	}
+}
+
+// TestEndpointPolicyIsolation is the behavioral form of the sharing concern: a
+// permissive device login must not widen a default one that runs after it.
+func TestEndpointPolicyIsolation(t *testing.T) {
+	origin, hits := bc5Endpoints(t)
+
+	if _, err := PerformDeviceLogin(context.Background(), loopbackConfig(origin), "basecamp-cli", noDisplay,
+		WithDevicePolicy(DefaultIssuerPolicy().AllowLoopback()), WithDeviceSleep(noSleep)); err != nil {
+		t.Fatalf("the permissive login should reach loopback: %v", err)
+	}
+	deviceHits, tokenHits := hits.device.Load(), hits.token.Load()
+
+	_, err := PerformDeviceLogin(context.Background(), loopbackConfig(origin), "basecamp-cli", noDisplay,
+		WithDeviceSleep(noSleep))
+	assertBlockedEndpoint(t, err, nil)
+	if hits.device.Load() != deviceHits || hits.token.Load() != tokenHits {
+		t.Errorf("a default login contacted the endpoints after a permissive one; the permissive policy leaked")
+	}
+}

--- a/go/pkg/basecamp/oauth/exchange.go
+++ b/go/pkg/basecamp/oauth/exchange.go
@@ -3,6 +3,7 @@ package oauth
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -10,19 +11,69 @@ import (
 	"strings"
 	"time"
 
+	surfguard "github.com/basecamp/surfguard/go"
+
 	"github.com/basecamp/basecamp-sdk/go/pkg/basecamp"
 )
 
 // Exchanger handles OAuth 2.0 token exchange and refresh operations.
+//
+// Both post credentials — the authorization code and client secret, or the
+// refresh token — to a token endpoint the caller names in the request, which
+// may be one that DiscoverFromResource's metadata chose. By default the
+// Exchanger therefore carries those POSTs on a client that judges the
+// endpoint's literal address at dial time against [DefaultIssuerPolicy]; see
+// [NewExchanger] for the overrides.
 type Exchanger struct {
 	httpClient *http.Client
 }
 
-// NewExchanger creates an Exchanger with the given HTTP client.
-// If httpClient is nil, http.DefaultClient is used.
-func NewExchanger(httpClient *http.Client) *Exchanger {
-	if httpClient == nil {
-		httpClient = http.DefaultClient
+// ExchangerOption configures an Exchanger at construction.
+type ExchangerOption func(*exchangerConfig)
+
+type exchangerConfig struct {
+	policy    surfguard.Policy
+	policySet bool
+}
+
+// WithExchangerPolicy replaces [DefaultIssuerPolicy] for the token endpoint
+// POSTs, so a deployment whose authorization server is not on the public
+// internet re-admits exactly the space it needs rather than switching the
+// policy off. The derivations and the precedence trap are the ones documented
+// on [WithIssuerPolicy]: AllowLoopback for a local server,
+// surfguard.Policy{}.AllowAllPorts().Allow(...) for private space.
+//
+// It has no effect when NewExchanger is given a non-nil client, which supplies
+// the transport the policy would otherwise be installed in.
+func WithExchangerPolicy(p surfguard.Policy) ExchangerOption {
+	return func(c *exchangerConfig) { c.policy, c.policySet = p, true }
+}
+
+// NewExchanger creates an Exchanger.
+//
+// A nil httpClient selects the policy-enforced default: the shared
+// [DefaultIssuerPolicy] client, or a client built from [WithExchangerPolicy]
+// when that option is given. A non-nil httpClient is the caller's, enforcement
+// included — no address policy is applied on top of it, and
+// WithExchangerPolicy is ignored. A consumer that must egress through a proxy
+// has no other way to keep both, since surfguard's transport sets Proxy: nil
+// by construction; compose the client's transport from
+// DefaultIssuerPolicy().RoundTripper() where that is possible. Passing
+// http.DefaultClient restores the pre-policy behavior outright.
+//
+// An Exchanger given WithExchangerPolicy owns a transport, and has no Close, so
+// build it once and reuse it rather than constructing one per exchange.
+func NewExchanger(httpClient *http.Client, opts ...ExchangerOption) *Exchanger {
+	cfg := exchangerConfig{}
+	for _, o := range opts {
+		o(&cfg)
+	}
+	switch {
+	case httpClient != nil:
+	case cfg.policySet:
+		httpClient = newPolicyClient(cfg.policy)
+	default:
+		httpClient = sharedPolicyClient()
 	}
 	return &Exchanger{httpClient: httpClient}
 }
@@ -117,11 +168,17 @@ func (e *Exchanger) doTokenRequest(ctx context.Context, tokenEndpoint string, da
 	// The suppression is about gosec's taint rule, not a claim that this URL is
 	// trusted. TokenEndpoint may be caller-configured, but it may equally come
 	// from DiscoverFromResource's metadata, in which case a remote peer chose it
-	// and NOTHING here judges the address it resolves to — see issue #806. This
-	// request carries the authorization code, the client secret, or a refresh
-	// token, so it is the highest-value of the three such call sites.
-	resp, err := e.httpClient.Do(httpReq) // #nosec G704 -- see the note above: not address-policed (#806)
+	// — so by default the client judges the address it resolves to at dial
+	// time (DefaultIssuerPolicy, #806). This request carries the authorization
+	// code, the client secret, or a refresh token, so it is the highest-value
+	// of the three such call sites.
+	resp, err := e.httpClient.Do(httpReq) // #nosec G704 -- see the note above: address-policed by default
 	if err != nil {
+		// A policy refusal is a typed, permanent verdict on the endpoint; every
+		// other failure keeps the untyped wrap callers already match on.
+		if errors.Is(err, surfguard.ErrBlocked) {
+			return nil, blockedEndpointError("token endpoint", tokenEndpoint, err)
+		}
 		return nil, fmt.Errorf("token request failed: %w", err)
 	}
 	defer func() { _ = resp.Body.Close() }()


### PR DESCRIPTION
Closes #806.

## The exposure

#804 judges the advertised issuer's address before the metadata GET. That closes the direct route and leaves the indirect one open: an attacker-controlled issuer on **public** space passes the policy, is selected, and returns correctly issuer-bound metadata whose `token_endpoint` and `device_authorization_endpoint` point wherever it likes. `parseAndBindASMetadata` checks only that `token_endpoint` is non-empty and copies it verbatim; `RequireSecureEndpoint` admits any `https` host, private space included. The credential POSTs then went out on `http.DefaultClient` — `client_id` and `device_code` from the device flow, the authorization code, client secret, and refresh token from the `Exchanger`. One public host buys private space, and what arrives is credentials rather than a blind GET.

## The decision

**Dial-time address enforcement on every device and token endpoint request**, on the same shared `DefaultIssuerPolicy()` client as the issuer hop. Not same-origin, and the reasons are written into SPEC §16 so they are not re-litigated: RFC 8414 §2 does not require endpoints on the issuer origin, RFC 8705 §5 publishes off-origin endpoints by design, and an origin comparison judges a hostname string that is resolved twice — publicly at discovery, privately at the POST, under a rebind. Scheme alone is satisfied by any private host.

The device and exchange functions cannot tell a discovered endpoint from a hand-configured one (`PerformDeviceLogin` takes a `*Config`; `Exchange`/`Refresh` take a string), so the policy applies to every request on the default client. That is the same uniformity call as #804 made for `WithExpectedIssuer`, for the same reason; a provenance flag on `Config` is a marker that a consumer round-tripping the config through storage silently drops.

## The change

```go
func WithDevicePolicy(p surfguard.Policy) DeviceOption          // new
func NewExchanger(httpClient *http.Client, opts ...ExchangerOption) *Exchanger  // variadic added
func WithExchangerPolicy(p surfguard.Policy) ExchangerOption    // new
```

Precedence is one rule across all three surfaces of the package: a client you hand in is yours, enforcement included; otherwise your policy; otherwise the shared default. `http.DefaultClient` is the spelling of "no policy", so no `Without*` options were added for these two surfaces — there is nothing they would express that passing a plain client does not.

A refusal is a non-retryable `*basecamp.Error` (`api_error`) that also matches `errors.Is(err, surfguard.ErrBlocked)`. In the poll loop it is classified **ahead of** the timeout and transport cases, so the loop neither backs off and re-dials a target it must stop talking to nor reports it retryable.

The shared-client invariant from #804 extends to the new surfaces: `WithDevicePolicy` builds its transport once at option construction (`PerformDeviceLogin` hands the same opts to the auth request and the poll, so a transport per `newDeviceConfig` would be two pools per login), `WithExchangerPolicy` builds one per `Exchanger`, and `suppressRedirects` keeps copying so the shared default is never mutated.

## Demonstrated, not asserted

Seven mutations, each run against the new test file, each caught:

| Mutation | Tests that fail |
|---|---|
| device default back to `http.DefaultClient` | `PerformDeviceLogin_BlockedEndpointIsNeverContacted`, `PollDeviceToken_BlockedTokenEndpointTerminates`, `RefusesLegacyNumericSpelling`, `DefaultPolicyClientIsSharedAcrossSurfaces`, `EndpointPolicyIsolation` |
| exchanger default back to `http.DefaultClient` | `Exchanger_BlockedTokenEndpointIsNeverContacted`, `RefusesLegacyNumericSpelling`, `DefaultPolicyClientIsSharedAcrossSurfaces` |
| poll loop stops classifying `ErrBlocked` (falls to timeout/transport) | `PollDeviceToken_BlockedTokenEndpointTerminates` |
| device-auth stops classifying `ErrBlocked` (falls to transport) | `PerformDeviceLogin_Blocked…`, `RefusesLegacyNumericSpelling`, `EndpointPolicyIsolation` |
| exchange `ErrBlocked` branch made dead | `Exchanger_Blocked…`, `RefusesLegacyNumericSpelling` |
| `WithDevicePolicy` builds a transport per call | `DefaultPolicyClientIsSharedAcrossSurfaces` |
| refusal marked `Retryable: true` | all five blocked-endpoint tests |

Every blocked case asserts the endpoint's handler ran **zero times**, and every mock serves a usable response, so a policy that failed to block yields a successful login or exchange rather than a differently-worded failure. The poll test's injected clock advances by each sleep, so a loop that wrongly kept polling runs out to expiry with a recognizably wrong reason instead of hanging.

`go test ./...`, `go vet`, `gofmt -s`, `golangci-lint` clean; the conformance runner still builds; `make doc-constants-check` and `make go-check-drift` pass. The 74 existing device tests and 10 exchange tests pass **unedited** — every one that reaches the wire already injected `srv.Client()`, and the five that do not all fail before the request.

## What this does and does not close

**`basecamp-cli` is not protected by this change.** It passes its general-purpose `m.httpClient` to `NewExchanger`, `WithDeviceHTTPClient`, and `NewDiscoverer` alike, and a caller-supplied client is the caller's — the enforcement seam is the transport's dialer, so there is nothing to layer on top of an arbitrary `RoundTripper`. That is the #804 `WithIssuerHTTPClient` contract applied consistently; the alternative (clone an `*http.Transport` and overwrite its `DialContext`/`Proxy`) is "the policy applies sometimes" in another form. The consumer-side fix is one line, `&http.Client{Transport: oauth.DefaultIssuerPolicy().RoundTripper()}` for these three call sites, and it is recorded in MIGRATING and Appendix F rather than hidden. The SDK default is now safe; the CLI needs its own PR.

**Still open, recorded in Appendix F:**
- The other four SDKs. Only Go and Ruby have surfguard, and the Ruby gem is classification-only by design (the caller pins the resolved address), so Ruby's enforcement would be a `Net::HTTP#ipaddr=` pin under the default `Fetcher` transport — not reachable from the injected-Faraday lane. TS, Python, and Kotlin have no classification tables at all; the seams (undici connector `lookup`, a resolving httpcore backend, OkHttp `Dns`) are named so the follow-ups are specified rather than rediscovered. Same cross-SDK shape as #805.
- Exchange redirect-following is not uniform: Go's `Exchanger`, Kotlin's default client, and TS's exchange (no `redirect:` option) follow redirects, where the device flow suppresses them in all four. Under the policy client each redirect hop's dial is judged, so the address policy holds; a 307 re-POST of the secret to a *public* `Location` does not need the policy to be exploitable. Same shape as #805, so noted rather than patched here.
- `AuthManager.refreshLocked` posts a refresh token to `Credentials.TokenEndpoint` on the main API client. That endpoint is consumer-stored; if the consumer stored a discovered one, the same reasoning applies at the consumer's boundary.

## API break

`NewExchanger` gains a variadic parameter. Source-compatible for every direct call; a function value of the old type stops compiling, and `apidiff` reports it incompatible — hence `breaking`, as #804 was for `NewDiscoverer`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Polices the addresses of device-authorization and token endpoints, not just the issuer metadata GET, closing the indirect SSRF path where a public issuer could steer credentials into private space.

- Device flow (`PerformDeviceLogin`, `RequestDeviceAuthorization`, `PollDeviceToken`) and `Exchanger` POST via a shared client that enforces `oauth.DefaultIssuerPolicy()` (same as discovery). Device-flow redirects remain suppressed.
- Precedence: caller-provided HTTP client is used as-is; else a provided policy; else the shared default. Passing `http.DefaultClient` restores prior behavior.
- New options: `WithDevicePolicy`, `WithDeviceHTTPClient`, `WithExchangerPolicy`. `NewExchanger` now accepts variadic options.
- Refusals surface as non-retryable `api_error` matching `surfguard.ErrBlocked`; the poll loop terminates on the first attempt.
- Scope: this default enforcement applies to the device-flow and `Exchanger` POSTs only. `AuthManager.refreshLocked` posts to a stored `TokenEndpoint` on the caller’s client and remains outside this default policy. Caller-supplied clients are never wrapped; compose the policy into their transport if desired.

**Migration**

- If you used defaults with loopback/private AS endpoints, add `WithDevicePolicy(oauth.DefaultIssuerPolicy().AllowLoopback())` or `WithExchangerPolicy(...)`, or supply your own client. Otherwise these requests are now refused.
- Callers already passing their own client are unchanged and not protected; to enable enforcement, build it with `&http.Client{Transport: oauth.DefaultIssuerPolicy().RoundTripper()}`.
- If you used `NewExchanger` as a function value, update to its new type with `...oauth.ExchangerOption`. Direct calls remain source-compatible.

<sup>Written for commit 9eb2ddd8f742efa06bb535fb6d8189776ebebc96. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-sdk/pull/810?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

