### PR TITLE
feat(projects): expose starred and star_url on Project

### DIFF
--- a/go/pkg/basecamp/benchmark_test.go
+++ b/go/pkg/basecamp/benchmark_test.go
@@ -69,6 +69,7 @@ func BenchmarkJSONMarshalProject(b *testing.B) {
 		Purpose:        "company_hq",
 		ClientsEnabled: true,
 		BookmarkURL:    "https://3.basecamp.com/12345/bookmarks/67890",
+		StarURL:        "https://3.basecampapi.com/12345/buckets/67890/stars.json",
 		URL:            "https://3.basecampapi.com/12345/projects/67890.json",
 		AppURL:         "https://3.basecamp.com/12345/projects/67890",
 		Dock: []DockItem{
@@ -77,6 +78,7 @@ func BenchmarkJSONMarshalProject(b *testing.B) {
 			{ID: 3, Title: "Schedule", Name: "schedule", Enabled: true, URL: "https://example.com/3"},
 		},
 		Bookmarked: true,
+		Starred:    true,
 	}
 
 	b.ResetTimer()
@@ -97,6 +99,7 @@ func BenchmarkJSONUnmarshalProject(b *testing.B) {
 		"purpose": "company_hq",
 		"clients_enabled": true,
 		"bookmark_url": "https://3.basecamp.com/12345/bookmarks/67890",
+		"star_url": "https://3.basecampapi.com/12345/buckets/67890/stars.json",
 		"url": "https://3.basecampapi.com/12345/projects/67890.json",
 		"app_url": "https://3.basecamp.com/12345/projects/67890",
 		"dock": [
@@ -104,7 +107,8 @@ func BenchmarkJSONUnmarshalProject(b *testing.B) {
 			{"id": 2, "title": "To-dos", "name": "todoset", "enabled": true, "url": "https://example.com/2"},
 			{"id": 3, "title": "Schedule", "name": "schedule", "enabled": true, "url": "https://example.com/3"}
 		],
-		"bookmarked": true
+		"bookmarked": true,
+		"starred": true
 	}`)
 
 	b.ResetTimer()

--- a/go/pkg/basecamp/projects.go
+++ b/go/pkg/basecamp/projects.go
@@ -22,10 +22,12 @@ type Project struct {
 	EndDate        string         `json:"end_date,omitempty"`
 	ClientsEnabled bool           `json:"clients_enabled"`
 	BookmarkURL    string         `json:"bookmark_url"`
+	StarURL        string         `json:"star_url"`
 	URL            string         `json:"url"`
 	AppURL         string         `json:"app_url"`
 	Dock           []DockItem     `json:"dock,omitempty"`
 	Bookmarked     bool           `json:"bookmarked"`
+	Starred        bool           `json:"starred"`
 	ClientCompany  *ClientCompany `json:"client_company,omitempty"`
 	Clientside     *Clientside    `json:"clientside,omitempty"`
 }
@@ -438,9 +440,11 @@ func projectFromGenerated(gp generated.Project) Project {
 		EndDate:        deref(gp.EndDate),
 		ClientsEnabled: deref(gp.ClientsEnabled),
 		BookmarkURL:    deref(gp.BookmarkUrl),
+		StarURL:        deref(gp.StarUrl),
 		URL:            gp.Url,
 		AppURL:         gp.AppUrl,
 		Bookmarked:     deref(gp.Bookmarked),
+		Starred:        deref(gp.Starred),
 		CreatedAt:      gp.CreatedAt,
 		UpdatedAt:      gp.UpdatedAt,
 	}

--- a/go/pkg/basecamp/projects_test.go
+++ b/go/pkg/basecamp/projects_test.go
@@ -116,11 +116,34 @@ func TestProject_UnmarshalGet(t *testing.T) {
 	if project.EndDate != "2022-04-01" {
 		t.Errorf("expected end_date '2022-04-01', got %q", project.EndDate)
 	}
+	if project.StarURL != "https://3.basecampapi.com/195539477/buckets/2085958499/stars.json" {
+		t.Errorf("unexpected star_url %q", project.StarURL)
+	}
+	if !project.Bookmarked || !project.Starred {
+		t.Errorf("expected bookmarked=true starred=true, got bookmarked=%v starred=%v", project.Bookmarked, project.Starred)
+	}
 	if project.CreatedAt.IsZero() {
 		t.Error("expected non-zero CreatedAt")
 	}
 	if project.UpdatedAt.IsZero() {
 		t.Error("expected non-zero UpdatedAt")
+	}
+}
+
+func TestProjectFromGenerated_StarFields(t *testing.T) {
+	bookmarked, starred := true, false
+	starURL := "https://3.basecampapi.com/195539477/buckets/2085958500/stars.json"
+	p := projectFromGenerated(generated.Project{
+		Id: 2085958500, Status: "active", Name: "The Leto Laptop",
+		StarUrl: &starURL, Bookmarked: &bookmarked, Starred: &starred,
+	})
+
+	if p.StarURL != starURL {
+		t.Errorf("unexpected StarURL %q", p.StarURL)
+	}
+	// Bookmarked-but-unstarred is the case that tells the two flags apart.
+	if !p.Bookmarked || p.Starred {
+		t.Errorf("expected bookmarked=true starred=false, got bookmarked=%v starred=%v", p.Bookmarked, p.Starred)
 	}
 }
 

--- a/go/pkg/generated/client.gen.go
+++ b/go/pkg/generated/client.gen.go
@@ -2340,8 +2340,11 @@ type PrioritizeAssignmentRequestContent struct {
 
 // Project defines model for Project.
 type Project struct {
-	AppUrl         string         `json:"app_url"`
-	BookmarkUrl    *string        `json:"bookmark_url,omitempty"`
+	AppUrl      string  `json:"app_url"`
+	BookmarkUrl *string `json:"bookmark_url,omitempty"`
+
+	// Bookmarked True when the project is pinned on the current user's home page at all,
+	// whether starred or filed into a stack.
 	Bookmarked     *bool          `json:"bookmarked,omitempty"`
 	ClientCompany  *ClientCompany `json:"client_company,omitempty"`
 	ClientsEnabled *bool          `json:"clients_enabled,omitempty"`
@@ -2357,7 +2360,13 @@ type Project struct {
 	Id          int64       `json:"id"`
 	Name        string      `json:"name"`
 	Purpose     *string     `json:"purpose,omitempty"`
-	StartDate   *string     `json:"start_date,omitempty"`
+
+	// StarUrl Bucket stars collection for this project (`/buckets/{id}/stars.json`).
+	StarUrl *string `json:"star_url,omitempty"`
+
+	// Starred True only when the project carries a star on the current user's home page.
+	Starred   *bool   `json:"starred,omitempty"`
+	StartDate *string `json:"start_date,omitempty"`
 
 	// Status active|archived|trashed
 	Status    string    `json:"status"`

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/models/Project.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/models/Project.kt
@@ -26,8 +26,10 @@ data class Project(
     @SerialName("end_date") val endDate: String? = null,
     @SerialName("clients_enabled") val clientsEnabled: Boolean? = null,
     @SerialName("bookmark_url") val bookmarkUrl: String? = null,
+    @SerialName("star_url") val starUrl: String? = null,
     val dock: List<DockItem>? = null,
     val bookmarked: Boolean? = null,
+    val starred: Boolean? = null,
     @SerialName("client_company") val clientCompany: ClientCompany? = null,
     @Deprecated("This shape is deprecated since 2024-01: Use Client Visibility feature instead")
     val clientside: ClientSide? = null

--- a/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/ProjectsServiceTest.kt
+++ b/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/ProjectsServiceTest.kt
@@ -26,12 +26,14 @@ class ProjectsServiceTest {
         }
     }
 
-    private fun projectJson(id: Long, name: String, description: String? = null) = """{
+    private fun projectJson(id: Long, name: String, description: String? = null, starred: Boolean = false) = """{
         "id": $id, "status": "active", "name": "$name",
         "created_at": "2025-01-01T00:00:00Z", "updated_at": "2025-01-01T00:00:00Z",
         "start_date": "2024-01-01", "end_date": "2024-03-31",
         "url": "https://3.basecampapi.com/12345/projects/$id.json",
         "app_url": "https://3.basecamp.com/12345/projects/$id",
+        "star_url": "https://3.basecampapi.com/12345/buckets/$id/stars.json",
+        "bookmarked": true, "starred": $starred,
         "dock": []
         ${if (description != null) """, "description": "$description"""" else ""}
     }"""
@@ -44,7 +46,7 @@ class ProjectsServiceTest {
 
             respond(
                 content = """[
-                    ${projectJson(1, "Project Alpha")},
+                    ${projectJson(1, "Project Alpha", starred = true)},
                     ${projectJson(2, "Project Beta")}
                 ]""",
                 status = HttpStatusCode.OK,
@@ -63,6 +65,10 @@ class ProjectsServiceTest {
         assertEquals("Project Alpha", projects[0].name)
         assertEquals(2L, projects[1].id)
         assertEquals("Project Beta", projects[1].name)
+        // starred implies bookmarked, never the reverse: Beta is pinned but unstarred.
+        assertEquals(listOf(true, true), projects.map { it.bookmarked })
+        assertEquals(listOf(true, false), projects.map { it.starred })
+        assertEquals("https://3.basecampapi.com/12345/buckets/2/stars.json", projects[1].starUrl)
         assertEquals(2L, projects.meta.totalCount)
 
         client.close()

--- a/openapi.json
+++ b/openapi.json
@@ -32581,6 +32581,10 @@
           "bookmark_url": {
             "type": "string"
           },
+          "star_url": {
+            "type": "string",
+            "description": "Bucket stars collection for this project (`/buckets/{id}/stars.json`)."
+          },
           "url": {
             "type": "string"
           },
@@ -32595,7 +32599,12 @@
             "x-go-type-skip-optional-pointer": true
           },
           "bookmarked": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "True when the project is pinned on the current user's home page at all,\nwhether starred or filed into a stack."
+          },
+          "starred": {
+            "type": "boolean",
+            "description": "True only when the project carries a star on the current user's home page."
           },
           "client_company": {
             "$ref": "#/components/schemas/ClientCompany"

--- a/python/src/basecamp/generated/types.py
+++ b/python/src/basecamp/generated/types.py
@@ -1293,6 +1293,8 @@ class Project(TypedDict):
     id: int
     name: str
     purpose: NotRequired[str]
+    star_url: NotRequired[str]
+    starred: NotRequired[bool]
     start_date: NotRequired[str]
     status: str
     updated_at: str

--- a/python/tests/services/test_projects.py
+++ b/python/tests/services/test_projects.py
@@ -32,6 +32,9 @@ class TestProjects:
                     "updated_at": "2024-01-15T10:00:00Z",
                     "url": "https://3.basecampapi.com/12345/projects/42.json",
                     "app_url": "https://3.basecamp.com/12345/projects/42",
+                    "star_url": "https://3.basecampapi.com/12345/buckets/42/stars.json",
+                    "bookmarked": True,
+                    "starred": False,
                 },
             )
         )
@@ -42,6 +45,10 @@ class TestProjects:
 
         assert project["start_date"] == "2024-01-01"
         assert project["end_date"] == "2024-03-31"
+        assert project["star_url"] == "https://3.basecampapi.com/12345/buckets/42/stars.json"
+        # starred implies bookmarked, never the reverse: pinned but unstarred is the discriminating case.
+        assert project["bookmarked"] is True
+        assert project["starred"] is False
 
     @respx.mock
     def test_list_projects_includes_schedule_dates(self):

--- a/ruby/lib/basecamp/generated/metadata.json
+++ b/ruby/lib/basecamp/generated/metadata.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://basecamp.com/schemas/sdk-metadata.json",
   "version": "1.0.0",
-  "generated": "2026-08-31T20:18:08Z",
+  "generated": "2026-09-01T04:02:35Z",
   "operations": {
     "GetAccount": {
       "retry": {

--- a/ruby/lib/basecamp/generated/types.rb
+++ b/ruby/lib/basecamp/generated/types.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # Auto-generated from OpenAPI spec. Do not edit manually.
-# Generated: 2026-08-31T20:18:08Z
+# Generated: 2026-09-01T04:02:35Z
 
 require "json"
 require "time"
@@ -3169,7 +3169,7 @@ module Basecamp
       include TypeHelpers
       # @!attribute [rw] clientside
       #   @deprecated This shape is deprecated since 2024-01: Use Client Visibility feature instead
-      attr_accessor :app_url, :created_at, :id, :name, :status, :updated_at, :url, :bookmark_url, :bookmarked, :client_company, :clients_enabled, :clientside, :description, :dock, :end_date, :purpose, :start_date
+      attr_accessor :app_url, :created_at, :id, :name, :status, :updated_at, :url, :bookmark_url, :bookmarked, :client_company, :clients_enabled, :clientside, :description, :dock, :end_date, :purpose, :star_url, :starred, :start_date
 
       # @return [Array<Symbol>]
       def self.required_fields
@@ -3193,6 +3193,8 @@ module Basecamp
         @dock = parse_array(data["dock"], "DockItem")
         @end_date = data["end_date"]
         @purpose = data["purpose"]
+        @star_url = data["star_url"]
+        @starred = parse_boolean(data["starred"])
         @start_date = data["start_date"]
       end
 
@@ -3214,6 +3216,8 @@ module Basecamp
           "dock" => @dock,
           "end_date" => @end_date,
           "purpose" => @purpose,
+          "star_url" => @star_url,
+          "starred" => @starred,
           "start_date" => @start_date,
         }.compact
       end

--- a/ruby/test/basecamp/services/projects_service_test.rb
+++ b/ruby/test/basecamp/services/projects_service_test.rb
@@ -15,25 +15,31 @@ class ProjectsServiceTest < Minitest::Test
     @account = create_account_client(account_id: "12345")
   end
 
-  def sample_project(id: 123, name: "Test Project")
+  def sample_project(id: 123, name: "Test Project", starred: false)
     {
       "id" => id,
       "name" => name,
       "description" => "A test project",
       "status" => "active",
       "start_date" => "2024-01-01",
-      "end_date" => "2024-03-31"
+      "end_date" => "2024-03-31",
+      "star_url" => "https://3.basecampapi.com/12345/buckets/#{id}/stars.json",
+      "bookmarked" => true,
+      "starred" => starred
     }
   end
 
   def test_list_projects
-    stub_get("/12345/projects.json", response_body: [ sample_project, sample_project(id: 456, name: "Other") ])
+    stub_get("/12345/projects.json", response_body: [ sample_project(starred: true), sample_project(id: 456, name: "Other") ])
 
     projects = @account.projects.list.to_a
 
     assert_equal 2, projects.length
     assert_equal "Test Project", projects[0]["name"]
     assert_equal "Other", projects[1]["name"]
+    # starred implies bookmarked, never the reverse: the second project is pinned but unstarred.
+    assert_equal [ true, true ], projects.map { |p| p["bookmarked"] }
+    assert_equal [ true, false ], projects.map { |p| p["starred"] }
   end
 
   def test_list_projects_with_status_filter
@@ -67,6 +73,9 @@ class ProjectsServiceTest < Minitest::Test
     assert_equal "Test Project", project["name"]
     assert_equal "2024-01-01", project["start_date"]
     assert_equal "2024-03-31", project["end_date"]
+    assert_equal "https://3.basecampapi.com/12345/buckets/123/stars.json", project["star_url"]
+    assert_equal true, project["bookmarked"]
+    assert_equal false, project["starred"]
   end
 
   def test_create_project

--- a/spec/api-gaps/README.md
+++ b/spec/api-gaps/README.md
@@ -140,6 +140,17 @@ making the absorption journey publicly auditable.
 > whose polymorphic members were already optional. None requires another
 > Smithy member or operation.
 >
+> One correction to that disposition, not a new range: BC3 #13042
+> (`abdcdc61ef`), inside this range, made `GET /projects.json` emit `starred`
+> beside `bookmarked` and `GET /projects/{id}.json` emit both; the triage
+> above read the projects partial's dock filter and missed the two members
+> the index and show templates add around it. `Project` now carries `starred`
+> and the already-documented `star_url` the partial always emitted. Both are
+> optional, like `bookmarked` and `bookmark_url`, and the fixtures pin the
+> one combination that tells the flags apart: a star is a flag on a pin, so
+> `starred` implies `bookmarked` and pinned-but-unstarred is the case a
+> conflating decoder gets wrong.
+>
 > Controller and route drift was checked through the pinned route-table
 > regeneration and bidirectional route parity, not treated as API merely
 > because a Rails controller changed. The table moves from 373 routes across

--- a/spec/api-gaps/README.md
+++ b/spec/api-gaps/README.md
@@ -143,9 +143,10 @@ making the absorption journey publicly auditable.
 > One correction to that disposition, not a new range: BC3 #13042
 > (`abdcdc61ef`), inside this range, made `GET /projects.json` emit `starred`
 > beside `bookmarked` and `GET /projects/{id}.json` emit both; the triage
-> above read the projects partial's dock filter and missed the two members
-> the index and show templates add around it. `Project` now carries `starred`
-> and the already-documented `star_url` the partial always emitted. Both are
+> above read the projects partial's dock filter and missed the two members —
+> `bookmarked` and `starred` — the index and show templates add around it.
+> `Project` now carries the newly emitted `starred`, plus `star_url`, which
+> the partial itself always emitted but the spec never modeled. Both are
 > optional, like `bookmarked` and `bookmark_url`, and the fixtures pin the
 > one combination that tells the flags apart: a star is a flag on a pin, so
 > `starred` implies `bookmarked` and pinned-but-unstarred is the case a

--- a/spec/basecamp.smithy
+++ b/spec/basecamp.smithy
@@ -766,12 +766,18 @@ structure Project {
   end_date: ISO8601Date
   clients_enabled: Boolean
   bookmark_url: String
+  /// Bucket stars collection for this project (`/buckets/{id}/stars.json`).
+  star_url: String
   @required
   url: String
   @required
   app_url: String
   dock: DockItemList
+  /// True when the project is pinned on the current user's home page at all,
+  /// whether starred or filed into a stack.
   bookmarked: Boolean
+  /// True only when the project carries a star on the current user's home page.
+  starred: Boolean
   client_company: ClientCompany
   @deprecated(message: "Use Client Visibility feature instead", since: "2024-01")
   clientside: ClientSide

--- a/spec/fixtures/projects/README.md
+++ b/spec/fixtures/projects/README.md
@@ -39,5 +39,7 @@ JSON fixtures extracted from the canonical projects docs in `basecamp/bc3/doc/ap
 
 - get.json includes a scheduled project with `start_date` and `end_date`
 - list.json includes one scheduled project and one project with `client_company` and `clientside` fields (id: 2085958500)
+- `bookmarked` and `starred` describe the current user's home page (BC3 #13042): `bookmarked` is true when the project is pinned there at all, `starred` only when the pin carries a star — so `starred` implies `bookmarked`, never the reverse. list.json carries one starred project and one bookmarked-but-unstarred project (id: 2085958500), so a decoder that conflated the two would fail on the second
+- `star_url` is the bucket stars collection, `/buckets/{id}/stars.json`
 - DockItem.position can be null when enabled=false
 - All timestamps are ISO8601 format

--- a/spec/fixtures/projects/get.json
+++ b/spec/fixtures/projects/get.json
@@ -10,6 +10,7 @@
   "end_date": "2022-04-01",
   "clients_enabled": false,
   "bookmark_url": "https://3.basecampapi.com/195539477/my/bookmarks/BAh7CEkiCGdpZAY6BkVUSSIrZ2lkOi8vYmMzL0J1Y2tldC8yMDg1OTU4NDk5P2V4cGlyZXNfaW4GOwBUSSIMcHVycG9zZQY7AFRJIg1yZWFkYWJsZQY7AFRJIg9leHBpcmVzX2F0BjsAVDA=--691d627098347705738640552798539681dcd3b6.json",
+  "star_url": "https://3.basecampapi.com/195539477/buckets/2085958499/stars.json",
   "url": "https://3.basecampapi.com/195539477/projects/2085958499.json",
   "app_url": "https://3.basecamp.com/195539477/projects/2085958499",
   "dock": [
@@ -85,5 +86,7 @@
       "url": "https://3.basecampapi.com/195539477/buckets/2085958499/card_tables/1069479345.json",
       "app_url": "https://3.basecamp.com/195539477/buckets/2085958499/card_tables/1069479345"
     }
-  ]
+  ],
+  "bookmarked": true,
+  "starred": true
 }

