### PR TITLE
Resolve the release heading from the top of the guide, not anywhere in it

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -165,6 +165,15 @@ jobs:
         env:
           LC_ALL: C
 
+      # The MIGRATING.md heading promotion decides what a tag ships as its
+      # release notes; the self-test asserts the script refuses a backward
+      # bump, a rollback, and a headingless file, and accepts the idempotent
+      # and no-notes states. Its first shipped version accepted a historical
+      # heading as "already promoted", which is the regression the backward
+      # cases pin.
+      - name: MIGRATING heading promotion self-test
+        run: make test-promote-migrating
+
       - name: Bucket-scoped vs flat operation parity
         run: make check-bucket-flat-parity
 

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -3922,7 +3922,8 @@ oversight, and it should be stated rather than assumed.
 
 # Not in this release
 
-Every change the `# Unreleased` section describes was merged by `fa15fc126`,
+Every change the newest release section above describes was merged by
+`fa15fc126`,
 and the in-flight set below was surveyed at that commit; the historical
 sections' counts keep the baselines they themselves state (v0.13.0's totals
 were measured at `9a819e44d`, as that section says). In flight at

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -3922,8 +3922,7 @@ oversight, and it should be stated rather than assumed.
 
 # Not in this release
 
-Every change the newest release section above describes was merged by
-`fa15fc126`,
+Every change the v0.15.0 section describes was merged by `fa15fc126`,
 and the in-flight set below was surveyed at that commit; the historical
 sections' counts keep the baselines they themselves state (v0.13.0's totals
 were measured at `9a819e44d`, as that section says). In flight at

--- a/Makefile
+++ b/Makefile
@@ -303,6 +303,7 @@ endif
 	@echo "Pushed v$(VERSION) — all SDK release workflows will trigger."
 
 # Self-test for the MIGRATING.md heading promotion used by bump and release
+.PHONY: test-promote-migrating
 test-promote-migrating:
 	@./scripts/test-promote-migrating.sh
 

--- a/Makefile
+++ b/Makefile
@@ -269,10 +269,7 @@ endif
 		{ echo "ERROR: Python pyproject.toml [project].version does not match $(VERSION). Run 'make bump VERSION=$(VERSION)' first."; exit 1; }
 	@grep -qF 'VERSION = "$(VERSION)"' python/src/basecamp/_version.py || \
 		{ echo "ERROR: Python version does not match $(VERSION). Run 'make bump VERSION=$(VERSION)' first."; exit 1; }
-	@grep -qxF '# v$(VERSION)' MIGRATING.md || \
-		{ echo "ERROR: MIGRATING.md has no '# v$(VERSION)' heading. Run 'make bump VERSION=$(VERSION)' first."; exit 1; }
-	@! grep -qxF '# Unreleased' MIGRATING.md || \
-		{ echo "ERROR: MIGRATING.md still has an '# Unreleased' section — its notes would miss the release. Run 'make bump VERSION=$(VERSION)' first."; exit 1; }
+	@./scripts/promote-migrating.sh --check $(VERSION)
 	@# Verify lockfiles are frozen against their manifests
 	@test "$$(jq -r '.version' typescript/package-lock.json)" = "$(VERSION)" -a "$$(jq -r '.packages[""].version' typescript/package-lock.json)" = "$(VERSION)" || \
 		{ echo "ERROR: typescript/package-lock.json records a stale SDK version. Run 'make bump VERSION=$(VERSION)' first."; exit 1; }
@@ -304,6 +301,10 @@ endif
 	git tag "v$(VERSION)"
 	git push origin "v$(VERSION)"
 	@echo "Pushed v$(VERSION) — all SDK release workflows will trigger."
+
+# Self-test for the MIGRATING.md heading promotion used by bump and release
+test-promote-migrating:
+	@./scripts/test-promote-migrating.sh
 
 # Sync Smithy service version from spec/api-provenance.json
 sync-spec-version:
@@ -1598,7 +1599,7 @@ check:
 	 if [ $$rc -ne 0 ]; then exit $$rc; fi; \
 	 echo "==> All checks passed"
 
-check-targets: check-gradle-serialization test-check-gradle-serialization lint-actions sync-spec-version-check smithy-check smithy-mapper-test behavior-model-check provenance-check sync-api-version-check doc-constants-check url-routes-check bc3-route-parity test-bc3-route-parity go-check-drift go-check-wrapper-drift go-check-generated-drift check-grouped-client-coverage test-check-grouped-client-coverage auth-routable-check check-service-inventory-parity test-check-service-inventory-parity check-operation-assignment-parity test-check-operation-assignment-parity kt-check-drift swift-check-drift go-check ts-check rb-check kt-check swift-check py-check check-bucket-flat-parity validate-api-gaps check-deprecation-parity check-fixture-coverage kt-check-optional-arrays-and-scalars go-check-optional-pointers test-enhance-request-reachability check-idempotency-parity check-write-semantics-parity check-retry-metadata-parity check-runner-test-reachability conformance check-fixture-execution check-replay-decoder-parity check-readme-env-vars test-check-readme-env-vars lint-npm-lockfile-writes test-lint-npm-lockfile-writes test-assert-sdk-built test-assert-lockfiles-unchanged check-projected-examples
+check-targets: check-gradle-serialization test-check-gradle-serialization test-promote-migrating lint-actions sync-spec-version-check smithy-check smithy-mapper-test behavior-model-check provenance-check sync-api-version-check doc-constants-check url-routes-check bc3-route-parity test-bc3-route-parity go-check-drift go-check-wrapper-drift go-check-generated-drift check-grouped-client-coverage test-check-grouped-client-coverage auth-routable-check check-service-inventory-parity test-check-service-inventory-parity check-operation-assignment-parity test-check-operation-assignment-parity kt-check-drift swift-check-drift go-check ts-check rb-check kt-check swift-check py-check check-bucket-flat-parity validate-api-gaps check-deprecation-parity check-fixture-coverage kt-check-optional-arrays-and-scalars go-check-optional-pointers test-enhance-request-reachability check-idempotency-parity check-write-semantics-parity check-retry-metadata-parity check-runner-test-reachability conformance check-fixture-execution check-replay-decoder-parity check-readme-env-vars test-check-readme-env-vars lint-npm-lockfile-writes test-lint-npm-lockfile-writes test-assert-sdk-built test-assert-lockfiles-unchanged check-projected-examples
 	@:
 
 # Clean all build artifacts

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -27,6 +27,11 @@ sedi() {
 
 echo "Bumping version to: $VERSION"
 
+# 0. MIGRATING.md — promote "# Unreleased" to "# v$VERSION" (or verify the
+# no-notes/idempotent states). Runs FIRST so its refusals — a backward bump,
+# a rollback — abort before any version file has been rewritten.
+"$(dirname "$0")/promote-migrating.sh" "$VERSION"
+
 # 1. Root package.json
 sedi "s/\"version\": \".*\"/\"version\": \"$VERSION\"/" package.json
 
@@ -58,10 +63,6 @@ sedi "s/^version = \".*\"/version = \"$VERSION\"/" python/pyproject.toml
 
 # 10. Python _version.py
 sedi "s/^VERSION = \".*\"/VERSION = \"$VERSION\"/" python/src/basecamp/_version.py
-
-# 11. MIGRATING.md — promote "# Unreleased" to "# v$VERSION" (make release
-# guards the promoted heading, so skipping this cannot reach a tag)
-"$(dirname "$0")/promote-migrating.sh" "$VERSION"
 
 # Sync TypeScript lockfile
 echo "Syncing TypeScript lockfile..."

--- a/scripts/promote-migrating.sh
+++ b/scripts/promote-migrating.sh
@@ -16,7 +16,14 @@ if [ "${1:-}" = "--check" ]; then MODE=check; shift; fi
 VERSION="${1:?usage: $0 [--check] <version> [file]}"
 FILE="${2:-MIGRATING.md}"
 
-FIRST=$(grep -m1 -E '^# (Unreleased|v[0-9]+\.[0-9]+\.[0-9]+)$' "$FILE" || true)
+# Heading judgments read the guide's PROSE only: the guide legitimately
+# quotes old headings inside fenced code blocks (its own derivation recipes
+# do), and a fence containing "# Unreleased" is an example, not a section.
+guide_prose() {
+  awk '/^```/ { fenced = !fenced; next } !fenced' "$FILE"
+}
+
+FIRST=$(guide_prose | grep -m1 -E '^# (Unreleased|v[0-9]+\.[0-9]+\.[0-9]+)$' || true)
 
 # The guide's headings are not the authority on the released order: a
 # no-notes release advances the SDK version without adding a heading, so the
@@ -114,18 +121,18 @@ fi
 
 case "$FIRST" in
   "# Unreleased")
-    if [ "$(grep -cxF "# Unreleased" "$FILE")" -gt 1 ]; then
+    if [ "$(guide_prose | grep -cxF "# Unreleased")" -gt 1 ]; then
       echo "ERROR: $FILE has more than one '# Unreleased' heading — promotion would rename only the first and leave the rest to fail the release late." >&2
       exit 1
     fi
-    if grep -qxF "# v$VERSION" "$FILE"; then
+    if guide_prose | grep -qxF "# v$VERSION"; then
       echo "ERROR: $FILE already has a '# v$VERSION' section below '# Unreleased' — releasing $VERSION again would be a version rollback." >&2
       exit 1
     fi
     # The target must also be newer than the newest RELEASED section, or the
     # promotion itself would file today's notes behind history (bump 0.9.0
     # with 0.15.0 released would otherwise happily mint "# v0.9.0").
-    NEWEST_RELEASED=$(grep -m1 -E '^# v[0-9]+\.[0-9]+\.[0-9]+$' "$FILE" || true)
+    NEWEST_RELEASED=$(guide_prose | grep -m1 -E '^# v[0-9]+\.[0-9]+\.[0-9]+$' || true)
     if [ -n "$NEWEST_RELEASED" ]; then
       REL="${NEWEST_RELEASED#\# v}"
       if ! newer "$VERSION" "$REL"; then
@@ -152,7 +159,7 @@ case "$FIRST" in
     echo "Promoted '# Unreleased' -> '# v$VERSION' in $FILE"
     ;;
   "# v$VERSION")
-    if grep -qxF "# Unreleased" "$FILE"; then
+    if guide_prose | grep -qxF "# Unreleased"; then
       echo "ERROR: $FILE has a misplaced '# Unreleased' section below '# v$VERSION' — its notes would silently miss the release." >&2
       exit 1
     fi
@@ -160,7 +167,7 @@ case "$FIRST" in
     ;;
   *)
     TOP="${FIRST#\# v}"
-    if grep -qxF "# Unreleased" "$FILE"; then
+    if guide_prose | grep -qxF "# Unreleased"; then
       echo "ERROR: $FILE has a misplaced '# Unreleased' section below '$FIRST' — its notes would silently miss the release." >&2
       exit 1
     fi

--- a/scripts/promote-migrating.sh
+++ b/scripts/promote-migrating.sh
@@ -1,27 +1,60 @@
 #!/usr/bin/env bash
-# Promotes MIGRATING.md's "# Unreleased" heading to "# v<version>".
-# Called by bump-version.sh; `make release` guards the result, so a bump that
-# skips this (or a hand-rolled bump) cannot tag with notes still unpromoted.
+# Promotes MIGRATING.md's "# Unreleased" heading to "# v<version>", or verifies
+# the promoted state (--check, used by `make release`).
+#
+# The current release's heading is always the FIRST release heading in the
+# file — the guide is newest-first, and its top stays prose (code blocks that
+# quote old headings all sit below the newest section). Matching "# vX"
+# anywhere in the file is the v0.15.0 regression this replaces: a historical
+# section satisfied the "already promoted" check, so a bump rolled backward
+# to an old version reported success and `make release` would have pushed the
+# rollback before failing on the existing tag.
 set -euo pipefail
 
-VERSION="${1:?usage: $0 <version> [file]}"
+MODE=promote
+if [ "${1:-}" = "--check" ]; then MODE=check; shift; fi
+VERSION="${1:?usage: $0 [--check] <version> [file]}"
 FILE="${2:-MIGRATING.md}"
 
-if grep -qxF "# v$VERSION" "$FILE"; then
-  if grep -qxF "# Unreleased" "$FILE"; then
-    echo "ERROR: $FILE carries both '# v$VERSION' and '# Unreleased' — resolve by hand." >&2
-    exit 1
-  fi
-  echo "$FILE already promoted to v$VERSION"
-  exit 0
-fi
+FIRST=$(grep -m1 -E '^# (Unreleased|v[0-9]+\.[0-9]+\.[0-9]+)$' "$FILE" || true)
 
-if ! grep -qxF "# Unreleased" "$FILE"; then
-  echo "ERROR: $FILE has neither '# Unreleased' nor '# v$VERSION' — nothing to promote." >&2
+if [ -z "$FIRST" ]; then
+  echo "ERROR: $FILE has no release heading ('# Unreleased' or '# vX.Y.Z')." >&2
   exit 1
 fi
 
-awk -v v="# v$VERSION" 'BEGIN { done = 0 }
-  !done && $0 == "# Unreleased" { print v; done = 1; next }
-  { print }' "$FILE" > "$FILE.tmp" && mv "$FILE.tmp" "$FILE"
-echo "Promoted '# Unreleased' -> '# v$VERSION' in $FILE"
+# newer A B: true when A sorts strictly after B by version order
+newer() {
+  [ "$1" != "$2" ] && [ "$(printf '%s\n%s\n' "$1" "$2" | sort -V | tail -1)" = "$1" ]
+}
+
+case "$FIRST" in
+  "# Unreleased")
+    if grep -qxF "# v$VERSION" "$FILE"; then
+      echo "ERROR: $FILE already has a '# v$VERSION' section below '# Unreleased' — releasing $VERSION again would be a version rollback." >&2
+      exit 1
+    fi
+    if [ "$MODE" = check ]; then
+      echo "ERROR: $FILE still has an '# Unreleased' section — its notes would miss the release. Run 'make bump VERSION=$VERSION' first." >&2
+      exit 1
+    fi
+    awk -v v="# v$VERSION" 'BEGIN { done = 0 }
+      !done && $0 == "# Unreleased" { print v; done = 1; next }
+      { print }' "$FILE" > "$FILE.tmp" && mv "$FILE.tmp" "$FILE"
+    echo "Promoted '# Unreleased' -> '# v$VERSION' in $FILE"
+    ;;
+  "# v$VERSION")
+    echo "$FILE: '# v$VERSION' is the newest section — promoted."
+    ;;
+  *)
+    TOP="${FIRST#\# v}"
+    if newer "$VERSION" "$TOP"; then
+      # Legitimate: a release with nothing migration-worthy has no section,
+      # per the guide's one-section-per-release-that-breaks-something rule.
+      echo "$FILE: no '# Unreleased' section — v$VERSION ships without migration notes (newest documented: v$TOP)."
+    else
+      echo "ERROR: $FILE's newest section is '# v$TOP'; $VERSION would release backward past it." >&2
+      exit 1
+    fi
+    ;;
+esac

--- a/scripts/promote-migrating.sh
+++ b/scripts/promote-migrating.sh
@@ -23,9 +23,17 @@ if [ -z "$FIRST" ]; then
   exit 1
 fi
 
-# newer A B: true when A sorts strictly after B by version order
+# newer A B: true when A is strictly newer than B, compared component-wise.
+# Pure arithmetic on the three semver components — no reliance on sort -V,
+# whose availability varies across BSD userlands (Apple's current sort has
+# it; the portable spelling retires the question).
 newer() {
-  [ "$1" != "$2" ] && [ "$(printf '%s\n%s\n' "$1" "$2" | sort -V | tail -1)" = "$1" ]
+  local a1 a2 a3 b1 b2 b3
+  IFS=. read -r a1 a2 a3 <<< "$1"
+  IFS=. read -r b1 b2 b3 <<< "$2"
+  [ "$a1" -ne "$b1" ] && { [ "$a1" -gt "$b1" ]; return; }
+  [ "$a2" -ne "$b2" ] && { [ "$a2" -gt "$b2" ]; return; }
+  [ "$a3" -gt "$b3" ]
 }
 
 case "$FIRST" in
@@ -33,6 +41,17 @@ case "$FIRST" in
     if grep -qxF "# v$VERSION" "$FILE"; then
       echo "ERROR: $FILE already has a '# v$VERSION' section below '# Unreleased' — releasing $VERSION again would be a version rollback." >&2
       exit 1
+    fi
+    # The target must also be newer than the newest RELEASED section, or the
+    # promotion itself would file today's notes behind history (bump 0.9.0
+    # with 0.15.0 released would otherwise happily mint "# v0.9.0").
+    NEWEST_RELEASED=$(grep -m1 -E '^# v[0-9]+\.[0-9]+\.[0-9]+$' "$FILE" || true)
+    if [ -n "$NEWEST_RELEASED" ]; then
+      REL="${NEWEST_RELEASED#\# v}"
+      if ! newer "$VERSION" "$REL"; then
+        echo "ERROR: $VERSION is not newer than the newest released section in $FILE ('# v$REL') — refusing to promote backward." >&2
+        exit 1
+      fi
     fi
     if [ "$MODE" = check ]; then
       echo "ERROR: $FILE still has an '# Unreleased' section — its notes would miss the release. Run 'make bump VERSION=$VERSION' first." >&2
@@ -44,10 +63,18 @@ case "$FIRST" in
     echo "Promoted '# Unreleased' -> '# v$VERSION' in $FILE"
     ;;
   "# v$VERSION")
