### PR TITLE
Fix failing npm audit in the TypeScript SDK

### DIFF
--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1084,23 +1084,6 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
-    "node_modules/@redocly/ajv/node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/fastify"
-        },
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/fastify"
-        }
-      ],
-      "license": "BSD-3-Clause"
-    },
     "node_modules/@redocly/config": {
       "version": "0.22.2",
       "resolved": "https://registry.npmjs.org/@redocly/config/-/config-0.22.2.tgz",
@@ -1963,6 +1946,23 @@
       "dependencies": {
         "fast-string-truncated-width": "^3.0.2"
       }
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/fast-wrap-ansi": {
       "version": "0.2.0",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -71,7 +71,7 @@
   "overrides": {
     "minimatch": ">=10.2.1",
     "brace-expansion": ">=5.0.9",
-    "fast-uri": ">=3.1.5 <4",
+    "fast-uri": ">=3.1.7 <4",
     "js-yaml": ">=4.3.1 <5"
   }
 }


### PR DESCRIPTION
## Problem

The **npm Audit (TypeScript SDK)** CI step (`npm audit --audit-level=high` in `typescript/`) fails on `main`:

```
fast-uri  3.0.0 - 3.1.5
Severity: high
  - GHSA-5jgf-p345-68v8  host confusion via skipped IDN canonicalization
  - GHSA-f65p-4m7j-42xc  SSRF via malformed IPv6 normalization
  - GHSA-fph4-wmhf-6fwf  SSRF via repeated hostname percent-decoding
  - GHSA-jqff-g426-hqxp  host confusion via percent-encoded scheme normalization
node_modules/@redocly/ajv/node_modules/fast-uri
1 high severity vulnerability
```

- **Package:** `fast-uri`, high severity, fixed in `3.1.6`.
- **Path:** transitive, dev-only — `openapi-typescript` (devDependency) → `@redocly/openapi-core` → `@redocly/ajv` → `fast-uri`. No runtime/published exposure.
- **Root cause:** the existing `overrides` entry already pinned `fast-uri` for security, but its lower bound (`>=3.1.5 <4`) still permitted the now-vulnerable `3.1.5`.

## Fix

Raise the existing override bound to `>=3.1.7 <4` and regenerate `package-lock.json`. This stays within the `3.x` major (non-breaking), matches how the repo already handles audit exceptions (the `overrides` block), and touches only the TypeScript package + its lockfile — no other-language SDK output.

## Verification (local, Node 24 as in CI)

- `npm audit --audit-level=high` → **found 0 vulnerabilities**
- `npm run build` → pass
- `npm run typecheck` → pass
- `npm test` → **1698 passed (87 files)**
- Lockfile diff is limited to `fast-uri` (bumped 3.1.5 → 3.1.7, hoisted/deduped).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the failing `npm audit` step in the TypeScript SDK by raising the `fast-uri` override bound from `>=3.1.5 <4` to `>=3.1.7 <4` and regenerating the lockfile, so npm resolves the patched 3.1.7 instead of the vulnerable 3.1.5.

**Bug Fixes**
- The vulnerable `fast-uri` reaches the tree transitively via the `openapi-typescript` devDependency and never ships in runtime output.
- Verified locally on Node 24 that audit reports 0 vulnerabilities and build, typecheck, and all 1698 tests pass.

<sup>Written for commit fc4b3af595a38eb67685df5f197a0f403f7f985e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-sdk/pull/840?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

