### PR TITLE
fix(projects): pin the ListProjects status wire contract, "active" included

### DIFF
--- a/go/README.md
+++ b/go/README.md
@@ -154,10 +154,8 @@ func main() {
     // Create an account-scoped client
     account := client.ForAccount(fmt.Sprint(info.Accounts[0].ID))
 
-    // List active projects
-    result, err := account.Projects().List(context.Background(), &basecamp.ProjectListOptions{
-        Status: basecamp.ProjectStatusActive,
-    })
+    // List projects (active by default; filter with ProjectStatusArchived/Trashed)
+    result, err := account.Projects().List(context.Background(), nil)
     if err != nil {
         log.Fatal(err)
     }

--- a/go/pkg/basecamp/projects_test.go
+++ b/go/pkg/basecamp/projects_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"path/filepath"
 	"testing"
@@ -272,6 +273,49 @@ func testProjectsServer(t *testing.T, handler http.HandlerFunc) *ProjectsService
 	client := NewClient(cfg, token)
 	account := client.ForAccount("99999")
 	return account.Projects()
+}
+
+// TestProjectsService_ListStatusFilter pins the ListProjects status semantics:
+// any explicit Status — active included, an alias of the default the server
+// accepts — is forwarded, and an empty Status sends no status param at all.
+func TestProjectsService_ListStatusFilter(t *testing.T) {
+	fixture := loadFixture(t, "list.json")
+
+	cases := []struct {
+		name string
+		opts *ProjectListOptions
+		want string // expected status query value; "" means the param must be absent
+	}{
+		{name: "nil options omit the param", opts: nil, want: ""},
+		{name: "empty status omits the param", opts: &ProjectListOptions{}, want: ""},
+		{name: "active is forwarded", opts: &ProjectListOptions{Status: ProjectStatusActive}, want: "active"},
+		{name: "archived is forwarded", opts: &ProjectListOptions{Status: ProjectStatusArchived}, want: "archived"},
+		{name: "trashed is forwarded", opts: &ProjectListOptions{Status: ProjectStatusTrashed}, want: "trashed"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var query url.Values
+			svc := testProjectsServer(t, func(w http.ResponseWriter, r *http.Request) {
+				query = r.URL.Query()
+				w.Header().Set("Content-Type", "application/json")
+				w.WriteHeader(200)
+				w.Write(fixture)
+			})
+
+			if _, err := svc.List(context.Background(), tc.opts); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if tc.want == "" {
+				if query.Has("status") {
+					t.Errorf("expected status to be absent, got %q", query.Get("status"))
+				}
+			} else if got := query.Get("status"); got != tc.want {
+				t.Errorf("expected status=%q, got %q", tc.want, got)
+			}
+		})
+	}
 }
 
 func TestProjectsService_UpdatePartial(t *testing.T) {

--- a/python/tests/services/test_projects.py
+++ b/python/tests/services/test_projects.py
@@ -71,6 +71,42 @@ class TestProjects:
         assert projects[0]["start_date"] == "2024-01-01"
         assert projects[0]["end_date"] == "2024-03-31"
 
+    @respx.mock
+    def test_list_projects_forwards_archived_status_filter(self):
+        route = respx.get(f"{BASE}/projects.json", params={"status": "archived"}).mock(
+            return_value=httpx.Response(200, json=[])
+        )
+
+        client, account = make_account()
+        account.projects.list(status="archived")
+        client.close()
+
+        assert route.call_count == 1
+
+    @respx.mock
+    def test_list_projects_forwards_explicit_active_status(self):
+        # active is a server-accepted alias of the unfiltered default.
+        route = respx.get(f"{BASE}/projects.json", params={"status": "active"}).mock(
+            return_value=httpx.Response(200, json=[])
+        )
+
+        client, account = make_account()
+        account.projects.list(status="active")
+        client.close()
+
+        assert route.call_count == 1
+
+    @respx.mock
+    def test_list_projects_default_sends_no_status_param(self):
+        route = respx.get(f"{BASE}/projects.json").mock(return_value=httpx.Response(200, json=[]))
+
+        client, account = make_account()
+        account.projects.list()
+        client.close()
+
+        assert route.call_count == 1
+        assert "status" not in route.calls.last.request.url.params
+
 
 PROJECT_LIMIT_BODY = {"error": "The project limit for this account has been reached."}
 

--- a/ruby/test/basecamp/services/projects_service_test.rb
+++ b/ruby/test/basecamp/services/projects_service_test.rb
@@ -46,6 +46,17 @@ class ProjectsServiceTest < Minitest::Test
     assert_equal 1, projects.length
   end
 
+  def test_list_projects_forwards_explicit_active_status
+    # active is a server-accepted alias of the unfiltered default.
+    stub_request(:get, "https://3.basecampapi.com/12345/projects.json")
+      .with(query: { status: "active" })
+      .to_return(status: 200, body: [ sample_project ].to_json)
+
+    projects = @account.projects.list(status: "active").to_a
+
+    assert_equal 1, projects.length
+  end
+
   def test_get_project
     # Generated service: /projects/{id} without .json
     stub_get("/12345/projects/123", response_body: sample_project)

--- a/typescript/tests/services/projects.test.ts
+++ b/typescript/tests/services/projects.test.ts
@@ -47,6 +47,45 @@ describe("ProjectsService", () => {
       expect(projects[1]!.id).toBe(2);
     });
 
+    it("should send no status param by default", async () => {
+      server.use(
+        http.get(`${BASE_URL}/projects.json`, ({ request }) => {
+          const url = new URL(request.url);
+          expect(url.searchParams.has("status")).toBe(false);
+          return HttpResponse.json([sampleProject(1)]);
+        })
+      );
+
+      const projects = await client.projects.list();
+      expect(projects).toHaveLength(1);
+    });
+
+    it("should forward an explicit active status — a server-accepted alias of the default", async () => {
+      server.use(
+        http.get(`${BASE_URL}/projects.json`, ({ request }) => {
+          const url = new URL(request.url);
+          expect(url.searchParams.get("status")).toBe("active");
+          return HttpResponse.json([sampleProject(1)]);
+        })
+      );
+
+      const projects = await client.projects.list({ status: "active" });
+      expect(projects).toHaveLength(1);
+    });
+
+    it("should forward the archived status filter", async () => {
+      server.use(
+        http.get(`${BASE_URL}/projects.json`, ({ request }) => {
+          const url = new URL(request.url);
+          expect(url.searchParams.get("status")).toBe("archived");
+          return HttpResponse.json([sampleProject(1)]);
+        })
+      );
+
+      const projects = await client.projects.list({ status: "archived" });
+      expect(projects).toHaveLength(1);
+    });
+
     it("should return empty array when no projects exist", async () => {
       server.use(
         http.get(`${BASE_URL}/projects.json`, () => {


### PR DESCRIPTION
`basecamp.ProjectStatusActive` — and TypeScript's `{ status: "active" }` — used to fail on first use: BC3's `ProjectsController#status_param_for_api` permitted only `archived` and `trashed` and answered `400` (`{"code":"validation"}`) to any other present value, while active projects are what the unfiltered list returns.

That server-side gap is now closed: [basecamp/bc3#13037](https://github.com/basecamp/bc3/pull/13037) (merged 2026-09-01) makes `status=active` a valid explicit value on the projects index — an alias of the unfiltered default. So this PR is no longer a removal. **No API change in any SDK**; the tri-state filter the SDKs have always advertised now works end to end.

Card: https://app.basecamp.com/2914079/buckets/48521764/card_tables/cards/10254772286

What's left after the server fix:

- **Spec**: unchanged — `ListProjectsInput.status` keeps the shared tri-state `ProjectStatus` shape (`active|archived|trashed`), the same convention every other status filter uses (Todo, Todolist, ScheduleEntry, Recording). No generated code changes.
- **Tests** pin the wire contract in Go, TypeScript, Python, and Ruby: nil/empty options send no `status` param at all; `active`, `archived`, and `trashed` are each forwarded verbatim (`active` as the server-accepted alias of the default).
- **Go README**: the example moves off the redundant explicit `Status: ProjectStatusActive` to the idiomatic default — `List(ctx, nil)` — with archived/trashed noted as the filter values worth passing.
- **MIGRATING.md**: no entry — nothing breaks. Consumers who pass `status=active` stop getting a 400 once the bc3 change is deployed; that's the whole behavior change, and it's server-side.

Earlier revisions of this PR removed the `active` filter value (Go constant, TS union narrowing) because the server rejected it; review comments referencing that shape predate the bc3 fix.

Checks run locally: `make generate` clean (spec and generated files byte-identical to `main`); Go/TS/Ruby/Python check lanes, smithy/behavior-model/drift/doc-constants/projected-examples gates, and all non-Swift conformance lanes green. Same environment caveats as before: `lint-actions` and the Swift test lanes are covered by remote CI (local Command Line Tools has no XCTest; this PR's Swift diff is empty).