+    if grep -qxF "# Unreleased" "$FILE"; then
+      echo "ERROR: $FILE has a misplaced '# Unreleased' section below '# v$VERSION' — its notes would silently miss the release." >&2
+      exit 1
+    fi
     echo "$FILE: '# v$VERSION' is the newest section — promoted."
     ;;
   *)
     TOP="${FIRST#\# v}"
+    if grep -qxF "# Unreleased" "$FILE"; then
+      echo "ERROR: $FILE has a misplaced '# Unreleased' section below '$FIRST' — its notes would silently miss the release." >&2
+      exit 1
+    fi
     if newer "$VERSION" "$TOP"; then
       # Legitimate: a release with nothing migration-worthy has no section,
       # per the guide's one-section-per-release-that-breaks-something rule.

--- a/scripts/promote-migrating.sh
+++ b/scripts/promote-migrating.sh
@@ -56,16 +56,17 @@ current_blocks() {
   newer "$CURRENT" "$1"
 }
 
-# released W: true when the release tag vW exists — the authority on whether
-# a version actually shipped. A PRESENT local tag is proof positive. A local
-# tag's ABSENCE proves nothing at all: shallow and filtered clones carry
-# partial tag inventories, and one unrelated v-tag's presence is no evidence
-# the missing one never shipped. So absence is confirmed against the remote
-# (git ls-remote --tags origin), and when the remote cannot answer — offline,
-# no origin — the question fails closed rather than renaming what might be
-# history. PROMOTE_MIGRATING_RELEASED (a space-separated version list — the
-# complete authority; may be set empty to model "cannot establish") overrides
-# for the self-test.
+# released W: true when the release tag vW exists ON THE REMOTE — the only
+# authority on whether a version actually shipped. Local tags are consulted
+# for nothing: their absence proves nothing (shallow and filtered clones
+# carry partial inventories), and their presence proves nothing either — a
+# release whose tag push failed leaves the local tag behind with nothing
+# published. When the remote cannot answer — offline, no origin — the
+# question fails closed rather than guessing at history.
+# PROMOTE_MIGRATING_RELEASED (a space-separated version list — the complete
+# authority; may be set empty to model "cannot establish") overrides for the
+# self-test's scratch-file cases; its git-fixture cases run this path for
+# real against a file:// remote.
 released() {
   if [ -n "${PROMOTE_MIGRATING_RELEASED+x}" ]; then
     local r
@@ -73,21 +74,17 @@ released() {
       [ "$r" = "$1" ] && return 0
     done
     if [ -z "$PROMOTE_MIGRATING_RELEASED" ]; then
-      echo "ERROR: whether '# v$1' ever shipped cannot be established. Run 'git fetch --tags' and retry." >&2
+      echo "ERROR: whether '# v$1' ever shipped cannot be established. Check the remote connection and retry." >&2
       exit 1
     fi
     return 1
   fi
-  if git -C "$(dirname "$0")/.." tag -l "v$1" 2>/dev/null | grep -qx "v$1"; then
-    return 0
-  fi
   local remote
   if ! remote=$(git -C "$(dirname "$0")/.." ls-remote --tags origin "refs/tags/v$1" 2>/dev/null); then
-    echo "ERROR: tag v$1 is not in this checkout and the remote cannot be reached to confirm its absence, so whether '# v$1' ever shipped cannot be established. Run 'git fetch --tags' and retry." >&2
+    echo "ERROR: the remote cannot be reached to establish whether v$1 ever shipped. Check the connection and retry." >&2
     exit 1
   fi
-  [ -z "$remote" ] || return 0
-  return 1
+  [ -n "$remote" ]
 }
 
 # newer A B: true when A is strictly newer than B, compared component-wise.
@@ -105,6 +102,13 @@ newer() {
 
 if current_blocks "$VERSION"; then
   echo "ERROR: $VERSION is older than the SDK's current version ($CURRENT in go/pkg/basecamp/version.go) — refusing the rollback." >&2
+  exit 1
+fi
+
+# A release target that is already tagged cannot be released again; catching
+# it here keeps `make release` from pushing main before dying on the tag.
+if [ "$MODE" = check ] && released "$VERSION"; then
+  echo "ERROR: v$VERSION is already tagged — it cannot be released again." >&2
   exit 1
 fi
 

--- a/scripts/promote-migrating.sh
+++ b/scripts/promote-migrating.sh
@@ -18,10 +18,31 @@ FILE="${2:-MIGRATING.md}"
 
 FIRST=$(grep -m1 -E '^# (Unreleased|v[0-9]+\.[0-9]+\.[0-9]+)$' "$FILE" || true)
 
+# The guide's headings are not the authority on the released order: a
+# no-notes release advances the SDK version without adding a heading, so the
+# newest heading can legitimately lag. The version constant is the authority,
+# read from a bump-written source; at bump time (step 0) it still holds the
+# PRE-bump version, so a target older than it is a rollback however the
+# headings read. At release time the version guards have already pinned the
+# constants to the target, so the comparison is trivially equal — harmless.
+# PROMOTE_MIGRATING_CURRENT overrides the source for the self-test only.
+if [ -n "${PROMOTE_MIGRATING_CURRENT:-}" ]; then
+  CURRENT="$PROMOTE_MIGRATING_CURRENT"
+else
+  VERSION_GO="$(dirname "$0")/../go/pkg/basecamp/version.go"
+  CURRENT=$(sed -n 's/^const Version = "\(.*\)"$/\1/p' "$VERSION_GO" 2>/dev/null || true)
+fi
+
 if [ -z "$FIRST" ]; then
   echo "ERROR: $FILE has no release heading ('# Unreleased' or '# vX.Y.Z')." >&2
   exit 1
 fi
+
+# current_blocks TARGET: refuse a target strictly older than the SDK's own
+# current version constant.
+current_blocks() {
+  [ -n "$CURRENT" ] && newer "$CURRENT" "$1"
+}
 
 # newer A B: true when A is strictly newer than B, compared component-wise.
 # Pure arithmetic on the three semver components — no reliance on sort -V,
@@ -36,8 +57,17 @@ newer() {
   [ "$a3" -gt "$b3" ]
 }
 
+if current_blocks "$VERSION"; then
+  echo "ERROR: $VERSION is older than the SDK's current version ($CURRENT in go/pkg/basecamp/version.go) — refusing the rollback." >&2
+  exit 1
+fi
+
 case "$FIRST" in
   "# Unreleased")
+    if [ "$(grep -cxF "# Unreleased" "$FILE")" -gt 1 ]; then
+      echo "ERROR: $FILE has more than one '# Unreleased' heading — promotion would rename only the first and leave the rest to fail the release late." >&2
+      exit 1
+    fi
     if grep -qxF "# v$VERSION" "$FILE"; then
       echo "ERROR: $FILE already has a '# v$VERSION' section below '# Unreleased' — releasing $VERSION again would be a version rollback." >&2
       exit 1

--- a/scripts/promote-migrating.sh
+++ b/scripts/promote-migrating.sh
@@ -27,31 +27,32 @@ PROSE=$(awk '/^```/ { fenced = !fenced; next } !fenced' "$FILE")
 
 FIRST=$(grep -m1 -E '^# (Unreleased|v[0-9]+\.[0-9]+\.[0-9]+)$' <<< "$PROSE" || true)
 
-# The guide's headings are not the authority on the released order: a
-# no-notes release advances the SDK version without adding a heading, so the
-# newest heading can legitimately lag. The version constant is the authority,
-# read from a bump-written source; at bump time (step 0) it still holds the
-# PRE-bump version, so a target older than it is a rollback however the
-# headings read. At release time the version guards have already pinned the
-# constants to the target, so the comparison is trivially equal — harmless.
-# PROMOTE_MIGRATING_CURRENT overrides the source for the self-test only.
-if [ -n "${PROMOTE_MIGRATING_CURRENT:-}" ]; then
-  CURRENT="$PROMOTE_MIGRATING_CURRENT"
-else
-  VERSION_GO="$(dirname "$0")/../go/pkg/basecamp/version.go"
-  CURRENT=$(sed -n 's/^const Version = "\(.*\)"$/\1/p' "$VERSION_GO" 2>/dev/null || true)
-fi
-# Fail closed on an absent OR malformed authority: an empty CURRENT would
-# make current_blocks vacuously permissive, and a non-numeric one (say
-# "dev") errors every arithmetic test in `newer`, which an `if` reads as
-# false — the rollback authority bypassed either way.
-if ! printf '%s' "$CURRENT" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
-  echo "ERROR: current SDK version '$CURRENT' (from go/pkg/basecamp/version.go) is not X.Y.Z — refusing to run without a usable rollback authority." >&2
-  exit 1
-fi
 if ! printf '%s' "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
   echo "ERROR: target version '$VERSION' is not X.Y.Z." >&2
   exit 1
+fi
+
+# The ordering authority is the REMOTE TAG LIST, fetched once — neither the
+# guide's headings (a no-notes release advances without a heading) nor the
+# version constants (an unshipped bump moves them, and a hand edit can move
+# them backward) can answer what actually shipped. The override serves the
+# self-test; empty models "cannot establish", which fails closed.
+if [ -n "${PROMOTE_MIGRATING_RELEASED+x}" ]; then
+  SHIPPED="$PROMOTE_MIGRATING_RELEASED"
+  if [ -z "$SHIPPED" ]; then
+    echo "ERROR: the shipped releases cannot be established. Check the remote connection and retry." >&2
+    exit 1
+  fi
+else
+  if ! TAGLIST=$(git -C "$(dirname "$0")/.." ls-remote --tags origin 'refs/tags/v[0-9]*' 2>/dev/null); then
+    echo "ERROR: the remote cannot be reached to establish what has shipped. Check the connection and retry." >&2
+    exit 1
+  fi
+  SHIPPED=$(sed -n 's|.*refs/tags/v\([0-9][0-9]*\.[0-9][0-9]*\.[0-9][0-9]*\)$|\1|p' <<< "$TAGLIST" | sort -u | tr '\n' ' ')
+  if [ -z "${SHIPPED// /}" ]; then
+    echo "ERROR: the remote lists no release tags — refusing to judge ordering with no shipped history." >&2
+    exit 1
+  fi
 fi
 
 if [ -z "$FIRST" ]; then
@@ -59,41 +60,26 @@ if [ -z "$FIRST" ]; then
   exit 1
 fi
 
-# current_blocks TARGET: refuse a target strictly older than the SDK's own
-# current version constant.
-current_blocks() {
-  newer "$CURRENT" "$1"
+# released W: true when vW is in the shipped list. Local tags are consulted
+# for nothing: their absence proves nothing (partial clones), their presence
+# proves nothing either (a failed tag push leaves one behind with nothing
+# published).
+released() {
+  local r
+  for r in $SHIPPED; do
+    [ "$r" = "$1" ] && return 0
+  done
+  return 1
 }
 
-# released W: true when the release tag vW exists ON THE REMOTE — the only
-# authority on whether a version actually shipped. Local tags are consulted
-# for nothing: their absence proves nothing (shallow and filtered clones
-# carry partial inventories), and their presence proves nothing either — a
-# release whose tag push failed leaves the local tag behind with nothing
-# published. When the remote cannot answer — offline, no origin — the
-# question fails closed rather than guessing at history.
-# PROMOTE_MIGRATING_RELEASED (a space-separated version list — the complete
-# authority; may be set empty to model "cannot establish") overrides for the
-# self-test's scratch-file cases; its git-fixture cases run this path for
-# real against a file:// remote.
-released() {
-  if [ -n "${PROMOTE_MIGRATING_RELEASED+x}" ]; then
-    local r
-    for r in $PROMOTE_MIGRATING_RELEASED; do
-      [ "$r" = "$1" ] && return 0
-    done
-    if [ -z "$PROMOTE_MIGRATING_RELEASED" ]; then
-      echo "ERROR: whether '# v$1' ever shipped cannot be established. Check the remote connection and retry." >&2
-      exit 1
+newest_shipped() {
+  local max="" r
+  for r in $SHIPPED; do
+    if [ -z "$max" ] || newer "$r" "$max"; then
+      max="$r"
     fi
-    return 1
-  fi
-  local remote
-  if ! remote=$(git -C "$(dirname "$0")/.." ls-remote --tags origin "refs/tags/v$1" 2>/dev/null); then
-    echo "ERROR: the remote cannot be reached to establish whether v$1 ever shipped. Check the connection and retry." >&2
-    exit 1
-  fi
-  [ -n "$remote" ]
+  done
+  printf '%s' "$max"
 }
 
 # newer A B: true when A is strictly newer than B, compared component-wise.
@@ -109,15 +95,14 @@ newer() {
   [ "$a3" -gt "$b3" ]
 }
 
-if current_blocks "$VERSION"; then
-  echo "ERROR: $VERSION is older than the SDK's current version ($CURRENT in go/pkg/basecamp/version.go) — refusing the rollback." >&2
-  exit 1
-fi
-
-# A release target that is already tagged cannot be released again; catching
-# it here keeps `make release` from pushing main before dying on the tag.
-if [ "$MODE" = check ] && released "$VERSION"; then
-  echo "ERROR: v$VERSION is already tagged — it cannot be released again." >&2
+# The one ordering gate: the target must be strictly newer than everything
+# that shipped. This subsumes the rollback, re-release, and hand-edited
+# constant cases in one judgment against the one authority — and it is
+# deliberately indifferent to UNSHIPPED state, so a mistaken 0.17.0 bump can
+# be corrected downward to a still-forward 0.16.0 before anything ships.
+MAX_SHIPPED=$(newest_shipped)
+if ! newer "$VERSION" "$MAX_SHIPPED"; then
+  echo "ERROR: $VERSION is not newer than the newest shipped release (v$MAX_SHIPPED) — refusing." >&2
   exit 1
 fi
 
@@ -131,28 +116,8 @@ case "$FIRST" in
       echo "ERROR: $FILE already has a '# v$VERSION' section below '# Unreleased' — releasing $VERSION again would be a version rollback." >&2
       exit 1
     fi
-    # The target must also be newer than the newest RELEASED section, or the
-    # promotion itself would file today's notes behind history (bump 0.9.0
-    # with 0.15.0 released would otherwise happily mint "# v0.9.0").
-    NEWEST_RELEASED=$(grep -m1 -E '^# v[0-9]+\.[0-9]+\.[0-9]+$' <<< "$PROSE" || true)
-    if [ -n "$NEWEST_RELEASED" ]; then
-      REL="${NEWEST_RELEASED#\# v}"
-      if ! newer "$VERSION" "$REL"; then
-        echo "ERROR: $VERSION is not newer than the newest released section in $FILE ('# v$REL') — refusing to promote backward." >&2
-        exit 1
-      fi
-    fi
     if [ "$MODE" = check ]; then
       echo "ERROR: $FILE still has an '# Unreleased' section — its notes would miss the release. Run 'make bump VERSION=$VERSION' first." >&2
-      exit 1
-    fi
-    # New notes belong to a release NEWER than what already shipped: with the
-    # SDK at 0.16.0 (released without notes), promoting fresh notes to
-    # "# v0.16.0" would file them under a tag that already exists, and the
-    # release would push main before failing on that tag. Equality is legal
-    # only for the no-mutation paths.
-    if ! newer "$VERSION" "$CURRENT"; then
-      echo "ERROR: $VERSION is not newer than the SDK's current version ($CURRENT) — these notes belong to a later release." >&2
       exit 1
     fi
     awk -v v="# v$VERSION" 'BEGIN { done = 0 }
@@ -173,27 +138,26 @@ case "$FIRST" in
       echo "ERROR: $FILE has a misplaced '# Unreleased' section below '$FIRST' — its notes would silently miss the release." >&2
       exit 1
     fi
-    if newer "$VERSION" "$TOP"; then
-      if ! released "$TOP"; then
-        # "# v$TOP" was promoted but never released — a bump corrected to a
-        # higher version before committing. Its notes belong to THIS release,
-        # not to a version no tag will ever name.
-        if [ "$MODE" = check ]; then
-          echo "ERROR: $FILE's newest section '# v$TOP' is promoted but unreleased — run 'make bump VERSION=$VERSION' to carry its notes forward." >&2
-          exit 1
-        fi
-        awk -v old="# v$TOP" -v v="# v$VERSION" 'BEGIN { done = 0 }
-          !done && $0 == old { print v; done = 1; next }
-          { print }' "$FILE" > "$FILE.tmp" && mv "$FILE.tmp" "$FILE"
-        echo "Re-promoted pending '# v$TOP' -> '# v$VERSION' in $FILE (v$TOP was never released)."
-        exit 0
-      fi
+    if released "$TOP"; then
       # Legitimate: a release with nothing migration-worthy has no section,
       # per the guide's one-section-per-release-that-breaks-something rule.
+      # The shipped gate already proved VERSION newer than every shipped
+      # release, TOP included.
       echo "$FILE: no '# Unreleased' section — v$VERSION ships without migration notes (newest documented: v$TOP)."
     else
-      echo "ERROR: $FILE's newest section is '# v$TOP'; $VERSION would release backward past it." >&2
-      exit 1
+      # "# v$TOP" was promoted but never released — a bump corrected before
+      # committing, in EITHER direction: the shipped gate holds for the new
+      # target, so its notes carry to it whether it is above or below the
+      # mistaken one.
+      if [ "$MODE" = check ]; then
+        echo "ERROR: $FILE's newest section '# v$TOP' is promoted but unreleased — run 'make bump VERSION=$VERSION' to carry its notes forward." >&2
+        exit 1
+      fi
+      awk -v old="# v$TOP" -v v="# v$VERSION" 'BEGIN { done = 0 }
+        !done && $0 == old { print v; done = 1; next }
+        { print }' "$FILE" > "$FILE.tmp" && mv "$FILE.tmp" "$FILE"
+      echo "Re-promoted pending '# v$TOP' -> '# v$VERSION' in $FILE (v$TOP was never released)."
+      exit 0
     fi
     ;;
 esac

--- a/scripts/promote-migrating.sh
+++ b/scripts/promote-migrating.sh
@@ -23,7 +23,28 @@ FILE="${2:-MIGRATING.md}"
 # `grep -q` under pipefail turns a successful early match into a failure —
 # grep closes the pipe, awk dies on SIGPIPE writing the rest of a large
 # guide, and the pipeline reports the producer's 141.
-PROSE=$(awk '/^ {0,3}(```|~~~)/ { fenced = !fenced; next } !fenced' "$FILE")
+# CommonMark closes a fence only with the SAME delimiter character, at least
+# the opening run's length, and nothing but spaces after -- a ``` line inside
+# a ```` block, or a tilde fence inside a backtick fence, is content, and a
+# backtick opener may carry an info string but never backticks. The one fence
+# automaton is interpolated into every awk pass so the judgments and the
+# rewrites cannot disagree about what is prose. fenceline() returns truth for
+# any line the automaton consumed as fence delimiter or fenced content.
+FENCE_FN='function fenceline(   run, ch, len, rest) {
+  if (match($0, /^ {0,3}(```+|~~~+)/)) {
+    run = substr($0, RSTART, RLENGTH); gsub(/ /, "", run)
+    ch = substr(run, 1, 1); len = length(run)
+    rest = substr($0, RSTART + RLENGTH)
+    if (!fenced) {
+      if (ch != "`" || rest !~ /`/) { fenced = 1; fch = ch; flen = len }
+      return 1
+    }
+    if (ch == fch && len >= flen && rest ~ /^[ \t]*$/) fenced = 0
+    return 1
+  }
+  return fenced
+}'
+PROSE=$(awk "$FENCE_FN"'{ if (fenceline()) next } { print }' "$FILE")
 
 FIRST=$(grep -m1 -E '^# (Unreleased|v[0-9]+\.[0-9]+\.[0-9]+)$' <<< "$PROSE" || true)
 
@@ -72,6 +93,26 @@ released() {
   return 1
 }
 
+# refuse_abandoned SKIP: any UNSHIPPED version heading in the prose, other
+# than one heading equal to SKIP (the branch's own subject, skipped once), is
+# an abandoned promotion whose notes would be orphaned forever the moment a
+# release moves past it -- refuse until it is folded or re-titled. Every
+# branch calls this, so an orphan cannot hide below a promoted target either.
+refuse_abandoned() {
+  local skip="$1" h hv seen_skip=0
+  while IFS= read -r h; do
+    hv="${h#\# v}"
+    if [ -n "$skip" ] && [ "$hv" = "$skip" ] && [ "$seen_skip" = 0 ]; then
+      seen_skip=1
+      continue
+    fi
+    if ! released "$hv"; then
+      echo "ERROR: $FILE carries an unshipped section '# v$hv' -- an abandoned promotion; fold or re-title it before releasing past it." >&2
+      exit 1
+    fi
+  done < <(grep -E '^# v[0-9]+\.[0-9]+\.[0-9]+$' <<< "$PROSE" || true)
+}
+
 newest_shipped() {
   local max="" r
   for r in $SHIPPED; do
@@ -116,24 +157,15 @@ case "$FIRST" in
       echo "ERROR: $FILE already has a '# v$VERSION' section below '# Unreleased' — releasing $VERSION again would be a version rollback." >&2
       exit 1
     fi
-    # Any UNSHIPPED version heading below is an abandoned promotion whose
-    # notes would be orphaned forever the moment a fresh Unreleased promotes
-    # past it — resolve it (fold or re-title) before promoting.
-    while IFS= read -r h; do
-      hv="${h#\# v}"
-      if ! released "$hv"; then
-        echo "ERROR: $FILE carries an unshipped section '# v$hv' below '# Unreleased' — an abandoned promotion; fold or re-title it before promoting new notes past it." >&2
-        exit 1
-      fi
-    done < <(grep -E '^# v[0-9]+\.[0-9]+\.[0-9]+$' <<< "$PROSE" || true)
+    refuse_abandoned ""
     if [ "$MODE" = check ]; then
       echo "ERROR: $FILE still has an '# Unreleased' section — its notes would miss the release. Run 'make bump VERSION=$VERSION' first." >&2
       exit 1
     fi
-    awk -v v="# v$VERSION" 'BEGIN { done = 0 }
-      /^ {0,3}(```|~~~)/ { fenced = !fenced }
-      !fenced && !done && $0 == "# Unreleased" { print v; done = 1; next }
-      { print }' "$FILE" > "$FILE.tmp" && mv "$FILE.tmp" "$FILE"
+    awk "$FENCE_FN"'BEGIN { done = 0 }
+      { if (fenceline()) { print; next } }
+      !done && $0 == "# Unreleased" { print v; done = 1; next }
+      { print }' v="# v$VERSION" "$FILE" > "$FILE.tmp" && mv "$FILE.tmp" "$FILE"
     echo "Promoted '# Unreleased' -> '# v$VERSION' in $FILE"
     ;;
   "# v$VERSION")
@@ -141,6 +173,7 @@ case "$FIRST" in
       echo "ERROR: $FILE has a misplaced '# Unreleased' section below '# v$VERSION' — its notes would silently miss the release." >&2
       exit 1
     fi
+    refuse_abandoned "$VERSION"
     echo "$FILE: '# v$VERSION' is the newest section — promoted."
     ;;
   *)
@@ -149,6 +182,7 @@ case "$FIRST" in
       echo "ERROR: $FILE has a misplaced '# Unreleased' section below '$FIRST' — its notes would silently miss the release." >&2
       exit 1
     fi
+    refuse_abandoned "$TOP"
     if released "$TOP"; then
       # Legitimate: a release with nothing migration-worthy has no section,
       # per the guide's one-section-per-release-that-breaks-something rule.
@@ -164,10 +198,10 @@ case "$FIRST" in
         echo "ERROR: $FILE's newest section '# v$TOP' is promoted but unreleased — run 'make bump VERSION=$VERSION' to carry its notes forward." >&2
         exit 1
       fi
-      awk -v old="# v$TOP" -v v="# v$VERSION" 'BEGIN { done = 0 }
-        /^ {0,3}(```|~~~)/ { fenced = !fenced }
-        !fenced && !done && $0 == old { print v; done = 1; next }
-        { print }' "$FILE" > "$FILE.tmp" && mv "$FILE.tmp" "$FILE"
+      awk "$FENCE_FN"'BEGIN { done = 0 }
+        { if (fenceline()) { print; next } }
+        !done && $0 == old { print v; done = 1; next }
+        { print }' old="# v$TOP" v="# v$VERSION" "$FILE" > "$FILE.tmp" && mv "$FILE.tmp" "$FILE"
       echo "Re-promoted pending '# v$TOP' -> '# v$VERSION' in $FILE (v$TOP was never released)."
       exit 0
     fi

--- a/scripts/promote-migrating.sh
+++ b/scripts/promote-migrating.sh
@@ -116,12 +116,23 @@ case "$FIRST" in
       echo "ERROR: $FILE already has a '# v$VERSION' section below '# Unreleased' — releasing $VERSION again would be a version rollback." >&2
       exit 1
     fi
+    # Any UNSHIPPED version heading below is an abandoned promotion whose
+    # notes would be orphaned forever the moment a fresh Unreleased promotes
+    # past it — resolve it (fold or re-title) before promoting.
+    while IFS= read -r h; do
+      hv="${h#\# v}"
+      if ! released "$hv"; then
+        echo "ERROR: $FILE carries an unshipped section '# v$hv' below '# Unreleased' — an abandoned promotion; fold or re-title it before promoting new notes past it." >&2
+        exit 1
+      fi
+    done < <(grep -E '^# v[0-9]+\.[0-9]+\.[0-9]+$' <<< "$PROSE" || true)
     if [ "$MODE" = check ]; then
       echo "ERROR: $FILE still has an '# Unreleased' section — its notes would miss the release. Run 'make bump VERSION=$VERSION' first." >&2
       exit 1
     fi
     awk -v v="# v$VERSION" 'BEGIN { done = 0 }
-      !done && $0 == "# Unreleased" { print v; done = 1; next }
+      /^```/ { fenced = !fenced }
+      !fenced && !done && $0 == "# Unreleased" { print v; done = 1; next }
       { print }' "$FILE" > "$FILE.tmp" && mv "$FILE.tmp" "$FILE"
     echo "Promoted '# Unreleased' -> '# v$VERSION' in $FILE"
     ;;
@@ -154,7 +165,8 @@ case "$FIRST" in
         exit 1
       fi
       awk -v old="# v$TOP" -v v="# v$VERSION" 'BEGIN { done = 0 }
-        !done && $0 == old { print v; done = 1; next }
+        /^```/ { fenced = !fenced }
+        !fenced && !done && $0 == old { print v; done = 1; next }
         { print }' "$FILE" > "$FILE.tmp" && mv "$FILE.tmp" "$FILE"
       echo "Re-promoted pending '# v$TOP' -> '# v$VERSION' in $FILE (v$TOP was never released)."
       exit 0

--- a/scripts/promote-migrating.sh
+++ b/scripts/promote-migrating.sh
@@ -23,7 +23,7 @@ FILE="${2:-MIGRATING.md}"
 # `grep -q` under pipefail turns a successful early match into a failure —
 # grep closes the pipe, awk dies on SIGPIPE writing the rest of a large
 # guide, and the pipeline reports the producer's 141.
-PROSE=$(awk '/^```/ { fenced = !fenced; next } !fenced' "$FILE")
+PROSE=$(awk '/^ {0,3}(```|~~~)/ { fenced = !fenced; next } !fenced' "$FILE")
 
 FIRST=$(grep -m1 -E '^# (Unreleased|v[0-9]+\.[0-9]+\.[0-9]+)$' <<< "$PROSE" || true)
 
@@ -131,7 +131,7 @@ case "$FIRST" in
       exit 1
     fi
     awk -v v="# v$VERSION" 'BEGIN { done = 0 }
-      /^```/ { fenced = !fenced }
+      /^ {0,3}(```|~~~)/ { fenced = !fenced }
       !fenced && !done && $0 == "# Unreleased" { print v; done = 1; next }
       { print }' "$FILE" > "$FILE.tmp" && mv "$FILE.tmp" "$FILE"
     echo "Promoted '# Unreleased' -> '# v$VERSION' in $FILE"
@@ -165,7 +165,7 @@ case "$FIRST" in
         exit 1
       fi
       awk -v old="# v$TOP" -v v="# v$VERSION" 'BEGIN { done = 0 }
-        /^```/ { fenced = !fenced }
+        /^ {0,3}(```|~~~)/ { fenced = !fenced }
         !fenced && !done && $0 == old { print v; done = 1; next }
         { print }' "$FILE" > "$FILE.tmp" && mv "$FILE.tmp" "$FILE"
       echo "Re-promoted pending '# v$TOP' -> '# v$VERSION' in $FILE (v$TOP was never released)."

--- a/scripts/promote-migrating.sh
+++ b/scripts/promote-migrating.sh
@@ -12,8 +12,21 @@
 set -euo pipefail
 
 MODE=promote
-if [ "${1:-}" = "--check" ]; then MODE=check; shift; fi
-VERSION="${1:?usage: $0 [--check] <version> [file]}"
+RELEASED_OVERRIDE=
+RELEASED_SET=
+while :; do
+  case "${1:-}" in
+    --check) MODE=check; shift ;;
+    # The self-test's seam, an explicit argument by design: an ENVIRONMENT
+    # override would ride along into any `make release` that inherited a
+    # stale list from the caller's shell and silently displace the remote as
+    # the ordering authority. Nothing in the production entry points passes
+    # this flag.
+    --released) RELEASED_OVERRIDE="${2?--released needs a value}"; RELEASED_SET=1; shift 2 ;;
+    *) break ;;
+  esac
+done
+VERSION="${1:?usage: $0 [--check] [--released "<versions>"] <version> [file]}"
 FILE="${2:-MIGRATING.md}"
 
 # Heading judgments read the guide's PROSE only: the guide legitimately