--- a/spec/fixtures/projects/list.json
+++ b/spec/fixtures/projects/list.json
@@ -11,6 +11,7 @@
     "end_date": "2022-04-01",
     "clients_enabled": false,
     "bookmark_url": "https://3.basecampapi.com/195539477/my/bookmarks/BAh7CEkiCGdpZAY6BkVUSSIrZ2lkOi8vYmMzL0J1Y2tldC8yMDg1OTU4NDk5P2V4cGlyZXNfaW4GOwBUSSIMcHVycG9zZQY7AFRJIg1yZWFkYWJsZQY7AFRJIg9leHBpcmVzX2F0BjsAVDA=--691d627098347705738640552798539681dcd3b6.json",
+    "star_url": "https://3.basecampapi.com/195539477/buckets/2085958499/stars.json",
     "url": "https://3.basecampapi.com/195539477/projects/2085958499.json",
     "app_url": "https://3.basecamp.com/195539477/projects/2085958499",
     "dock": [
@@ -87,7 +88,8 @@
         "app_url": "https://3.basecamp.com/195539477/buckets/2085958499/card_tables/1069479345"
       }
     ],
-    "bookmarked": true
+    "bookmarked": true,
+    "starred": true
   },
   {
     "id": 2085958500,
@@ -99,6 +101,7 @@
     "purpose": "topic",
     "clients_enabled": false,
     "bookmark_url": "https://3.basecampapi.com/195539477/my/bookmarks/BAh7CEkiCGdpZAY6BkVUSSIrZ2lkOi8vYmMzL0J1Y2tldC8yMDg1OTU4NTAwP2V4cGlyZXNfaW4GOwBUSSIMcHVycG9zZQY7AFRJIg1yZWFkYWJsZQY7AFRJIg9leHBpcmVzX2F0BjsAVDA=--3792afdce2e0fb99a38a2fcecf198313a428c478.json",
+    "star_url": "https://3.basecampapi.com/195539477/buckets/2085958500/stars.json",
     "url": "https://3.basecampapi.com/195539477/projects/2085958500.json",
     "app_url": "https://3.basecamp.com/195539477/projects/2085958500",
     "client_company": {
@@ -183,6 +186,7 @@
         "app_url": "https://3.basecamp.com/195539477/buckets/2085958500/card_tables/1069479558"
       }
     ],