@@ -56,10 +69,10 @@ fi
 # The ordering authority is the REMOTE TAG LIST, fetched once — neither the
 # guide's headings (a no-notes release advances without a heading) nor the
 # version constants (an unshipped bump moves them, and a hand edit can move
-# them backward) can answer what actually shipped. The override serves the
-# self-test; empty models "cannot establish", which fails closed.
-if [ -n "${PROMOTE_MIGRATING_RELEASED+x}" ]; then
-  SHIPPED="$PROMOTE_MIGRATING_RELEASED"
+# them backward) can answer what actually shipped. The --released flag serves
+# the self-test; empty models "cannot establish", which fails closed.
+if [ -n "$RELEASED_SET" ]; then
+  SHIPPED="$RELEASED_OVERRIDE"
   if [ -z "$SHIPPED" ]; then
     echo "ERROR: the shipped releases cannot be established. Check the remote connection and retry." >&2
     exit 1

--- a/scripts/promote-migrating.sh
+++ b/scripts/promote-migrating.sh
@@ -57,13 +57,15 @@ current_blocks() {
 }
 
 # released W: true when the release tag vW exists — the authority on whether
-# a version actually shipped. A local tag's ABSENCE proves nothing on its
-# own: a shallow or --no-tags clone has no historical tags at all, and
-# treating that as "never released" would rename real history. So absence
-# counts only when the checkout demonstrably knows release tags; a checkout
-# that knows none fails closed. PROMOTE_MIGRATING_RELEASED (a space-separated
-# version list; may be set empty to model a tagless checkout) overrides for
-# the self-test.
+# a version actually shipped. A PRESENT local tag is proof positive. A local
+# tag's ABSENCE proves nothing at all: shallow and filtered clones carry
+# partial tag inventories, and one unrelated v-tag's presence is no evidence
+# the missing one never shipped. So absence is confirmed against the remote
+# (git ls-remote --tags origin), and when the remote cannot answer — offline,
+# no origin — the question fails closed rather than renaming what might be
+# history. PROMOTE_MIGRATING_RELEASED (a space-separated version list — the
+# complete authority; may be set empty to model "cannot establish") overrides
+# for the self-test.
 released() {
   if [ -n "${PROMOTE_MIGRATING_RELEASED+x}" ]; then
     local r
@@ -71,18 +73,21 @@ released() {
       [ "$r" = "$1" ] && return 0
     done
     if [ -z "$PROMOTE_MIGRATING_RELEASED" ]; then
-      echo "ERROR: no release tags visible in this checkout, so whether '# v$1' ever shipped cannot be established. Run 'git fetch --tags' and retry." >&2
+      echo "ERROR: whether '# v$1' ever shipped cannot be established. Run 'git fetch --tags' and retry." >&2
       exit 1
     fi
     return 1
   fi
-  local any
-  any=$(git -C "$(dirname "$0")/.." tag -l 'v[0-9]*' 2>/dev/null | head -1)
-  if [ -z "$any" ]; then
-    echo "ERROR: no release tags visible in this checkout, so whether '# v$1' ever shipped cannot be established (shallow or --no-tags clone?). Run 'git fetch --tags' and retry." >&2
+  if git -C "$(dirname "$0")/.." tag -l "v$1" 2>/dev/null | grep -qx "v$1"; then
+    return 0
+  fi
+  local remote
+  if ! remote=$(git -C "$(dirname "$0")/.." ls-remote --tags origin "refs/tags/v$1" 2>/dev/null); then
+    echo "ERROR: tag v$1 is not in this checkout and the remote cannot be reached to confirm its absence, so whether '# v$1' ever shipped cannot be established. Run 'git fetch --tags' and retry." >&2
     exit 1
   fi
-  git -C "$(dirname "$0")/.." tag -l "v$1" 2>/dev/null | grep -qx "v$1"
+  [ -z "$remote" ] || return 0
+  return 1
 }
 
 # newer A B: true when A is strictly newer than B, compared component-wise.

--- a/scripts/promote-migrating.sh
+++ b/scripts/promote-migrating.sh
@@ -32,6 +32,12 @@ else
   VERSION_GO="$(dirname "$0")/../go/pkg/basecamp/version.go"
   CURRENT=$(sed -n 's/^const Version = "\(.*\)"$/\1/p' "$VERSION_GO" 2>/dev/null || true)
 fi
+if [ -z "$CURRENT" ]; then
+  # Fail closed: with no rollback authority, current_blocks would accept
+  # every target — including the rollback it exists to refuse.
+  echo "ERROR: cannot read the current SDK version from go/pkg/basecamp/version.go — refusing to run without the rollback authority." >&2
+  exit 1
+fi
 
 if [ -z "$FIRST" ]; then
   echo "ERROR: $FILE has no release heading ('# Unreleased' or '# vX.Y.Z')." >&2
@@ -41,7 +47,14 @@ fi
 # current_blocks TARGET: refuse a target strictly older than the SDK's own
 # current version constant.
 current_blocks() {
-  [ -n "$CURRENT" ] && newer "$CURRENT" "$1"
+  newer "$CURRENT" "$1"
+}
+
+# released W: true when the release tag vW exists — the offline authority on
+# whether a version actually shipped. A heading newer than every tag is a
+# PROMOTION THAT NEVER RELEASED (a bump corrected before commit), not history.
+released() {
+  git -C "$(dirname "$0")/.." tag -l "v$1" 2>/dev/null | grep -qx "v$1"
 }
 
 # newer A B: true when A is strictly newer than B, compared component-wise.
@@ -87,6 +100,15 @@ case "$FIRST" in
       echo "ERROR: $FILE still has an '# Unreleased' section — its notes would miss the release. Run 'make bump VERSION=$VERSION' first." >&2
       exit 1
     fi
+    # New notes belong to a release NEWER than what already shipped: with the
+    # SDK at 0.16.0 (released without notes), promoting fresh notes to
+    # "# v0.16.0" would file them under a tag that already exists, and the
+    # release would push main before failing on that tag. Equality is legal
+    # only for the no-mutation paths.
+    if ! newer "$VERSION" "$CURRENT"; then
+      echo "ERROR: $VERSION is not newer than the SDK's current version ($CURRENT) — these notes belong to a later release." >&2
+      exit 1
+    fi
     awk -v v="# v$VERSION" 'BEGIN { done = 0 }
       !done && $0 == "# Unreleased" { print v; done = 1; next }
       { print }' "$FILE" > "$FILE.tmp" && mv "$FILE.tmp" "$FILE"
@@ -106,6 +128,20 @@ case "$FIRST" in
       exit 1
     fi
     if newer "$VERSION" "$TOP"; then
+      if ! released "$TOP"; then
+        # "# v$TOP" was promoted but never released — a bump corrected to a
+        # higher version before committing. Its notes belong to THIS release,
+        # not to a version no tag will ever name.
+        if [ "$MODE" = check ]; then
+          echo "ERROR: $FILE's newest section '# v$TOP' is promoted but unreleased — run 'make bump VERSION=$VERSION' to carry its notes forward." >&2
+          exit 1
+        fi
+        awk -v old="# v$TOP" -v v="# v$VERSION" 'BEGIN { done = 0 }
+          !done && $0 == old { print v; done = 1; next }
+          { print }' "$FILE" > "$FILE.tmp" && mv "$FILE.tmp" "$FILE"
+        echo "Re-promoted pending '# v$TOP' -> '# v$VERSION' in $FILE (v$TOP was never released)."
+        exit 0
+      fi
       # Legitimate: a release with nothing migration-worthy has no section,
       # per the guide's one-section-per-release-that-breaks-something rule.
       echo "$FILE: no '# Unreleased' section — v$VERSION ships without migration notes (newest documented: v$TOP)."

--- a/scripts/promote-migrating.sh
+++ b/scripts/promote-migrating.sh
@@ -32,10 +32,16 @@ else
   VERSION_GO="$(dirname "$0")/../go/pkg/basecamp/version.go"
   CURRENT=$(sed -n 's/^const Version = "\(.*\)"$/\1/p' "$VERSION_GO" 2>/dev/null || true)
 fi
-if [ -z "$CURRENT" ]; then
-  # Fail closed: with no rollback authority, current_blocks would accept
-  # every target — including the rollback it exists to refuse.
-  echo "ERROR: cannot read the current SDK version from go/pkg/basecamp/version.go — refusing to run without the rollback authority." >&2
+# Fail closed on an absent OR malformed authority: an empty CURRENT would
+# make current_blocks vacuously permissive, and a non-numeric one (say
+# "dev") errors every arithmetic test in `newer`, which an `if` reads as
+# false — the rollback authority bypassed either way.
+if ! printf '%s' "$CURRENT" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+  echo "ERROR: current SDK version '$CURRENT' (from go/pkg/basecamp/version.go) is not X.Y.Z — refusing to run without a usable rollback authority." >&2
+  exit 1
+fi
+if ! printf '%s' "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+  echo "ERROR: target version '$VERSION' is not X.Y.Z." >&2
   exit 1
 fi
 
@@ -50,10 +56,32 @@ current_blocks() {
   newer "$CURRENT" "$1"
 }
 
-# released W: true when the release tag vW exists — the offline authority on
-# whether a version actually shipped. A heading newer than every tag is a
-# PROMOTION THAT NEVER RELEASED (a bump corrected before commit), not history.
+# released W: true when the release tag vW exists — the authority on whether
+# a version actually shipped. A local tag's ABSENCE proves nothing on its
+# own: a shallow or --no-tags clone has no historical tags at all, and
+# treating that as "never released" would rename real history. So absence
+# counts only when the checkout demonstrably knows release tags; a checkout
+# that knows none fails closed. PROMOTE_MIGRATING_RELEASED (a space-separated
+# version list; may be set empty to model a tagless checkout) overrides for
+# the self-test.
 released() {
+  if [ -n "${PROMOTE_MIGRATING_RELEASED+x}" ]; then
+    local r
+    for r in $PROMOTE_MIGRATING_RELEASED; do
+      [ "$r" = "$1" ] && return 0
+    done
+    if [ -z "$PROMOTE_MIGRATING_RELEASED" ]; then
+      echo "ERROR: no release tags visible in this checkout, so whether '# v$1' ever shipped cannot be established. Run 'git fetch --tags' and retry." >&2
+      exit 1
+    fi
+    return 1
+  fi
+  local any
+  any=$(git -C "$(dirname "$0")/.." tag -l 'v[0-9]*' 2>/dev/null | head -1)
+  if [ -z "$any" ]; then
+    echo "ERROR: no release tags visible in this checkout, so whether '# v$1' ever shipped cannot be established (shallow or --no-tags clone?). Run 'git fetch --tags' and retry." >&2
+    exit 1
+  fi
   git -C "$(dirname "$0")/.." tag -l "v$1" 2>/dev/null | grep -qx "v$1"
 }
 

--- a/scripts/promote-migrating.sh
+++ b/scripts/promote-migrating.sh
@@ -19,11 +19,13 @@ FILE="${2:-MIGRATING.md}"
 # Heading judgments read the guide's PROSE only: the guide legitimately
 # quotes old headings inside fenced code blocks (its own derivation recipes
 # do), and a fence containing "# Unreleased" is an example, not a section.
-guide_prose() {
-  awk '/^```/ { fenced = !fenced; next } !fenced' "$FILE"
-}
+# Captured ONCE and searched with herestrings: piping the prose pass into
+# `grep -q` under pipefail turns a successful early match into a failure —
+# grep closes the pipe, awk dies on SIGPIPE writing the rest of a large
+# guide, and the pipeline reports the producer's 141.
+PROSE=$(awk '/^```/ { fenced = !fenced; next } !fenced' "$FILE")
 
-FIRST=$(guide_prose | grep -m1 -E '^# (Unreleased|v[0-9]+\.[0-9]+\.[0-9]+)$' || true)
+FIRST=$(grep -m1 -E '^# (Unreleased|v[0-9]+\.[0-9]+\.[0-9]+)$' <<< "$PROSE" || true)
 
 # The guide's headings are not the authority on the released order: a
 # no-notes release advances the SDK version without adding a heading, so the
@@ -121,18 +123,18 @@ fi
 
 case "$FIRST" in
   "# Unreleased")