-    "bookmarked": true
+    "bookmarked": true,
+    "starred": false
   }
 ]

--- a/swift/Sources/Basecamp/Generated/Models/Project.swift
+++ b/swift/Sources/Basecamp/Generated/Models/Project.swift
@@ -19,6 +19,8 @@ public struct Project: Codable, Sendable {
     public var dock: [DockItem]?
     public var endDate: String?
     public var purpose: String?
+    public var starUrl: String?
+    public var starred: Bool?
     public var startDate: String?
 
     public init(
@@ -38,6 +40,8 @@ public struct Project: Codable, Sendable {
         dock: [DockItem]? = nil,
         endDate: String? = nil,
         purpose: String? = nil,
+        starUrl: String? = nil,
+        starred: Bool? = nil,
         startDate: String? = nil
     ) {
         self.appUrl = appUrl
@@ -56,6 +60,8 @@ public struct Project: Codable, Sendable {
         self.dock = dock
         self.endDate = endDate
         self.purpose = purpose
+        self.starUrl = starUrl
+        self.starred = starred
         self.startDate = startDate
     }
 }

--- a/swift/Tests/BasecampTests/GeneratedServiceTests.swift
+++ b/swift/Tests/BasecampTests/GeneratedServiceTests.swift
@@ -14,6 +14,8 @@ final class GeneratedServiceTests: XCTestCase {
             "app_url": "https://3.basecamp.com/1/projects/42", "url": "https://3.basecampapi.com/1/projects/42.json",
             "created_at": "2026-01-01T00:00:00Z", "updated_at": "2026-01-01T00:00:00Z",
             "start_date": "2024-01-01", "end_date": "2024-03-31",
+            "star_url": "https://3.basecampapi.com/1/buckets/42/stars.json",
+            "bookmarked": true, "starred": false,
         ]
         let data = try JSONSerialization.data(withJSONObject: json)
 
@@ -26,6 +28,10 @@ final class GeneratedServiceTests: XCTestCase {
         XCTAssertEqual(project.status, "active")
         XCTAssertEqual(project.startDate, "2024-01-01")
         XCTAssertEqual(project.endDate, "2024-03-31")
+        XCTAssertEqual(project.starUrl, "https://3.basecampapi.com/1/buckets/42/stars.json")
+        // starred implies bookmarked, never the reverse: pinned but unstarred is the discriminating case.
+        XCTAssertEqual(project.bookmarked, true)
+        XCTAssertEqual(project.starred, false)
 
         // Verify request was sent to the correct path
         let lastURL = transport.lastRequest!.request.url!.absoluteString

--- a/typescript/src/generated/metadata.ts
+++ b/typescript/src/generated/metadata.ts
@@ -37,7 +37,7 @@ export interface MetadataOutput {
 const metadata: MetadataOutput = {
   "$schema": "https://basecamp.com/schemas/sdk-metadata.json",
   "version": "1.0.0",
-  "generated": "2026-08-31T20:18:07.889Z",
+  "generated": "2026-09-01T04:02:34.676Z",
   "operations": {
     "GetAccount": {
       "retry": {

--- a/typescript/src/generated/openapi-stripped.json
+++ b/typescript/src/generated/openapi-stripped.json
@@ -29719,6 +29719,10 @@
           "bookmark_url": {
             "type": "string"
           },
+          "star_url": {
+            "type": "string",
+            "description": "Bucket stars collection for this project (`/buckets/{id}/stars.json`)."
+          },
           "url": {
             "type": "string"
           },
@@ -29733,7 +29737,12 @@
             "x-go-type-skip-optional-pointer": true
           },
           "bookmarked": {
-            "type": "boolean"
+            "type": "boolean",
+            "description": "True when the project is pinned on the current user's home page at all,\nwhether starred or filed into a stack."
+          },
+          "starred": {
+            "type": "boolean",
+            "description": "True only when the project carries a star on the current user's home page."
           },
           "client_company": {
             "$ref": "#/components/schemas/ClientCompany"

--- a/typescript/src/generated/schema.d.ts
+++ b/typescript/src/generated/schema.d.ts
@@ -5317,10 +5317,18 @@ export interface components {
             end_date?: string;
             clients_enabled?: boolean;
             bookmark_url?: string;
+            /** @description Bucket stars collection for this project (`/buckets/{id}/stars.json`). */
+            star_url?: string;
             url: string;
             app_url: string;
             dock?: components["schemas"]["DockItem"][];
+            /**
+             * @description True when the project is pinned on the current user's home page at all,
+             *     whether starred or filed into a stack.
+             */
             bookmarked?: boolean;
+            /** @description True only when the project carries a star on the current user's home page. */
+            starred?: boolean;
             client_company?: components["schemas"]["ClientCompany"];
             /** @deprecated */
             clientside?: components["schemas"]["ClientSide"];

--- a/typescript/tests/services/projects.test.ts
+++ b/typescript/tests/services/projects.test.ts
@@ -10,7 +10,7 @@ import type { BasecampClient } from "../../src/client.js";
 
 const BASE_URL = "https://3.basecampapi.com/12345";
 
-const sampleProject = (id = 1) => ({
+const sampleProject = (id = 1, starred = false) => ({
   id,
   name: "My Project",
   description: "<p>A cool project</p>",
@@ -19,6 +19,9 @@ const sampleProject = (id = 1) => ({
   end_date: "2024-03-31",
   created_at: "2024-01-15T10:00:00Z",
   updated_at: "2024-01-15T10:00:00Z",
+  star_url: `${BASE_URL}/buckets/${id}/stars.json`,
+  bookmarked: true,
+  starred,
 });
 
 describe("ProjectsService", () => {
@@ -113,6 +116,22 @@ describe("ProjectsService", () => {
       expect(project.name).toBe("My Project");
       expect(project.start_date).toBe("2024-01-01");
       expect(project.end_date).toBe("2024-03-31");
+      expect(project.star_url).toBe(`${BASE_URL}/buckets/${projectId}/stars.json`);
+      // starred implies bookmarked, never the reverse: pinned but unstarred is the discriminating case.
+      expect(project.bookmarked).toBe(true);
+      expect(project.starred).toBe(false);
+    });
+
+    it("should carry starred through alongside bookmarked", async () => {
+      server.use(
+        http.get(`${BASE_URL}/projects/7`, () => {
+          return HttpResponse.json(sampleProject(7, true));
+        })
+      );
+
+      const project = await client.projects.get(7);
+      expect(project.bookmarked).toBe(true);
+      expect(project.starred).toBe(true);
     });
 
     it("should throw not_found for missing project", async () => {

--- a/typescript/tests/services/projects.test.ts
+++ b/typescript/tests/services/projects.test.ts
@@ -39,7 +39,7 @@ describe("ProjectsService", () => {
     it("should list projects", async () => {
       server.use(
         http.get(`${BASE_URL}/projects.json`, () => {
-          return HttpResponse.json([sampleProject(1), sampleProject(2)]);
+          return HttpResponse.json([sampleProject(1, true), sampleProject(2)]);
         })
       );
 
@@ -48,6 +48,10 @@ describe("ProjectsService", () => {
       expect(projects[0]!.id).toBe(1);
       expect(projects[0]!.start_date).toBe("2024-01-01");
       expect(projects[1]!.id).toBe(2);
+      // starred implies bookmarked, never the reverse: the second project is pinned but unstarred.
+      expect(projects.map((p) => p.bookmarked)).toEqual([true, true]);
+      expect(projects.map((p) => p.starred)).toEqual([true, false]);
+      expect(projects[1]!.star_url).toBe(`${BASE_URL}/buckets/2/stars.json`);
     });
 
     it("should send no status param by default", async () => {


### PR DESCRIPTION
## What

`Project` gains two members:

- **`starred`** (optional Boolean) — true only when the project carries a star on the current user's home page. New on the wire in [bc3#13042](https://github.com/basecamp/bc3/pull/13042), which made `GET /projects.json` emit it beside `bookmarked` and `GET /projects/{id}.json` emit both.
- **`star_url`** (optional String) — the bucket stars collection (`/buckets/{id}/stars.json`). The projects partial has always emitted it and the docs show it, but the spec never modeled it (Folder had it; Project didn't).

Both optional, matching `bookmarked` / `bookmark_url`. All six SDKs regenerated; the Go hand-written `Project` wrapper maps both through `projectFromGenerated`.

## Semantics the tests pin

A star is a flag on a pin (`Bucket::Pin#starred`), so `starred` implies `bookmarked` — never the reverse. The shared fixtures (`spec/fixtures/projects/list.json` + `get.json`) and each SDK's project tests carry the pinned-but-unstarred combination, the one a decoder that conflates the flags gets wrong.

## Provenance

bc3#13042 (`abdcdc61ef`) is already inside the current provenance pin; the pin does not move. The range triage in `spec/api-gaps/README.md` had recorded that range as needing no new Smithy member — it read the partial's dock filter and missed the members the index/show templates add around it. Corrected there in the established one-correction style. No route change, so `spec/bc3-routes.json` is untouched (verified with `bc3-routes-check` against a bc3 checkout at the pin).

Note: the field is live on the API only once bc3 master deploys; SDKs decode its absence as the usual optional-member `nil`/omitted before then.

Tracking: [Basecamp card](https://app.basecamp.com/2914079/buckets/48521764/card_tables/cards/10254639694)

## Checks

Run locally and green: `smithy-check`, `behavior-model-check`, `url-routes-check`, `bc3-route-parity` (+ self-test), `bc3-routes-check` (with bc3 checkout), `check-fixture-coverage`, `check-projected-examples`, `doc-constants-check`, provenance/version sync checks, `validate-api-gaps`, all drift gates, `go-check`, `ts-check`, `rb-check`, `py-check`, `kt-check`, conformance for Go/Kotlin/TypeScript/Ruby/Python (+ runner tests), parity gates, `check-fixture-execution --partial`.

Not runnable here (CommandLineTools without XCTest): the Swift **test** lanes — `swift-check` tests, `conformance-swift`, and the full six-runner `check-fixture-execution`. `swift build` (SDK + generator + public-API consumer) passes locally; CI is authoritative for the Swift test lanes and `lint-actions`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `starred` and `star_url` as optional fields on `Project` in the API spec and all six SDKs, so SDK consumers can now distinguish a starred project from one that's merely bookmarked. Both fields are already emitted by the API, so this is non-breaking.

**Behavior**
- `starred` is true only when the project carries a star on the current user's home page, and it implies `bookmarked` — never the reverse.
- `star_url` points to the bucket stars collection (`/buckets/{id}/stars.json`).
- Fixtures and SDK tests pin the bookmarked-but-unstarred combination so decoders that conflate the two flags fail.
- Corrects the api-gaps triage that had missed these members from the `bc3#13042` change.

<sup>Written for commit f30265b8c9623af6855a6e00f9213beee6a2b082. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-sdk/pull/835?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