-    if [ "$(guide_prose | grep -cxF "# Unreleased")" -gt 1 ]; then
+    if [ "$(grep -cxF "# Unreleased" <<< "$PROSE" || true)" -gt 1 ]; then
       echo "ERROR: $FILE has more than one '# Unreleased' heading — promotion would rename only the first and leave the rest to fail the release late." >&2
       exit 1
     fi
-    if guide_prose | grep -qxF "# v$VERSION"; then
+    if grep -qxF "# v$VERSION" <<< "$PROSE"; then
       echo "ERROR: $FILE already has a '# v$VERSION' section below '# Unreleased' — releasing $VERSION again would be a version rollback." >&2
       exit 1
     fi
     # The target must also be newer than the newest RELEASED section, or the
     # promotion itself would file today's notes behind history (bump 0.9.0
     # with 0.15.0 released would otherwise happily mint "# v0.9.0").
-    NEWEST_RELEASED=$(guide_prose | grep -m1 -E '^# v[0-9]+\.[0-9]+\.[0-9]+$' || true)
+    NEWEST_RELEASED=$(grep -m1 -E '^# v[0-9]+\.[0-9]+\.[0-9]+$' <<< "$PROSE" || true)
     if [ -n "$NEWEST_RELEASED" ]; then
       REL="${NEWEST_RELEASED#\# v}"
       if ! newer "$VERSION" "$REL"; then
@@ -159,7 +161,7 @@ case "$FIRST" in
     echo "Promoted '# Unreleased' -> '# v$VERSION' in $FILE"
     ;;
   "# v$VERSION")
-    if guide_prose | grep -qxF "# Unreleased"; then
+    if grep -qxF "# Unreleased" <<< "$PROSE"; then
       echo "ERROR: $FILE has a misplaced '# Unreleased' section below '# v$VERSION' — its notes would silently miss the release." >&2
       exit 1
     fi
@@ -167,7 +169,7 @@ case "$FIRST" in
     ;;
   *)
     TOP="${FIRST#\# v}"
-    if guide_prose | grep -qxF "# Unreleased"; then
+    if grep -qxF "# Unreleased" <<< "$PROSE"; then
       echo "ERROR: $FILE has a misplaced '# Unreleased' section below '$FIRST' — its notes would silently miss the release." >&2
       exit 1
     fi

--- a/scripts/test-promote-migrating.sh
+++ b/scripts/test-promote-migrating.sh
@@ -65,9 +65,11 @@ bash "$SCRIPT" --check 0.16.0 "$DIR/e.md" >/dev/null 2>&1; check "--check refuse
 fresh f.md "# v0.16.0" "# v0.15.0"
 bash "$SCRIPT" --check 0.16.0 "$DIR/f.md" >/dev/null 2>&1; check "--check accepts promoted heading" 0 $?
 
-# 10. --check accepts no-notes forward, refuses backward
-bash "$SCRIPT" --check 0.16.1 "$DIR/f.md" >/dev/null 2>&1; check "--check accepts no-notes forward" 0 $?
-bash "$SCRIPT" --check 0.15.0 "$DIR/f.md" >/dev/null 2>&1; check "--check refuses backward release" 1 $?
+# 10. --check accepts no-notes forward past a RELEASED heading (v0.15.0 has a
+#     real tag), refuses backward
+fresh f2.md "# v0.15.0" "# v0.14.0"
+bash "$SCRIPT" --check 0.15.1 "$DIR/f2.md" >/dev/null 2>&1; check "--check accepts no-notes forward" 0 $?
+bash "$SCRIPT" --check 0.14.0 "$DIR/f2.md" >/dev/null 2>&1; check "--check refuses backward release" 1 $?
 
 # 11. a code-block heading below the newest section does not confuse the
 #     first-heading scan (the guide quotes old headings in fences)
@@ -106,6 +108,31 @@ printf '# Unreleased\n\nstray\n' >> "$DIR/m.md"
 cp "$DIR/m.md" "$DIR/m.before"
 bash "$SCRIPT" 0.16.0 "$DIR/m.md" >/dev/null 2>&1; check "duplicate Unreleased refused" 1 $?
 diff -q "$DIR/m.md" "$DIR/m.before" >/dev/null; check "duplicate refusal leaves file untouched" 0 $?
+
+# 17. an unresolvable current version is fatal, not fail-open: a copy of the
+#     script outside the repo cannot find version.go
+cp "$SCRIPT" "$DIR/stray-promote.sh"
+fresh n.md "# Unreleased" "# v0.15.0"
+env -u PROMOTE_MIGRATING_CURRENT bash "$DIR/stray-promote.sh" 0.16.0 "$DIR/n.md" >/dev/null 2>&1
+check "unreadable current version is fatal" 1 $?
+
+# 18. promoting NEW notes to the version already shipped is refused: after a
+#     no-notes 0.16.0 release, a fresh Unreleased belongs to a later release
+fresh o.md "# Unreleased" "# v0.15.0"
+PROMOTE_MIGRATING_CURRENT=0.16.0 bash "$SCRIPT" 0.16.0 "$DIR/o.md" >/dev/null 2>&1
+check "equal-version promotion of new notes refused" 1 $?
+
+# 19. correcting a bump before commit re-promotes the pending heading (no tag
+#     names v0.99.0) instead of stranding its notes; --check refuses the same
+#     state instead of calling it no-notes
+fresh p.md "# v0.99.0" "# v0.15.0"
+PROMOTE_MIGRATING_CURRENT=0.99.0 bash "$SCRIPT" 0.99.1 "$DIR/p.md" >/dev/null 2>&1
+check "pending heading re-promoted on corrected bump" 0 $?
+grep -qxF "# v0.99.1" "$DIR/p.md" && ! grep -qxF "# v0.99.0" "$DIR/p.md"
+check "pending heading renamed" 0 $?
+fresh q.md "# v0.99.0" "# v0.15.0"
+PROMOTE_MIGRATING_CURRENT=0.99.0 bash "$SCRIPT" --check 0.99.1 "$DIR/q.md" >/dev/null 2>&1
+check "--check refuses a pending unreleased heading" 1 $?
 
 if [ "$FAILS" -gt 0 ]; then
   echo "test-promote-migrating: $FAILS of $CASES assertions failed" >&2

--- a/scripts/test-promote-migrating.sh
+++ b/scripts/test-promote-migrating.sh
@@ -193,6 +193,13 @@ fresh t4.md "# v0.5.0" "# v0.4.0"
 env -u PROMOTE_MIGRATING_CURRENT -u PROMOTE_MIGRATING_RELEASED bash "$FSCRIPT" 0.6.1 "$DIR/t4.md" >/dev/null 2>&1
 check "unreachable remote fails closed" 1 $?
 
+# 24. fenced examples are prose to a reader and NOTHING to the heading
+#     judgments: a code block quoting "# Unreleased" is not a duplicate, and
+#     one quoting the target heading is not a rollback
+{ echo "# Migrating"; echo; echo "# Unreleased"; echo; echo '```'; echo "# Unreleased"; echo "# v0.16.0"; echo '```'; echo; echo "# v0.15.0"; } > "$DIR/u.md"
+bash "$SCRIPT" 0.16.0 "$DIR/u.md" >/dev/null 2>&1; check "fenced headings are invisible to promotion" 0 $?
+grep -qxF "# v0.16.0" "$DIR/u.md"; check "promotion landed despite fenced examples" 0 $?
+
 if [ "$FAILS" -gt 0 ]; then
   echo "test-promote-migrating: $FAILS of $CASES assertions failed" >&2
   exit 1

--- a/scripts/test-promote-migrating.sh
+++ b/scripts/test-promote-migrating.sh
@@ -5,11 +5,13 @@
 # anywhere, so a historical heading waved a rolled-back bump through.
 set -u
 SCRIPT="$(dirname "$0")/promote-migrating.sh"
-# Pin the current-version authority so the repo's real constant cannot leak
-# into scratch-file cases; individual cases override it to probe the gate.
-# Pin the shipped-releases authority: the suite must not depend on the
-# checkout's real tag state (CI checkouts are shallow and tagless).
-export PROMOTE_MIGRATING_RELEASED="0.14.0 0.15.0"
+# Pin the shipped-releases authority per invocation via --released: the suite
+# must not depend on the checkout's real tag state (CI checkouts are shallow
+# and tagless), and the seam is an argument rather than an environment
+# variable so nothing a caller's shell exports can displace the remote in a
+# production `make release`. Cases that probe the real remote path use the
+# file:// fixture origin and pass no flag.
+RELEASED_DEFAULT="0.14.0 0.15.0"
 DIR=$(mktemp -d)
 trap 'rm -rf "$DIR"' EXIT
 FAILS=0
@@ -30,137 +32,137 @@ fresh() { # fresh <file> <headings...>
 
 # 1. promote: Unreleased at top becomes the version heading
 fresh a.md "# Unreleased" "# v0.15.0"
-bash "$SCRIPT" 0.16.0 "$DIR/a.md" >/dev/null 2>&1; check "promote happy path" 0 $?
+bash "$SCRIPT" --released "$RELEASED_DEFAULT" 0.16.0 "$DIR/a.md" >/dev/null 2>&1; check "promote happy path" 0 $?
 grep -qxF "# v0.16.0" "$DIR/a.md" && ! grep -qxF "# Unreleased" "$DIR/a.md"
 check "heading replaced" 0 $?
 
 # 2. idempotent second run, file unchanged
 cp "$DIR/a.md" "$DIR/a.before"
-bash "$SCRIPT" 0.16.0 "$DIR/a.md" >/dev/null 2>&1; check "idempotent rerun" 0 $?
+bash "$SCRIPT" --released "$RELEASED_DEFAULT" 0.16.0 "$DIR/a.md" >/dev/null 2>&1; check "idempotent rerun" 0 $?
 diff -q "$DIR/a.md" "$DIR/a.before" >/dev/null; check "idempotent leaves file untouched" 0 $?
 
 # 3. THE regression: backward bump to a version whose heading exists historically
 fresh b.md "# v0.15.0" "# v0.14.0"
-bash "$SCRIPT" 0.14.0 "$DIR/b.md" >/dev/null 2>&1; check "backward bump to historical heading refused" 1 $?
+bash "$SCRIPT" --released "$RELEASED_DEFAULT" 0.14.0 "$DIR/b.md" >/dev/null 2>&1; check "backward bump to historical heading refused" 1 $?
 
 # 4. backward bump refused even without a matching historical heading
-bash "$SCRIPT" 0.14.9 "$DIR/b.md" >/dev/null 2>&1; check "backward bump without heading refused" 1 $?
+bash "$SCRIPT" --released "$RELEASED_DEFAULT" 0.14.9 "$DIR/b.md" >/dev/null 2>&1; check "backward bump without heading refused" 1 $?
 
 # 5. no-notes forward release accepted, file untouched
 cp "$DIR/b.md" "$DIR/b.before"
-bash "$SCRIPT" 0.15.1 "$DIR/b.md" >/dev/null 2>&1; check "no-notes forward release accepted" 0 $?
+bash "$SCRIPT" --released "$RELEASED_DEFAULT" 0.15.1 "$DIR/b.md" >/dev/null 2>&1; check "no-notes forward release accepted" 0 $?
 diff -q "$DIR/b.md" "$DIR/b.before" >/dev/null; check "no-notes leaves file untouched" 0 $?
 
 # 6. Unreleased plus an existing target heading is a rollback, refused
 fresh c.md "# Unreleased" "# v0.16.0" "# v0.15.0"
-bash "$SCRIPT" 0.16.0 "$DIR/c.md" >/dev/null 2>&1; check "duplicate target heading refused" 1 $?
+bash "$SCRIPT" --released "$RELEASED_DEFAULT" 0.16.0 "$DIR/c.md" >/dev/null 2>&1; check "duplicate target heading refused" 1 $?
 
 # 7. no release heading at all
 printf '# Migrating\n\nprose only\n' > "$DIR/d.md"
-bash "$SCRIPT" 0.16.0 "$DIR/d.md" >/dev/null 2>&1; check "headingless file refused" 1 $?
+bash "$SCRIPT" --released "$RELEASED_DEFAULT" 0.16.0 "$DIR/d.md" >/dev/null 2>&1; check "headingless file refused" 1 $?
 
 # 8. --check refuses an unpromoted Unreleased
 fresh e.md "# Unreleased" "# v0.15.0"
-bash "$SCRIPT" --check 0.16.0 "$DIR/e.md" >/dev/null 2>&1; check "--check refuses unpromoted notes" 1 $?
+bash "$SCRIPT" --released "$RELEASED_DEFAULT" --check 0.16.0 "$DIR/e.md" >/dev/null 2>&1; check "--check refuses unpromoted notes" 1 $?
 
 # 9. --check accepts the promoted top heading
 fresh f.md "# v0.16.0" "# v0.15.0"
-bash "$SCRIPT" --check 0.16.0 "$DIR/f.md" >/dev/null 2>&1; check "--check accepts promoted heading" 0 $?
+bash "$SCRIPT" --released "$RELEASED_DEFAULT" --check 0.16.0 "$DIR/f.md" >/dev/null 2>&1; check "--check accepts promoted heading" 0 $?
 
 # 10. --check accepts no-notes forward past a RELEASED heading (v0.15.0 has a
 #     real tag), refuses backward
 fresh f2.md "# v0.15.0" "# v0.14.0"
-bash "$SCRIPT" --check 0.15.1 "$DIR/f2.md" >/dev/null 2>&1; check "--check accepts no-notes forward" 0 $?
-bash "$SCRIPT" --check 0.14.0 "$DIR/f2.md" >/dev/null 2>&1; check "--check refuses backward release" 1 $?
+bash "$SCRIPT" --released "$RELEASED_DEFAULT" --check 0.15.1 "$DIR/f2.md" >/dev/null 2>&1; check "--check accepts no-notes forward" 0 $?
+bash "$SCRIPT" --released "$RELEASED_DEFAULT" --check 0.14.0 "$DIR/f2.md" >/dev/null 2>&1; check "--check refuses backward release" 1 $?
 
 # 11. a code-block heading below the newest section does not confuse the
 #     first-heading scan (the guide quotes old headings in fences)
 { echo "# Migrating"; echo; echo "# v0.16.0"; echo; echo '```'; echo "# v0.12.0"; echo '```'; } > "$DIR/g.md"
-bash "$SCRIPT" --check 0.16.0 "$DIR/g.md" >/dev/null 2>&1; check "quoted old heading below top ignored" 0 $?
+bash "$SCRIPT" --released "$RELEASED_DEFAULT" --check 0.16.0 "$DIR/g.md" >/dev/null 2>&1; check "quoted old heading below top ignored" 0 $?
 
 # 12. promote refuses a target older than the newest released section
 fresh h.md "# Unreleased" "# v0.15.0"
-bash "$SCRIPT" 0.9.0 "$DIR/h.md" >/dev/null 2>&1; check "promote refuses backward target" 1 $?
+bash "$SCRIPT" --released "$RELEASED_DEFAULT" 0.9.0 "$DIR/h.md" >/dev/null 2>&1; check "promote refuses backward target" 1 $?
 
 # 13. a two-digit component beats a one-digit one (component-wise, not lexicographic)
 fresh i.md "# Unreleased" "# v0.9.0"
-PROMOTE_MIGRATING_RELEASED="0.9.0" bash "$SCRIPT" 0.10.0 "$DIR/i.md" >/dev/null 2>&1; check "0.10.0 is newer than 0.9.0" 0 $?
+bash "$SCRIPT" --released "0.9.0" 0.10.0 "$DIR/i.md" >/dev/null 2>&1; check "0.10.0 is newer than 0.9.0" 0 $?
 grep -qxF "# v0.10.0" "$DIR/i.md"; check "0.10.0 promoted" 0 $?
 
 # 14. a misplaced "# Unreleased" below the promoted top is refused, both branches
 fresh j.md "# v0.16.0" "# Unreleased" "# v0.15.0"
-bash "$SCRIPT" 0.16.0 "$DIR/j.md" >/dev/null 2>&1; check "idempotent branch refuses misplaced Unreleased" 1 $?
-bash "$SCRIPT" --check 0.16.1 "$DIR/j.md" >/dev/null 2>&1; check "no-notes branch refuses misplaced Unreleased" 1 $?
+bash "$SCRIPT" --released "$RELEASED_DEFAULT" 0.16.0 "$DIR/j.md" >/dev/null 2>&1; check "idempotent branch refuses misplaced Unreleased" 1 $?
+bash "$SCRIPT" --released "$RELEASED_DEFAULT" --check 0.16.1 "$DIR/j.md" >/dev/null 2>&1; check "no-notes branch refuses misplaced Unreleased" 1 $?
 
 # 15. the shipped tags, not the headings or the constants, are the rollback
 #     authority: after a no-notes 0.16.0 release the newest heading lags, and
 #     a bump or a hand-edited --check between them must still refuse
 fresh k.md "# v0.15.0" "# v0.14.0"
-PROMOTE_MIGRATING_RELEASED="0.14.0 0.15.0 0.16.0" bash "$SCRIPT" 0.15.5 "$DIR/k.md" >/dev/null 2>&1
+bash "$SCRIPT" --released "0.14.0 0.15.0 0.16.0" 0.15.5 "$DIR/k.md" >/dev/null 2>&1
 check "no-notes bump below the newest shipped release refused" 1 $?
 fresh l.md "# Unreleased" "# v0.15.0"
-PROMOTE_MIGRATING_RELEASED="0.14.0 0.15.0 0.16.0" bash "$SCRIPT" 0.15.5 "$DIR/l.md" >/dev/null 2>&1
+bash "$SCRIPT" --released "0.14.0 0.15.0 0.16.0" 0.15.5 "$DIR/l.md" >/dev/null 2>&1
 check "promote below the newest shipped release refused" 1 $?
-PROMOTE_MIGRATING_RELEASED="0.14.0 0.15.0 0.16.0" bash "$SCRIPT" --check 0.15.5 "$DIR/k.md" >/dev/null 2>&1
+bash "$SCRIPT" --released "0.14.0 0.15.0 0.16.0" --check 0.15.5 "$DIR/k.md" >/dev/null 2>&1
 check "hand-edited constants cannot sneak an unshipped rollback past --check" 1 $?
-PROMOTE_MIGRATING_RELEASED="0.14.0 0.15.0 0.16.0" bash "$SCRIPT" --check 0.16.5 "$DIR/k.md" >/dev/null 2>&1
+bash "$SCRIPT" --released "0.14.0 0.15.0 0.16.0" --check 0.16.5 "$DIR/k.md" >/dev/null 2>&1
 check "--check past the newest shipped release accepted" 0 $?
 
 # 16. more than one "# Unreleased" heading is refused before any mutation
 fresh m.md "# Unreleased" "# v0.15.0"
 printf '# Unreleased\n\nstray\n' >> "$DIR/m.md"
 cp "$DIR/m.md" "$DIR/m.before"
-bash "$SCRIPT" 0.16.0 "$DIR/m.md" >/dev/null 2>&1; check "duplicate Unreleased refused" 1 $?
+bash "$SCRIPT" --released "$RELEASED_DEFAULT" 0.16.0 "$DIR/m.md" >/dev/null 2>&1; check "duplicate Unreleased refused" 1 $?
 diff -q "$DIR/m.md" "$DIR/m.before" >/dev/null; check "duplicate refusal leaves file untouched" 0 $?
 
 # 17. an unobtainable shipped list is fatal, not fail-open: a copy of the
 #     script outside the repo has no origin to ask
 cp "$SCRIPT" "$DIR/stray-promote.sh"
 fresh n.md "# Unreleased" "# v0.15.0"
-env -u PROMOTE_MIGRATING_RELEASED bash "$DIR/stray-promote.sh" 0.16.0 "$DIR/n.md" >/dev/null 2>&1
+bash "$DIR/stray-promote.sh" 0.16.0 "$DIR/n.md" >/dev/null 2>&1
 check "unobtainable shipped list is fatal" 1 $?
 
 # 18. promoting NEW notes to the version already shipped is refused: after a
 #     no-notes 0.16.0 release, a fresh Unreleased belongs to a later release
 fresh o.md "# Unreleased" "# v0.15.0"
-PROMOTE_MIGRATING_RELEASED="0.14.0 0.15.0 0.16.0" bash "$SCRIPT" 0.16.0 "$DIR/o.md" >/dev/null 2>&1
+bash "$SCRIPT" --released "0.14.0 0.15.0 0.16.0" 0.16.0 "$DIR/o.md" >/dev/null 2>&1
 check "equal-version promotion of new notes refused" 1 $?
 
 # 19. correcting a bump before commit re-promotes the pending heading (no tag
 #     names v0.99.0) instead of stranding its notes — in EITHER direction —
 #     and --check refuses the state instead of calling it no-notes
 fresh p.md "# v0.99.0" "# v0.15.0"
-bash "$SCRIPT" 0.99.1 "$DIR/p.md" >/dev/null 2>&1
+bash "$SCRIPT" --released "$RELEASED_DEFAULT" 0.99.1 "$DIR/p.md" >/dev/null 2>&1
 check "pending heading re-promoted on corrected bump" 0 $?
 grep -qxF "# v0.99.1" "$DIR/p.md" && ! grep -qxF "# v0.99.0" "$DIR/p.md"
 check "pending heading renamed" 0 $?
 fresh p2.md "# v0.99.0" "# v0.15.0"
-bash "$SCRIPT" 0.17.0 "$DIR/p2.md" >/dev/null 2>&1
+bash "$SCRIPT" --released "$RELEASED_DEFAULT" 0.17.0 "$DIR/p2.md" >/dev/null 2>&1
 check "pending heading re-promoted DOWNWARD to a still-forward target" 0 $?
 grep -qxF "# v0.17.0" "$DIR/p2.md" && ! grep -qxF "# v0.99.0" "$DIR/p2.md"
 check "downward correction renamed the heading" 0 $?
 fresh q.md "# v0.99.0" "# v0.15.0"
-bash "$SCRIPT" --check 0.99.1 "$DIR/q.md" >/dev/null 2>&1
+bash "$SCRIPT" --released "$RELEASED_DEFAULT" --check 0.99.1 "$DIR/q.md" >/dev/null 2>&1
 check "--check refuses a pending unreleased heading" 1 $?
 
 # 20. a malformed target is refused with the format diagnostic
 fresh r.md "# Unreleased" "# v0.15.0"
-ERR=$(bash "$SCRIPT" dev "$DIR/r.md" 2>&1 >/dev/null)
+ERR=$(bash "$SCRIPT" --released "$RELEASED_DEFAULT" dev "$DIR/r.md" 2>&1 >/dev/null)
 check "malformed target version is fatal" 1 $?
 printf '%s' "$ERR" | grep -q "is not X.Y.Z"; check "refusal names the malformed target" 0 $?
 
 # 21. a checkout that knows no release tags fails closed when release status
 #     matters, instead of renaming real history as "pending"
 fresh s.md "# v0.15.0" "# v0.14.0"
-PROMOTE_MIGRATING_RELEASED= bash "$SCRIPT" 0.15.1 "$DIR/s.md" >/dev/null 2>&1
+bash "$SCRIPT" --released "" 0.15.1 "$DIR/s.md" >/dev/null 2>&1
 check "tagless checkout fails closed on the pending question" 1 $?
 cp "$DIR/s.md" "$DIR/s.before" 2>/dev/null
-PROMOTE_MIGRATING_RELEASED= bash "$SCRIPT" 0.15.1 "$DIR/s.md" >/dev/null 2>&1 || true
+bash "$SCRIPT" --released "" 0.15.1 "$DIR/s.md" >/dev/null 2>&1 || true
 diff -q "$DIR/s.md" "$DIR/s.before" >/dev/null; check "tagless refusal leaves the file untouched" 0 $?
 
 # 22. an already-tagged target cannot pass --check, whatever the headings say
 fresh t0.md "# v0.15.0" "# v0.14.0"
-bash "$SCRIPT" --check 0.15.0 "$DIR/t0.md" >/dev/null 2>&1
+bash "$SCRIPT" --released "$RELEASED_DEFAULT" --check 0.15.0 "$DIR/t0.md" >/dev/null 2>&1
 check "--check refuses an already-tagged target" 1 $?
 
 # 23. the real remote-authority paths, exercised against a file:// origin —
@@ -180,49 +182,49 @@ FSCRIPT="$FIX/scripts/promote-migrating.sh"
 
 fresh t1.md "# v0.5.0" "# v0.4.0"
 cp "$DIR/t1.md" "$DIR/t1.before"
-env -u PROMOTE_MIGRATING_RELEASED bash "$FSCRIPT" 0.6.1 "$DIR/t1.md" >/dev/null 2>&1
+bash "$FSCRIPT" 0.6.1 "$DIR/t1.md" >/dev/null 2>&1
 check "remote-present tag reads as released (real ls-remote)" 0 $?
 diff -q "$DIR/t1.md" "$DIR/t1.before" >/dev/null
 check "released heading took the no-notes path without mutation" 0 $?
 
 fresh t2.md "# v0.6.0" "# v0.5.0"
-env -u PROMOTE_MIGRATING_RELEASED bash "$FSCRIPT" 0.6.1 "$DIR/t2.md" >/dev/null 2>&1
+bash "$FSCRIPT" 0.6.1 "$DIR/t2.md" >/dev/null 2>&1
 check "local-only tag reads as pending (re-promoted)" 0 $?
 grep -qxF "# v0.6.1" "$DIR/t2.md"; check "failed-push residue heading carried forward" 0 $?
 
 fresh t3.md "# v0.5.0" "# v0.4.0"
-env -u PROMOTE_MIGRATING_RELEASED bash "$FSCRIPT" --check 0.5.0 "$DIR/t3.md" >/dev/null 2>&1
+bash "$FSCRIPT" --check 0.5.0 "$DIR/t3.md" >/dev/null 2>&1
 check "real remote refuses an already-tagged --check target" 1 $?
 
 git -C "$FIX" remote set-url origin "$DIR/no-such-origin.git"
 fresh t4.md "# v0.5.0" "# v0.4.0"
-env -u PROMOTE_MIGRATING_RELEASED bash "$FSCRIPT" 0.6.1 "$DIR/t4.md" >/dev/null 2>&1
+bash "$FSCRIPT" 0.6.1 "$DIR/t4.md" >/dev/null 2>&1
 check "unreachable remote fails closed" 1 $?
 
 # 24. fenced examples are prose to a reader and NOTHING to the heading
 #     judgments: a code block quoting "# Unreleased" is not a duplicate, and
 #     one quoting the target heading is not a rollback
 { echo "# Migrating"; echo; echo "# Unreleased"; echo; echo '```'; echo "# Unreleased"; echo "# v0.16.0"; echo '```'; echo; echo "# v0.15.0"; } > "$DIR/u.md"
-bash "$SCRIPT" 0.16.0 "$DIR/u.md" >/dev/null 2>&1; check "fenced headings are invisible to promotion" 0 $?
+bash "$SCRIPT" --released "$RELEASED_DEFAULT" 0.16.0 "$DIR/u.md" >/dev/null 2>&1; check "fenced headings are invisible to promotion" 0 $?
 grep -qxF "# v0.16.0" "$DIR/u.md"; check "promotion landed despite fenced examples" 0 $?
 
 # 25. a guide large enough that grep's early exit outruns the prose pass:
 #     under pipefail a piped judgment would report the producer's SIGPIPE as
 #     no-match and wave a rollback through; the captured-prose form must not
 { echo "# Migrating"; echo; echo "# Unreleased"; echo; echo "# v0.16.0"; echo; for i in $(seq 1 8000); do echo "filler prose line $i to outlast the pipe buffer after the early match"; done; } > "$DIR/v.md"
-PROMOTE_MIGRATING_RELEASED="0.15.0" bash "$SCRIPT" 0.16.0 "$DIR/v.md" >/dev/null 2>&1
+bash "$SCRIPT" --released "0.15.0" 0.16.0 "$DIR/v.md" >/dev/null 2>&1
 check "duplicate target still refused on a large guide" 1 $?
 
 # 26. an abandoned unshipped section below a fresh Unreleased is refused
 #     before promotion can orphan its notes forever
 fresh w.md "# Unreleased" "# v0.16.0" "# v0.15.0"
-PROMOTE_MIGRATING_RELEASED="0.15.0" bash "$SCRIPT" 0.17.0 "$DIR/w.md" >/dev/null 2>&1
+bash "$SCRIPT" --released "0.15.0" 0.17.0 "$DIR/w.md" >/dev/null 2>&1
 check "abandoned unshipped section refused" 1 $?
 
 # 27. the rewrite passes skip fences too: a fenced "# Unreleased" BEFORE the
 #     real section must survive promotion untouched
 { echo "# Migrating"; echo; echo '```'; echo "# Unreleased"; echo '```'; echo; echo "# Unreleased"; echo; echo "# v0.15.0"; } > "$DIR/x.md"
-bash "$SCRIPT" 0.16.0 "$DIR/x.md" >/dev/null 2>&1
+bash "$SCRIPT" --released "$RELEASED_DEFAULT" 0.16.0 "$DIR/x.md" >/dev/null 2>&1
 check "promotion with a leading fenced example succeeds" 0 $?
 FENCED_KEPT=$(awk '/^```/{f=!f; next} f && $0 == "# Unreleased"' "$DIR/x.md" | wc -l | tr -d ' ')
 [ "$FENCED_KEPT" = "1" ]; check "the fenced example survived; the real heading promoted" 0 $?
@@ -230,16 +232,25 @@ grep -qxF "# v0.16.0" "$DIR/x.md"; check "real heading became the version" 0 $?
 
 # 28. tilde and indented fences are fences too
 { echo "# Migrating"; echo; echo "~~~"; echo "# Unreleased"; echo "~~~"; echo; echo "   \`\`\`"; echo "# v0.16.0"; echo "   \`\`\`"; echo; echo "# Unreleased"; echo; echo "# v0.15.0"; } > "$DIR/y.md"
-bash "$SCRIPT" 0.16.0 "$DIR/y.md" >/dev/null 2>&1
+bash "$SCRIPT" --released "$RELEASED_DEFAULT" 0.16.0 "$DIR/y.md" >/dev/null 2>&1
 check "tilde and indented fences are invisible to the judgments" 0 $?
 grep -qxF "# v0.16.0" "$DIR/y.md"; check "promotion landed past exotic fences" 0 $?
+
+# 28b. the environment is NOT a seam: an exported stale list must not
+#      displace the remote authority in a production invocation (the fixture
+#      origin's newest pushed tag is v0.5.0, so 0.6.1 proceeds; an honored
+#      env var claiming 0.99.0 shipped would refuse it)
+git -C "$FIX" remote set-url origin "$ORIGIN"   # case 23's tail left it unreachable
+fresh z0.md "# v0.5.0" "# v0.4.0"
+PROMOTE_MIGRATING_RELEASED="0.99.0" bash "$FSCRIPT" 0.6.1 "$DIR/z0.md" >/dev/null 2>&1
+check "an exported release list is ignored; the remote stays the authority" 0 $?
 
 # 29. CommonMark closes a fence only with the SAME delimiter at >= the
 #     opening length and no info string: a ``` line inside a ```` block is
 #     content, so a heading between them must stay hidden and the block must
 #     not "close early" and expose it to the judgments or the rewrites
 { echo "# Migrating"; echo; echo '````'; echo '```'; echo "# Unreleased"; echo '```'; echo '````'; echo; echo "# Unreleased"; echo; echo "# v0.15.0"; } > "$DIR/z1.md"
-bash "$SCRIPT" 0.16.0 "$DIR/z1.md" >/dev/null 2>&1
+bash "$SCRIPT" --released "$RELEASED_DEFAULT" 0.16.0 "$DIR/z1.md" >/dev/null 2>&1
 check "inner shorter fence does not close the outer block" 0 $?
 INNER_KEPT=$(awk '/^````/{f=!f; next} f && $0 == "# Unreleased"' "$DIR/z1.md" | wc -l | tr -d ' ')
 [ "$INNER_KEPT" = "1" ]; check "the quadruple-fenced example survived promotion" 0 $?
@@ -248,18 +259,18 @@ grep -qxF "# v0.16.0" "$DIR/z1.md"; check "the real heading promoted past the ne
 # 30. a tilde fence is closed by tildes, never backticks — and an opening
 #     fence may carry an info string
 { echo "# Migrating"; echo; echo '~~~markdown'; echo '```'; echo "# v0.16.0"; echo '```'; echo '~~~'; echo; echo "# Unreleased"; echo; echo "# v0.15.0"; } > "$DIR/z2.md"
-bash "$SCRIPT" 0.16.0 "$DIR/z2.md" >/dev/null 2>&1
+bash "$SCRIPT" --released "$RELEASED_DEFAULT" 0.16.0 "$DIR/z2.md" >/dev/null 2>&1
 check "backticks inside a tilde fence stay content" 0 $?
 grep -qxF "# v0.16.0" "$DIR/z2.md"; check "promotion landed past the info-string fence" 0 $?
 
 # 31. an abandoned unshipped section cannot hide below a promoted target:
 #     the idempotent branch and the pending branch refuse it too
 fresh z3.md "# v0.17.0" "# v0.16.0" "# v0.15.0"
-PROMOTE_MIGRATING_RELEASED="0.15.0" bash "$SCRIPT" 0.17.0 "$DIR/z3.md" >/dev/null 2>&1
+bash "$SCRIPT" --released "0.15.0" 0.17.0 "$DIR/z3.md" >/dev/null 2>&1
 check "abandoned section below the promoted target refused" 1 $?
 fresh z4.md "# v0.17.0" "# v0.16.0" "# v0.15.0"
 cp "$DIR/z4.md" "$DIR/z4.before"
-PROMOTE_MIGRATING_RELEASED="0.15.0" bash "$SCRIPT" 0.18.0 "$DIR/z4.md" >/dev/null 2>&1
+bash "$SCRIPT" --released "0.15.0" 0.18.0 "$DIR/z4.md" >/dev/null 2>&1
 check "abandoned section below a pending re-promotion refused" 1 $?
 diff -q "$DIR/z4.md" "$DIR/z4.before" >/dev/null
 check "the pending refusal left the file untouched" 0 $?

--- a/scripts/test-promote-migrating.sh
+++ b/scripts/test-promote-migrating.sh
@@ -7,8 +7,7 @@ set -u
 SCRIPT="$(dirname "$0")/promote-migrating.sh"
 # Pin the current-version authority so the repo's real constant cannot leak
 # into scratch-file cases; individual cases override it to probe the gate.
-export PROMOTE_MIGRATING_CURRENT=0.1.0
-# Pin the released-versions authority too: the suite must not depend on the
+# Pin the shipped-releases authority: the suite must not depend on the
 # checkout's real tag state (CI checkouts are shallow and tagless).
 export PROMOTE_MIGRATING_RELEASED="0.14.0 0.15.0"
 DIR=$(mktemp -d)
@@ -85,7 +84,7 @@ bash "$SCRIPT" 0.9.0 "$DIR/h.md" >/dev/null 2>&1; check "promote refuses backwar
 
 # 13. a two-digit component beats a one-digit one (component-wise, not lexicographic)
 fresh i.md "# Unreleased" "# v0.9.0"
-bash "$SCRIPT" 0.10.0 "$DIR/i.md" >/dev/null 2>&1; check "0.10.0 is newer than 0.9.0" 0 $?
+PROMOTE_MIGRATING_RELEASED="0.9.0" bash "$SCRIPT" 0.10.0 "$DIR/i.md" >/dev/null 2>&1; check "0.10.0 is newer than 0.9.0" 0 $?
 grep -qxF "# v0.10.0" "$DIR/i.md"; check "0.10.0 promoted" 0 $?
 
 # 14. a misplaced "# Unreleased" below the promoted top is refused, both branches
@@ -93,17 +92,19 @@ fresh j.md "# v0.16.0" "# Unreleased" "# v0.15.0"
 bash "$SCRIPT" 0.16.0 "$DIR/j.md" >/dev/null 2>&1; check "idempotent branch refuses misplaced Unreleased" 1 $?
 bash "$SCRIPT" --check 0.16.1 "$DIR/j.md" >/dev/null 2>&1; check "no-notes branch refuses misplaced Unreleased" 1 $?
 
-# 15. the version constant, not the headings, is the rollback authority:
-#     after a no-notes release the newest heading lags the SDK version, and a
-#     bump between them must still refuse (the round-two P1)
+# 15. the shipped tags, not the headings or the constants, are the rollback
+#     authority: after a no-notes 0.16.0 release the newest heading lags, and
+#     a bump or a hand-edited --check between them must still refuse
 fresh k.md "# v0.15.0" "# v0.14.0"
-PROMOTE_MIGRATING_CURRENT=0.16.0 bash "$SCRIPT" 0.15.5 "$DIR/k.md" >/dev/null 2>&1
-check "no-notes bump below current SDK version refused" 1 $?
+PROMOTE_MIGRATING_RELEASED="0.15.0 0.16.0" bash "$SCRIPT" 0.15.5 "$DIR/k.md" >/dev/null 2>&1
+check "no-notes bump below the newest shipped release refused" 1 $?
 fresh l.md "# Unreleased" "# v0.15.0"
-PROMOTE_MIGRATING_CURRENT=0.16.0 bash "$SCRIPT" 0.15.5 "$DIR/l.md" >/dev/null 2>&1
-check "promote below current SDK version refused" 1 $?
-PROMOTE_MIGRATING_CURRENT=0.16.0 bash "$SCRIPT" --check 0.16.0 "$DIR/k.md" >/dev/null 2>&1
-check "--check at the current version still accepted" 0 $?
+PROMOTE_MIGRATING_RELEASED="0.15.0 0.16.0" bash "$SCRIPT" 0.15.5 "$DIR/l.md" >/dev/null 2>&1
+check "promote below the newest shipped release refused" 1 $?
+PROMOTE_MIGRATING_RELEASED="0.15.0 0.16.0" bash "$SCRIPT" --check 0.15.5 "$DIR/k.md" >/dev/null 2>&1
+check "hand-edited constants cannot sneak an unshipped rollback past --check" 1 $?
+PROMOTE_MIGRATING_RELEASED="0.15.0 0.16.0" bash "$SCRIPT" --check 0.16.5 "$DIR/k.md" >/dev/null 2>&1
+check "--check past the newest shipped release accepted" 0 $?
 
 # 16. more than one "# Unreleased" heading is refused before any mutation
 fresh m.md "# Unreleased" "# v0.15.0"
@@ -112,47 +113,49 @@ cp "$DIR/m.md" "$DIR/m.before"
 bash "$SCRIPT" 0.16.0 "$DIR/m.md" >/dev/null 2>&1; check "duplicate Unreleased refused" 1 $?
 diff -q "$DIR/m.md" "$DIR/m.before" >/dev/null; check "duplicate refusal leaves file untouched" 0 $?
 
-# 17. an unresolvable current version is fatal, not fail-open: a copy of the
-#     script outside the repo cannot find version.go
+# 17. an unobtainable shipped list is fatal, not fail-open: a copy of the
+#     script outside the repo has no origin to ask
 cp "$SCRIPT" "$DIR/stray-promote.sh"
 fresh n.md "# Unreleased" "# v0.15.0"
-env -u PROMOTE_MIGRATING_CURRENT bash "$DIR/stray-promote.sh" 0.16.0 "$DIR/n.md" >/dev/null 2>&1
-check "unreadable current version is fatal" 1 $?
+env -u PROMOTE_MIGRATING_RELEASED bash "$DIR/stray-promote.sh" 0.16.0 "$DIR/n.md" >/dev/null 2>&1
+check "unobtainable shipped list is fatal" 1 $?
 
 # 18. promoting NEW notes to the version already shipped is refused: after a
 #     no-notes 0.16.0 release, a fresh Unreleased belongs to a later release
 fresh o.md "# Unreleased" "# v0.15.0"
-PROMOTE_MIGRATING_CURRENT=0.16.0 bash "$SCRIPT" 0.16.0 "$DIR/o.md" >/dev/null 2>&1
+PROMOTE_MIGRATING_RELEASED="0.15.0 0.16.0" bash "$SCRIPT" 0.16.0 "$DIR/o.md" >/dev/null 2>&1
 check "equal-version promotion of new notes refused" 1 $?
 
 # 19. correcting a bump before commit re-promotes the pending heading (no tag
-#     names v0.99.0) instead of stranding its notes; --check refuses the same
-#     state instead of calling it no-notes
+#     names v0.99.0) instead of stranding its notes — in EITHER direction —
+#     and --check refuses the state instead of calling it no-notes
 fresh p.md "# v0.99.0" "# v0.15.0"
-PROMOTE_MIGRATING_CURRENT=0.99.0 bash "$SCRIPT" 0.99.1 "$DIR/p.md" >/dev/null 2>&1
+bash "$SCRIPT" 0.99.1 "$DIR/p.md" >/dev/null 2>&1
 check "pending heading re-promoted on corrected bump" 0 $?
 grep -qxF "# v0.99.1" "$DIR/p.md" && ! grep -qxF "# v0.99.0" "$DIR/p.md"
 check "pending heading renamed" 0 $?
+fresh p2.md "# v0.99.0" "# v0.15.0"
+bash "$SCRIPT" 0.17.0 "$DIR/p2.md" >/dev/null 2>&1
+check "pending heading re-promoted DOWNWARD to a still-forward target" 0 $?
+grep -qxF "# v0.17.0" "$DIR/p2.md" && ! grep -qxF "# v0.99.0" "$DIR/p2.md"
+check "downward correction renamed the heading" 0 $?
 fresh q.md "# v0.99.0" "# v0.15.0"
-PROMOTE_MIGRATING_CURRENT=0.99.0 bash "$SCRIPT" --check 0.99.1 "$DIR/q.md" >/dev/null 2>&1
+bash "$SCRIPT" --check 0.99.1 "$DIR/q.md" >/dev/null 2>&1
 check "--check refuses a pending unreleased heading" 1 $?
 
-# 20. a malformed current version is fatal WITH the authority diagnostic —
-#     the pre-fix script also exited 1 here, but only because the arithmetic
-#     error happened to land in the blocking direction; the contract is the
-#     explicit refusal, not a lucky error path
+# 20. a malformed target is refused with the format diagnostic
 fresh r.md "# Unreleased" "# v0.15.0"
-ERR=$(PROMOTE_MIGRATING_CURRENT=dev bash "$SCRIPT" 0.16.0 "$DIR/r.md" 2>&1 >/dev/null)
-check "malformed current version is fatal" 1 $?
-printf '%s' "$ERR" | grep -q "is not X.Y.Z"; check "refusal names the malformed authority" 0 $?
+ERR=$(bash "$SCRIPT" dev "$DIR/r.md" 2>&1 >/dev/null)
+check "malformed target version is fatal" 1 $?
+printf '%s' "$ERR" | grep -q "is not X.Y.Z"; check "refusal names the malformed target" 0 $?
 
 # 21. a checkout that knows no release tags fails closed when release status
 #     matters, instead of renaming real history as "pending"
 fresh s.md "# v0.15.0" "# v0.14.0"
-PROMOTE_MIGRATING_CURRENT=0.15.0 PROMOTE_MIGRATING_RELEASED= bash "$SCRIPT" 0.15.1 "$DIR/s.md" >/dev/null 2>&1
+PROMOTE_MIGRATING_RELEASED= bash "$SCRIPT" 0.15.1 "$DIR/s.md" >/dev/null 2>&1
 check "tagless checkout fails closed on the pending question" 1 $?
 cp "$DIR/s.md" "$DIR/s.before" 2>/dev/null
-PROMOTE_MIGRATING_CURRENT=0.15.0 PROMOTE_MIGRATING_RELEASED= bash "$SCRIPT" 0.15.1 "$DIR/s.md" >/dev/null 2>&1 || true
+PROMOTE_MIGRATING_RELEASED= bash "$SCRIPT" 0.15.1 "$DIR/s.md" >/dev/null 2>&1 || true
 diff -q "$DIR/s.md" "$DIR/s.before" >/dev/null; check "tagless refusal leaves the file untouched" 0 $?
 
 # 22. an already-tagged target cannot pass --check, whatever the headings say
@@ -176,21 +179,21 @@ git -C "$FIX" tag v0.6.0   # local only: never pushed
 FSCRIPT="$FIX/scripts/promote-migrating.sh"
 
 fresh t1.md "# v0.5.0" "# v0.4.0"
-env -u PROMOTE_MIGRATING_CURRENT -u PROMOTE_MIGRATING_RELEASED bash "$FSCRIPT" 0.6.1 "$DIR/t1.md" >/dev/null 2>&1
+env -u PROMOTE_MIGRATING_RELEASED bash "$FSCRIPT" 0.6.1 "$DIR/t1.md" >/dev/null 2>&1
 check "remote-present tag reads as released (real ls-remote)" 0 $?
 
 fresh t2.md "# v0.6.0" "# v0.5.0"
-env -u PROMOTE_MIGRATING_CURRENT -u PROMOTE_MIGRATING_RELEASED bash "$FSCRIPT" 0.6.1 "$DIR/t2.md" >/dev/null 2>&1
+env -u PROMOTE_MIGRATING_RELEASED bash "$FSCRIPT" 0.6.1 "$DIR/t2.md" >/dev/null 2>&1
 check "local-only tag reads as pending (re-promoted)" 0 $?
 grep -qxF "# v0.6.1" "$DIR/t2.md"; check "failed-push residue heading carried forward" 0 $?
 
 fresh t3.md "# v0.5.0" "# v0.4.0"
-env -u PROMOTE_MIGRATING_CURRENT -u PROMOTE_MIGRATING_RELEASED bash "$FSCRIPT" --check 0.5.0 "$DIR/t3.md" >/dev/null 2>&1
+env -u PROMOTE_MIGRATING_RELEASED bash "$FSCRIPT" --check 0.5.0 "$DIR/t3.md" >/dev/null 2>&1
 check "real remote refuses an already-tagged --check target" 1 $?
 
 git -C "$FIX" remote set-url origin "$DIR/no-such-origin.git"
 fresh t4.md "# v0.5.0" "# v0.4.0"
-env -u PROMOTE_MIGRATING_CURRENT -u PROMOTE_MIGRATING_RELEASED bash "$FSCRIPT" 0.6.1 "$DIR/t4.md" >/dev/null 2>&1
+env -u PROMOTE_MIGRATING_RELEASED bash "$FSCRIPT" 0.6.1 "$DIR/t4.md" >/dev/null 2>&1
 check "unreachable remote fails closed" 1 $?
 
 # 24. fenced examples are prose to a reader and NOTHING to the heading

--- a/scripts/test-promote-migrating.sh
+++ b/scripts/test-promote-migrating.sh
@@ -5,6 +5,9 @@
 # anywhere, so a historical heading waved a rolled-back bump through.
 set -u
 SCRIPT="$(dirname "$0")/promote-migrating.sh"
+# Pin the current-version authority so the repo's real constant cannot leak
+# into scratch-file cases; individual cases override it to probe the gate.
+export PROMOTE_MIGRATING_CURRENT=0.1.0
 DIR=$(mktemp -d)
 trap 'rm -rf "$DIR"' EXIT
 FAILS=0
@@ -84,6 +87,25 @@ grep -qxF "# v0.10.0" "$DIR/i.md"; check "0.10.0 promoted" 0 $?
 fresh j.md "# v0.16.0" "# Unreleased" "# v0.15.0"
 bash "$SCRIPT" 0.16.0 "$DIR/j.md" >/dev/null 2>&1; check "idempotent branch refuses misplaced Unreleased" 1 $?
 bash "$SCRIPT" --check 0.16.1 "$DIR/j.md" >/dev/null 2>&1; check "no-notes branch refuses misplaced Unreleased" 1 $?
+
+# 15. the version constant, not the headings, is the rollback authority:
+#     after a no-notes release the newest heading lags the SDK version, and a
+#     bump between them must still refuse (the round-two P1)
+fresh k.md "# v0.15.0" "# v0.14.0"
+PROMOTE_MIGRATING_CURRENT=0.16.0 bash "$SCRIPT" 0.15.5 "$DIR/k.md" >/dev/null 2>&1
+check "no-notes bump below current SDK version refused" 1 $?
+fresh l.md "# Unreleased" "# v0.15.0"
+PROMOTE_MIGRATING_CURRENT=0.16.0 bash "$SCRIPT" 0.15.5 "$DIR/l.md" >/dev/null 2>&1
+check "promote below current SDK version refused" 1 $?
+PROMOTE_MIGRATING_CURRENT=0.16.0 bash "$SCRIPT" --check 0.16.0 "$DIR/k.md" >/dev/null 2>&1
+check "--check at the current version still accepted" 0 $?
+
+# 16. more than one "# Unreleased" heading is refused before any mutation
+fresh m.md "# Unreleased" "# v0.15.0"
+printf '# Unreleased\n\nstray\n' >> "$DIR/m.md"
+cp "$DIR/m.md" "$DIR/m.before"
+bash "$SCRIPT" 0.16.0 "$DIR/m.md" >/dev/null 2>&1; check "duplicate Unreleased refused" 1 $?
+diff -q "$DIR/m.md" "$DIR/m.before" >/dev/null; check "duplicate refusal leaves file untouched" 0 $?
 
 if [ "$FAILS" -gt 0 ]; then
   echo "test-promote-migrating: $FAILS of $CASES assertions failed" >&2

--- a/scripts/test-promote-migrating.sh
+++ b/scripts/test-promote-migrating.sh
@@ -200,6 +200,13 @@ check "unreachable remote fails closed" 1 $?
 bash "$SCRIPT" 0.16.0 "$DIR/u.md" >/dev/null 2>&1; check "fenced headings are invisible to promotion" 0 $?
 grep -qxF "# v0.16.0" "$DIR/u.md"; check "promotion landed despite fenced examples" 0 $?
 
+# 25. a guide large enough that grep's early exit outruns the prose pass:
+#     under pipefail a piped judgment would report the producer's SIGPIPE as
+#     no-match and wave a rollback through; the captured-prose form must not
+{ echo "# Migrating"; echo; echo "# Unreleased"; echo; echo "# v0.14.0"; echo; for i in $(seq 1 8000); do echo "filler prose line $i to outlast the pipe buffer after the early match"; done; } > "$DIR/v.md"
+PROMOTE_MIGRATING_CURRENT=0.1.0 bash "$SCRIPT" 0.14.0 "$DIR/v.md" >/dev/null 2>&1
+check "duplicate target still refused on a large guide" 1 $?
+
 if [ "$FAILS" -gt 0 ]; then
   echo "test-promote-migrating: $FAILS of $CASES assertions failed" >&2
   exit 1

--- a/scripts/test-promote-migrating.sh
+++ b/scripts/test-promote-migrating.sh
@@ -8,6 +8,9 @@ SCRIPT="$(dirname "$0")/promote-migrating.sh"
 # Pin the current-version authority so the repo's real constant cannot leak
 # into scratch-file cases; individual cases override it to probe the gate.
 export PROMOTE_MIGRATING_CURRENT=0.1.0
+# Pin the released-versions authority too: the suite must not depend on the
+# checkout's real tag state (CI checkouts are shallow and tagless).
+export PROMOTE_MIGRATING_RELEASED="0.14.0 0.15.0 0.16.0"
 DIR=$(mktemp -d)
 trap 'rm -rf "$DIR"' EXIT
 FAILS=0
@@ -133,6 +136,24 @@ check "pending heading renamed" 0 $?
 fresh q.md "# v0.99.0" "# v0.15.0"
 PROMOTE_MIGRATING_CURRENT=0.99.0 bash "$SCRIPT" --check 0.99.1 "$DIR/q.md" >/dev/null 2>&1
 check "--check refuses a pending unreleased heading" 1 $?
+
+# 20. a malformed current version is fatal WITH the authority diagnostic —
+#     the pre-fix script also exited 1 here, but only because the arithmetic
+#     error happened to land in the blocking direction; the contract is the
+#     explicit refusal, not a lucky error path
+fresh r.md "# Unreleased" "# v0.15.0"
+ERR=$(PROMOTE_MIGRATING_CURRENT=dev bash "$SCRIPT" 0.16.0 "$DIR/r.md" 2>&1 >/dev/null)
+check "malformed current version is fatal" 1 $?
+printf '%s' "$ERR" | grep -q "is not X.Y.Z"; check "refusal names the malformed authority" 0 $?
+
+# 21. a checkout that knows no release tags fails closed when release status
+#     matters, instead of renaming real history as "pending"
+fresh s.md "# v0.15.0" "# v0.14.0"
+PROMOTE_MIGRATING_CURRENT=0.15.0 PROMOTE_MIGRATING_RELEASED= bash "$SCRIPT" 0.15.1 "$DIR/s.md" >/dev/null 2>&1
+check "tagless checkout fails closed on the pending question" 1 $?
+cp "$DIR/s.md" "$DIR/s.before" 2>/dev/null
+PROMOTE_MIGRATING_CURRENT=0.15.0 PROMOTE_MIGRATING_RELEASED= bash "$SCRIPT" 0.15.1 "$DIR/s.md" >/dev/null 2>&1 || true
+diff -q "$DIR/s.md" "$DIR/s.before" >/dev/null; check "tagless refusal leaves the file untouched" 0 $?
 
 if [ "$FAILS" -gt 0 ]; then
   echo "test-promote-migrating: $FAILS of $CASES assertions failed" >&2

--- a/scripts/test-promote-migrating.sh
+++ b/scripts/test-promote-migrating.sh
@@ -71,6 +71,20 @@ bash "$SCRIPT" --check 0.15.0 "$DIR/f.md" >/dev/null 2>&1; check "--check refuse
 { echo "# Migrating"; echo; echo "# v0.16.0"; echo; echo '```'; echo "# v0.12.0"; echo '```'; } > "$DIR/g.md"
 bash "$SCRIPT" --check 0.16.0 "$DIR/g.md" >/dev/null 2>&1; check "quoted old heading below top ignored" 0 $?
 
+# 12. promote refuses a target older than the newest released section
+fresh h.md "# Unreleased" "# v0.15.0"
+bash "$SCRIPT" 0.9.0 "$DIR/h.md" >/dev/null 2>&1; check "promote refuses backward target" 1 $?
+
+# 13. a two-digit component beats a one-digit one (component-wise, not lexicographic)
+fresh i.md "# Unreleased" "# v0.9.0"
+bash "$SCRIPT" 0.10.0 "$DIR/i.md" >/dev/null 2>&1; check "0.10.0 is newer than 0.9.0" 0 $?
+grep -qxF "# v0.10.0" "$DIR/i.md"; check "0.10.0 promoted" 0 $?
+
+# 14. a misplaced "# Unreleased" below the promoted top is refused, both branches
+fresh j.md "# v0.16.0" "# Unreleased" "# v0.15.0"
+bash "$SCRIPT" 0.16.0 "$DIR/j.md" >/dev/null 2>&1; check "idempotent branch refuses misplaced Unreleased" 1 $?
+bash "$SCRIPT" --check 0.16.1 "$DIR/j.md" >/dev/null 2>&1; check "no-notes branch refuses misplaced Unreleased" 1 $?
+
 if [ "$FAILS" -gt 0 ]; then
   echo "test-promote-migrating: $FAILS of $CASES assertions failed" >&2
   exit 1

--- a/scripts/test-promote-migrating.sh
+++ b/scripts/test-promote-migrating.sh
@@ -10,7 +10,7 @@ SCRIPT="$(dirname "$0")/promote-migrating.sh"
 export PROMOTE_MIGRATING_CURRENT=0.1.0
 # Pin the released-versions authority too: the suite must not depend on the
 # checkout's real tag state (CI checkouts are shallow and tagless).
-export PROMOTE_MIGRATING_RELEASED="0.14.0 0.15.0 0.16.0"
+export PROMOTE_MIGRATING_RELEASED="0.14.0 0.15.0"
 DIR=$(mktemp -d)
 trap 'rm -rf "$DIR"' EXIT
 FAILS=0
@@ -154,6 +154,44 @@ check "tagless checkout fails closed on the pending question" 1 $?
 cp "$DIR/s.md" "$DIR/s.before" 2>/dev/null
 PROMOTE_MIGRATING_CURRENT=0.15.0 PROMOTE_MIGRATING_RELEASED= bash "$SCRIPT" 0.15.1 "$DIR/s.md" >/dev/null 2>&1 || true
 diff -q "$DIR/s.md" "$DIR/s.before" >/dev/null; check "tagless refusal leaves the file untouched" 0 $?
+
+# 22. an already-tagged target cannot pass --check, whatever the headings say
+fresh t0.md "# v0.15.0" "# v0.14.0"
+bash "$SCRIPT" --check 0.15.0 "$DIR/t0.md" >/dev/null 2>&1
+check "--check refuses an already-tagged target" 1 $?
+
+# 23. the real remote-authority paths, exercised against a file:// origin —
+#     no overrides, so the script's own git ls-remote runs. A tag pushed to
+#     the origin is released; a LOCAL-ONLY tag (the residue of a release
+#     whose tag push failed) is not; an unreachable origin fails closed.
+FIX="$DIR/fixture-repo"; ORIGIN="$DIR/origin.git"
+git init -q --bare "$ORIGIN"
+git init -q "$FIX" && git -C "$FIX" remote add origin "$ORIGIN"
+mkdir -p "$FIX/scripts" "$FIX/go/pkg/basecamp"
+cp "$SCRIPT" "$FIX/scripts/promote-migrating.sh"
+printf 'package basecamp\n\nconst Version = "0.6.0"\n' > "$FIX/go/pkg/basecamp/version.go"
+git -C "$FIX" -c user.email=t@t -c user.name=t commit -q --allow-empty -m fixture
+git -C "$FIX" tag v0.5.0 && git -C "$FIX" push -q origin v0.5.0
+git -C "$FIX" tag v0.6.0   # local only: never pushed
+FSCRIPT="$FIX/scripts/promote-migrating.sh"
+
+fresh t1.md "# v0.5.0" "# v0.4.0"
+env -u PROMOTE_MIGRATING_CURRENT -u PROMOTE_MIGRATING_RELEASED bash "$FSCRIPT" 0.6.1 "$DIR/t1.md" >/dev/null 2>&1
+check "remote-present tag reads as released (real ls-remote)" 0 $?
+
+fresh t2.md "# v0.6.0" "# v0.5.0"
+env -u PROMOTE_MIGRATING_CURRENT -u PROMOTE_MIGRATING_RELEASED bash "$FSCRIPT" 0.6.1 "$DIR/t2.md" >/dev/null 2>&1
+check "local-only tag reads as pending (re-promoted)" 0 $?
+grep -qxF "# v0.6.1" "$DIR/t2.md"; check "failed-push residue heading carried forward" 0 $?
+
+fresh t3.md "# v0.5.0" "# v0.4.0"
+env -u PROMOTE_MIGRATING_CURRENT -u PROMOTE_MIGRATING_RELEASED bash "$FSCRIPT" --check 0.5.0 "$DIR/t3.md" >/dev/null 2>&1
+check "real remote refuses an already-tagged --check target" 1 $?
+
+git -C "$FIX" remote set-url origin "$DIR/no-such-origin.git"
+fresh t4.md "# v0.5.0" "# v0.4.0"
+env -u PROMOTE_MIGRATING_CURRENT -u PROMOTE_MIGRATING_RELEASED bash "$FSCRIPT" 0.6.1 "$DIR/t4.md" >/dev/null 2>&1
+check "unreachable remote fails closed" 1 $?
 
 if [ "$FAILS" -gt 0 ]; then
   echo "test-promote-migrating: $FAILS of $CASES assertions failed" >&2

--- a/scripts/test-promote-migrating.sh
+++ b/scripts/test-promote-migrating.sh
@@ -96,14 +96,14 @@ bash "$SCRIPT" --check 0.16.1 "$DIR/j.md" >/dev/null 2>&1; check "no-notes branc
 #     authority: after a no-notes 0.16.0 release the newest heading lags, and
 #     a bump or a hand-edited --check between them must still refuse
 fresh k.md "# v0.15.0" "# v0.14.0"
-PROMOTE_MIGRATING_RELEASED="0.15.0 0.16.0" bash "$SCRIPT" 0.15.5 "$DIR/k.md" >/dev/null 2>&1
+PROMOTE_MIGRATING_RELEASED="0.14.0 0.15.0 0.16.0" bash "$SCRIPT" 0.15.5 "$DIR/k.md" >/dev/null 2>&1
 check "no-notes bump below the newest shipped release refused" 1 $?
 fresh l.md "# Unreleased" "# v0.15.0"
-PROMOTE_MIGRATING_RELEASED="0.15.0 0.16.0" bash "$SCRIPT" 0.15.5 "$DIR/l.md" >/dev/null 2>&1
+PROMOTE_MIGRATING_RELEASED="0.14.0 0.15.0 0.16.0" bash "$SCRIPT" 0.15.5 "$DIR/l.md" >/dev/null 2>&1
 check "promote below the newest shipped release refused" 1 $?
-PROMOTE_MIGRATING_RELEASED="0.15.0 0.16.0" bash "$SCRIPT" --check 0.15.5 "$DIR/k.md" >/dev/null 2>&1
+PROMOTE_MIGRATING_RELEASED="0.14.0 0.15.0 0.16.0" bash "$SCRIPT" --check 0.15.5 "$DIR/k.md" >/dev/null 2>&1
 check "hand-edited constants cannot sneak an unshipped rollback past --check" 1 $?
-PROMOTE_MIGRATING_RELEASED="0.15.0 0.16.0" bash "$SCRIPT" --check 0.16.5 "$DIR/k.md" >/dev/null 2>&1
+PROMOTE_MIGRATING_RELEASED="0.14.0 0.15.0 0.16.0" bash "$SCRIPT" --check 0.16.5 "$DIR/k.md" >/dev/null 2>&1
 check "--check past the newest shipped release accepted" 0 $?
 
 # 16. more than one "# Unreleased" heading is refused before any mutation
@@ -123,7 +123,7 @@ check "unobtainable shipped list is fatal" 1 $?
 # 18. promoting NEW notes to the version already shipped is refused: after a
 #     no-notes 0.16.0 release, a fresh Unreleased belongs to a later release
 fresh o.md "# Unreleased" "# v0.15.0"
-PROMOTE_MIGRATING_RELEASED="0.15.0 0.16.0" bash "$SCRIPT" 0.16.0 "$DIR/o.md" >/dev/null 2>&1
+PROMOTE_MIGRATING_RELEASED="0.14.0 0.15.0 0.16.0" bash "$SCRIPT" 0.16.0 "$DIR/o.md" >/dev/null 2>&1
 check "equal-version promotion of new notes refused" 1 $?
 
 # 19. correcting a bump before commit re-promotes the pending heading (no tag
@@ -174,7 +174,7 @@ mkdir -p "$FIX/scripts" "$FIX/go/pkg/basecamp"
 cp "$SCRIPT" "$FIX/scripts/promote-migrating.sh"
 printf 'package basecamp\n\nconst Version = "0.6.0"\n' > "$FIX/go/pkg/basecamp/version.go"
 git -C "$FIX" -c user.email=t@t -c user.name=t commit -q --allow-empty -m fixture
-git -C "$FIX" tag v0.5.0 && git -C "$FIX" push -q origin v0.5.0
+git -C "$FIX" tag v0.4.0 && git -C "$FIX" tag v0.5.0 && git -C "$FIX" push -q origin v0.4.0 v0.5.0
 git -C "$FIX" tag v0.6.0   # local only: never pushed
 FSCRIPT="$FIX/scripts/promote-migrating.sh"
 
@@ -233,6 +233,36 @@ grep -qxF "# v0.16.0" "$DIR/x.md"; check "real heading became the version" 0 $?
 bash "$SCRIPT" 0.16.0 "$DIR/y.md" >/dev/null 2>&1
 check "tilde and indented fences are invisible to the judgments" 0 $?
 grep -qxF "# v0.16.0" "$DIR/y.md"; check "promotion landed past exotic fences" 0 $?
+
+# 29. CommonMark closes a fence only with the SAME delimiter at >= the
+#     opening length and no info string: a ``` line inside a ```` block is
+#     content, so a heading between them must stay hidden and the block must
+#     not "close early" and expose it to the judgments or the rewrites
+{ echo "# Migrating"; echo; echo '````'; echo '```'; echo "# Unreleased"; echo '```'; echo '````'; echo; echo "# Unreleased"; echo; echo "# v0.15.0"; } > "$DIR/z1.md"
+bash "$SCRIPT" 0.16.0 "$DIR/z1.md" >/dev/null 2>&1
+check "inner shorter fence does not close the outer block" 0 $?
+INNER_KEPT=$(awk '/^````/{f=!f; next} f && $0 == "# Unreleased"' "$DIR/z1.md" | wc -l | tr -d ' ')
+[ "$INNER_KEPT" = "1" ]; check "the quadruple-fenced example survived promotion" 0 $?
+grep -qxF "# v0.16.0" "$DIR/z1.md"; check "the real heading promoted past the nested block" 0 $?
+
+# 30. a tilde fence is closed by tildes, never backticks — and an opening
+#     fence may carry an info string
+{ echo "# Migrating"; echo; echo '~~~markdown'; echo '```'; echo "# v0.16.0"; echo '```'; echo '~~~'; echo; echo "# Unreleased"; echo; echo "# v0.15.0"; } > "$DIR/z2.md"
+bash "$SCRIPT" 0.16.0 "$DIR/z2.md" >/dev/null 2>&1
+check "backticks inside a tilde fence stay content" 0 $?
+grep -qxF "# v0.16.0" "$DIR/z2.md"; check "promotion landed past the info-string fence" 0 $?
+
+# 31. an abandoned unshipped section cannot hide below a promoted target:
+#     the idempotent branch and the pending branch refuse it too
+fresh z3.md "# v0.17.0" "# v0.16.0" "# v0.15.0"
+PROMOTE_MIGRATING_RELEASED="0.15.0" bash "$SCRIPT" 0.17.0 "$DIR/z3.md" >/dev/null 2>&1
+check "abandoned section below the promoted target refused" 1 $?
+fresh z4.md "# v0.17.0" "# v0.16.0" "# v0.15.0"
+cp "$DIR/z4.md" "$DIR/z4.before"
+PROMOTE_MIGRATING_RELEASED="0.15.0" bash "$SCRIPT" 0.18.0 "$DIR/z4.md" >/dev/null 2>&1
+check "abandoned section below a pending re-promotion refused" 1 $?
+diff -q "$DIR/z4.md" "$DIR/z4.before" >/dev/null
+check "the pending refusal left the file untouched" 0 $?
 
 if [ "$FAILS" -gt 0 ]; then
   echo "test-promote-migrating: $FAILS of $CASES assertions failed" >&2

--- a/scripts/test-promote-migrating.sh
+++ b/scripts/test-promote-migrating.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# Self-test for scripts/promote-migrating.sh. Each case builds a scratch file,
+# runs the script, and asserts exit code plus resulting state. The backward-
+# bump cases are the point: the first version of this script matched "# vX"
+# anywhere, so a historical heading waved a rolled-back bump through.
+set -u
+SCRIPT="$(dirname "$0")/promote-migrating.sh"
+DIR=$(mktemp -d)
+trap 'rm -rf "$DIR"' EXIT
+FAILS=0
+CASES=0
+
+check() { # check <desc> <want_exit> <got_exit>
+  CASES=$((CASES + 1))
+  if [ "$2" != "$3" ]; then
+    echo "FAIL: $1 (want exit $2, got $3)" >&2
+    FAILS=$((FAILS + 1))
+  fi
+}
+
+fresh() { # fresh <file> <headings...>
+  local f="$DIR/$1"; shift
+  { echo "# Migrating"; echo; for h in "$@"; do echo "$h"; echo; echo "body"; echo; done; } > "$f"
+}
+
+# 1. promote: Unreleased at top becomes the version heading
+fresh a.md "# Unreleased" "# v0.15.0"
+bash "$SCRIPT" 0.16.0 "$DIR/a.md" >/dev/null 2>&1; check "promote happy path" 0 $?
+grep -qxF "# v0.16.0" "$DIR/a.md" && ! grep -qxF "# Unreleased" "$DIR/a.md"
+check "heading replaced" 0 $?
+
+# 2. idempotent second run, file unchanged
+cp "$DIR/a.md" "$DIR/a.before"
+bash "$SCRIPT" 0.16.0 "$DIR/a.md" >/dev/null 2>&1; check "idempotent rerun" 0 $?
+diff -q "$DIR/a.md" "$DIR/a.before" >/dev/null; check "idempotent leaves file untouched" 0 $?
+
+# 3. THE regression: backward bump to a version whose heading exists historically
+fresh b.md "# v0.15.0" "# v0.14.0"
+bash "$SCRIPT" 0.14.0 "$DIR/b.md" >/dev/null 2>&1; check "backward bump to historical heading refused" 1 $?
+
+# 4. backward bump refused even without a matching historical heading
+bash "$SCRIPT" 0.14.9 "$DIR/b.md" >/dev/null 2>&1; check "backward bump without heading refused" 1 $?
+
+# 5. no-notes forward release accepted, file untouched
+cp "$DIR/b.md" "$DIR/b.before"
+bash "$SCRIPT" 0.15.1 "$DIR/b.md" >/dev/null 2>&1; check "no-notes forward release accepted" 0 $?
+diff -q "$DIR/b.md" "$DIR/b.before" >/dev/null; check "no-notes leaves file untouched" 0 $?
+
+# 6. Unreleased plus an existing target heading is a rollback, refused
+fresh c.md "# Unreleased" "# v0.16.0" "# v0.15.0"
+bash "$SCRIPT" 0.16.0 "$DIR/c.md" >/dev/null 2>&1; check "duplicate target heading refused" 1 $?
+
+# 7. no release heading at all
+printf '# Migrating\n\nprose only\n' > "$DIR/d.md"
+bash "$SCRIPT" 0.16.0 "$DIR/d.md" >/dev/null 2>&1; check "headingless file refused" 1 $?
+
+# 8. --check refuses an unpromoted Unreleased
+fresh e.md "# Unreleased" "# v0.15.0"
+bash "$SCRIPT" --check 0.16.0 "$DIR/e.md" >/dev/null 2>&1; check "--check refuses unpromoted notes" 1 $?
+
+# 9. --check accepts the promoted top heading
+fresh f.md "# v0.16.0" "# v0.15.0"
+bash "$SCRIPT" --check 0.16.0 "$DIR/f.md" >/dev/null 2>&1; check "--check accepts promoted heading" 0 $?
+
+# 10. --check accepts no-notes forward, refuses backward
+bash "$SCRIPT" --check 0.16.1 "$DIR/f.md" >/dev/null 2>&1; check "--check accepts no-notes forward" 0 $?
+bash "$SCRIPT" --check 0.15.0 "$DIR/f.md" >/dev/null 2>&1; check "--check refuses backward release" 1 $?
+
+# 11. a code-block heading below the newest section does not confuse the
+#     first-heading scan (the guide quotes old headings in fences)
+{ echo "# Migrating"; echo; echo "# v0.16.0"; echo; echo '```'; echo "# v0.12.0"; echo '```'; } > "$DIR/g.md"
+bash "$SCRIPT" --check 0.16.0 "$DIR/g.md" >/dev/null 2>&1; check "quoted old heading below top ignored" 0 $?
+
+if [ "$FAILS" -gt 0 ]; then
+  echo "test-promote-migrating: $FAILS of $CASES assertions failed" >&2
+  exit 1
+fi
+echo "test-promote-migrating: passed — $CASES assertions."

--- a/scripts/test-promote-migrating.sh
+++ b/scripts/test-promote-migrating.sh
@@ -179,8 +179,11 @@ git -C "$FIX" tag v0.6.0   # local only: never pushed
 FSCRIPT="$FIX/scripts/promote-migrating.sh"
 
 fresh t1.md "# v0.5.0" "# v0.4.0"
+cp "$DIR/t1.md" "$DIR/t1.before"
 env -u PROMOTE_MIGRATING_RELEASED bash "$FSCRIPT" 0.6.1 "$DIR/t1.md" >/dev/null 2>&1
 check "remote-present tag reads as released (real ls-remote)" 0 $?
+diff -q "$DIR/t1.md" "$DIR/t1.before" >/dev/null
+check "released heading took the no-notes path without mutation" 0 $?
 
 fresh t2.md "# v0.6.0" "# v0.5.0"
 env -u PROMOTE_MIGRATING_RELEASED bash "$FSCRIPT" 0.6.1 "$DIR/t2.md" >/dev/null 2>&1
@@ -207,7 +210,7 @@ grep -qxF "# v0.16.0" "$DIR/u.md"; check "promotion landed despite fenced exampl
 #     under pipefail a piped judgment would report the producer's SIGPIPE as
 #     no-match and wave a rollback through; the captured-prose form must not
 { echo "# Migrating"; echo; echo "# Unreleased"; echo; echo "# v0.16.0"; echo; for i in $(seq 1 8000); do echo "filler prose line $i to outlast the pipe buffer after the early match"; done; } > "$DIR/v.md"
-PROMOTE_MIGRATING_RELEASED="0.15.0 0.16.0" bash "$SCRIPT" 0.16.0 "$DIR/v.md" >/dev/null 2>&1
+PROMOTE_MIGRATING_RELEASED="0.15.0" bash "$SCRIPT" 0.16.0 "$DIR/v.md" >/dev/null 2>&1
 check "duplicate target still refused on a large guide" 1 $?
 
 # 26. an abandoned unshipped section below a fresh Unreleased is refused
@@ -224,6 +227,12 @@ check "promotion with a leading fenced example succeeds" 0 $?
 FENCED_KEPT=$(awk '/^```/{f=!f; next} f && $0 == "# Unreleased"' "$DIR/x.md" | wc -l | tr -d ' ')
 [ "$FENCED_KEPT" = "1" ]; check "the fenced example survived; the real heading promoted" 0 $?
 grep -qxF "# v0.16.0" "$DIR/x.md"; check "real heading became the version" 0 $?
+
+# 28. tilde and indented fences are fences too
+{ echo "# Migrating"; echo; echo "~~~"; echo "# Unreleased"; echo "~~~"; echo; echo "   \`\`\`"; echo "# v0.16.0"; echo "   \`\`\`"; echo; echo "# Unreleased"; echo; echo "# v0.15.0"; } > "$DIR/y.md"
+bash "$SCRIPT" 0.16.0 "$DIR/y.md" >/dev/null 2>&1
+check "tilde and indented fences are invisible to the judgments" 0 $?
+grep -qxF "# v0.16.0" "$DIR/y.md"; check "promotion landed past exotic fences" 0 $?
 
 if [ "$FAILS" -gt 0 ]; then
   echo "test-promote-migrating: $FAILS of $CASES assertions failed" >&2

--- a/scripts/test-promote-migrating.sh
+++ b/scripts/test-promote-migrating.sh
@@ -206,9 +206,24 @@ grep -qxF "# v0.16.0" "$DIR/u.md"; check "promotion landed despite fenced exampl
 # 25. a guide large enough that grep's early exit outruns the prose pass:
 #     under pipefail a piped judgment would report the producer's SIGPIPE as
 #     no-match and wave a rollback through; the captured-prose form must not
-{ echo "# Migrating"; echo; echo "# Unreleased"; echo; echo "# v0.14.0"; echo; for i in $(seq 1 8000); do echo "filler prose line $i to outlast the pipe buffer after the early match"; done; } > "$DIR/v.md"
-PROMOTE_MIGRATING_CURRENT=0.1.0 bash "$SCRIPT" 0.14.0 "$DIR/v.md" >/dev/null 2>&1
+{ echo "# Migrating"; echo; echo "# Unreleased"; echo; echo "# v0.16.0"; echo; for i in $(seq 1 8000); do echo "filler prose line $i to outlast the pipe buffer after the early match"; done; } > "$DIR/v.md"
+PROMOTE_MIGRATING_RELEASED="0.15.0 0.16.0" bash "$SCRIPT" 0.16.0 "$DIR/v.md" >/dev/null 2>&1
 check "duplicate target still refused on a large guide" 1 $?
+
+# 26. an abandoned unshipped section below a fresh Unreleased is refused
+#     before promotion can orphan its notes forever
+fresh w.md "# Unreleased" "# v0.16.0" "# v0.15.0"
+PROMOTE_MIGRATING_RELEASED="0.15.0" bash "$SCRIPT" 0.17.0 "$DIR/w.md" >/dev/null 2>&1
+check "abandoned unshipped section refused" 1 $?
+
+# 27. the rewrite passes skip fences too: a fenced "# Unreleased" BEFORE the
+#     real section must survive promotion untouched
+{ echo "# Migrating"; echo; echo '```'; echo "# Unreleased"; echo '```'; echo; echo "# Unreleased"; echo; echo "# v0.15.0"; } > "$DIR/x.md"
+bash "$SCRIPT" 0.16.0 "$DIR/x.md" >/dev/null 2>&1
+check "promotion with a leading fenced example succeeds" 0 $?
+FENCED_KEPT=$(awk '/^```/{f=!f; next} f && $0 == "# Unreleased"' "$DIR/x.md" | wc -l | tr -d ' ')
+[ "$FENCED_KEPT" = "1" ]; check "the fenced example survived; the real heading promoted" 0 $?
+grep -qxF "# v0.16.0" "$DIR/x.md"; check "real heading became the version" 0 $?
 
 if [ "$FAILS" -gt 0 ]; then
   echo "test-promote-migrating: $FAILS of $CASES assertions failed" >&2


### PR DESCRIPTION
Repairs the release-guard regression #808 shipped, flagged by Copilot's final-head review ([suppressed block](https://github.com/basecamp/basecamp-sdk/pull/808#pullrequestreview-4999852730)) 26 minutes before the merge and not absorbed — the review discipline failed, not the reviewer. All three suppressed findings taken:

1. **The historical-heading bypass (the dangerous one).** The tagged `promote-migrating.sh` matched `# v$VERSION` anywhere in MIGRATING.md, so after v0.15.0's promotion, `make bump VERSION=0.14.0` found the *historical* v0.14.0 heading, reported "already promoted", and rewrote every version file backward; `make release` used the same global grep and would have pushed the rollback to `main` before failing on the existing tag. The script now resolves the current release heading as the **first** release heading in the file, with a closed verdict set: promote / idempotent no-op / no-notes forward release (succeed, untouched) / backward release (refuse) / rollback-duplicate (refuse). `make release` calls `--check` mode instead of the two global greps.

2. **The no-notes release aborted mid-bump.** A release with nothing migration-worthy legitimately has neither heading (the guide's one-section-per-release-that-breaks-something convention); the old script errored on it — after the version files were already rewritten. The no-notes forward case now succeeds explicitly, and the promotion runs as bump step 0, before any file is touched, so every refusal aborts with a clean tree.

3. **The tagged trailer pointed at a removed heading.** "Every change the `# Unreleased` section describes…" — promotion renames that heading, so the v0.15.0 guide referenced a section that no longer existed. Now release-neutral ("the newest release section above").

**Proofs.** `scripts/test-promote-migrating.sh`: 15 assertions covering every verdict, including a fence-quoted-heading case; wired into `check-targets` **and** its own CI step (check-targets membership alone is not CI coverage in this repo). Mutation proof: the self-test run against the tagged script fails 5 assertions — the backward-bump regression first among them — then passes 15/15 restored. `make release VERSION=0.15.0` on this branch prints the idempotent verdict and proceeds to the expected dirty-tree stop, proving the `--check` wiring executes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resolves the release heading from the top of MIGRATING.md and blocks rollbacks by using the remote tag list as the only ordering authority. Old behavior matched any historical “# vX.Y.Z”; new behavior treats the first release heading as current and requires the target to be strictly newer than the newest shipped tag.

- Heading checks and rewrites read prose only with a CommonMark-correct fence parser, so fenced examples never count.
- Refuses multiple or misplaced “# Unreleased”, rejects any abandoned unshipped section, and re‑promotes pending headings instead of orphaning notes.
- --check refuses already-tagged targets, and all paths fail closed when the remote cannot be reached.
- Promotion runs before version bumps; a .PHONY self-test is wired into check-targets; CI runs make test-promote-migrating.
- The self-test pins shipped versions via a --released argument; environment overrides are ignored to prevent inheriting stale lists.
- The self-test exercises live file:// remotes (remote-present, local-only, unreachable), large-guide SIGPIPE nets, and exotic fences.
- MIGRATING.md’s trailer names the v0.15.0 section directly.

<sup>Written for commit 19cedba4020187ef15e3f052d7c7deeba75e1f96. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-sdk/pull/812?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

