### PR TITLE
Send login_hint with the device authorization request

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -2348,8 +2348,10 @@ FUNCTION requestDeviceAuthorization(deviceAuthEndpoint, clientId, scope?, loginH
   2. POST deviceAuthEndpoint (application/x-www-form-urlencoded):
        client_id={clientId}
        scope={scope}          # OMITTED entirely when unset → server default `read`
-       login_hint={loginHint} # OMITTED when unset (RFC 8628 §3.1); steers the
-                              # sign-in page, never authenticates. Go only, today.
+       login_hint={loginHint} # OMITTED when unset. Basecamp extension (RFC 8628
+                              # §3.1 permits extension parameters; the name follows
+                              # OIDC Core §3.1.2.1): steers the sign-in page, never
+                              # authenticates. Go only, today.
   3. Parse → { device_code, user_code, verification_uri,
                verification_uri_complete?, expires_in, interval? }
   4. Validate: device_code, user_code, verification_uri non-empty;
@@ -2500,11 +2502,12 @@ fixed at issuance, and a date can only be resolved against wall-clock `now()`, w
 reads. §6 records the exception and its cost; the block above is the contract.
 
 ```
-FUNCTION performDeviceLogin(config: OAuthConfig, clientId, scope?, display, clock?) → Token
+FUNCTION performDeviceLogin(config: OAuthConfig, clientId, scope?, display, clock?, loginHint?) → Token
   1. Capability guard: REQUIRE config.deviceAuthorizationEndpoint present
      AND config.grantTypesSupported ∋ "urn:ietf:params:oauth:grant-type:device_code"
      ELSE raise DeviceFlowError(unavailable)      # accepts an ALREADY-SELECTED config
-  2. auth = requestDeviceAuthorization(config.deviceAuthorizationEndpoint, clientId, scope)
+  2. auth = requestDeviceAuthorization(config.deviceAuthorizationEndpoint, clientId, scope, loginHint)
+     # loginHint is Go only, today (forwarded from WithDeviceLoginHint)
   3. deadline = clock.now() + auth.expiresIn   # anchor at ISSUANCE, before the hook
      display(auth)         # hook: show user_code + verification_uri
   4. remaining = deadline − clock.now()        # deduct display-hook time

--- a/SPEC.md
+++ b/SPEC.md
@@ -2343,11 +2343,13 @@ SSRF hardening, requirement 6), since the endpoints they POST credentials to may
 be the ones a discovered issuer's metadata named.
 
 ```
-FUNCTION requestDeviceAuthorization(deviceAuthEndpoint, clientId, scope?) → DeviceAuthorization
+FUNCTION requestDeviceAuthorization(deviceAuthEndpoint, clientId, scope?, loginHint?) → DeviceAuthorization
   1. requireSecureEndpoint(deviceAuthEndpoint)
   2. POST deviceAuthEndpoint (application/x-www-form-urlencoded):
        client_id={clientId}
        scope={scope}          # OMITTED entirely when unset → server default `read`
+       login_hint={loginHint} # OMITTED when unset (RFC 8628 §3.1); steers the
+                              # sign-in page, never authenticates. Go only, today.
   3. Parse → { device_code, user_code, verification_uri,
                verification_uri_complete?, expires_in, interval? }
   4. Validate: device_code, user_code, verification_uri non-empty;

--- a/go/pkg/basecamp/oauth/device.go
+++ b/go/pkg/basecamp/oauth/device.go
@@ -85,6 +85,7 @@ type deviceConfig struct {
 	policyClient *http.Client
 	scope        string
 	hasScope     bool
+	loginHint    string
 	timeout      time.Duration
 	clock        func() time.Time
 	sleep        func(ctx context.Context, d time.Duration) error
@@ -137,6 +138,15 @@ func WithDeviceScope(scope string) DeviceOption {
 		cfg.scope = scope
 		cfg.hasScope = true
 	}
+}
+
+// WithDeviceLoginHint sets the RFC 8628 §3.1 login_hint sent with the device
+// authorization request: the identifier (an email address) of the user the
+// client expects to approve the code. It steers the server's sign-in page
+// and never authenticates on its own; the approval still comes from whoever
+// holds the session. Empty leaves the parameter out entirely.
+func WithDeviceLoginHint(hint string) DeviceOption {
+	return func(cfg *deviceConfig) { cfg.loginHint = hint }
 }
 
 // WithDeviceTimeout bounds each individual HTTP round-trip. Zero, negative,
@@ -288,6 +298,9 @@ func RequestDeviceAuthorization(ctx context.Context, deviceAuthEndpoint, clientI
 	// Omit scope entirely when unset so the server applies its default (`read`).
 	if cfg.hasScope && cfg.scope != "" {
 		form.Set("scope", cfg.scope)
+	}
+	if cfg.loginHint != "" {
+		form.Set("login_hint", cfg.loginHint)
 	}
 
 	reqCtx, cancel := context.WithTimeout(ctx, cfg.timeout)

--- a/go/pkg/basecamp/oauth/device.go
+++ b/go/pkg/basecamp/oauth/device.go
@@ -140,11 +140,14 @@ func WithDeviceScope(scope string) DeviceOption {
 	}
 }
 
-// WithDeviceLoginHint sets the RFC 8628 §3.1 login_hint sent with the device
-// authorization request: the identifier (an email address) of the user the
-// client expects to approve the code. It steers the server's sign-in page
-// and never authenticates on its own; the approval still comes from whoever
-// holds the session. Empty leaves the parameter out entirely.
+// WithDeviceLoginHint sets login_hint on the device authorization request:
+// the identifier (an email address) of the user the client expects to
+// approve the code. RFC 8628 §3.1 defines only client_id and scope and
+// leaves room for extension parameters; login_hint is Basecamp's extension,
+// borrowing the OpenID Connect Core §3.1.2.1 parameter of the same name. It
+// steers the server's sign-in page and never authenticates on its own; the
+// approval still comes from whoever holds the session. Empty leaves the
+// parameter out entirely.
 func WithDeviceLoginHint(hint string) DeviceOption {
 	return func(cfg *deviceConfig) { cfg.loginHint = hint }
 }

--- a/go/pkg/basecamp/oauth/device_test.go
+++ b/go/pkg/basecamp/oauth/device_test.go
@@ -265,6 +265,35 @@ func TestRequestDeviceAuthorization_SendsScopeWhenSet(t *testing.T) {
 	}
 }
 
+func TestRequestDeviceAuthorization_SendsLoginHintWhenSet(t *testing.T) {
+	var form url.Values
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		form = r.PostForm
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(deviceAuthBody)
+	}))
+	defer srv.Close()
+
+	_, err := RequestDeviceAuthorization(context.Background(), srv.URL, "basecamp-cli",
+		WithDeviceHTTPClient(tlsClient(srv)), WithDeviceLoginHint("bot@example.com"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := form.Get("login_hint"); got != "bot@example.com" {
+		t.Errorf("login_hint = %q, want %q", got, "bot@example.com")
+	}
+
+	_, err = RequestDeviceAuthorization(context.Background(), srv.URL, "basecamp-cli",
+		WithDeviceHTTPClient(tlsClient(srv)))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, present := form["login_hint"]; present {
+		t.Errorf("login_hint must be omitted when no hint is set, got %q", form.Get("login_hint"))
+	}
+}
+
 func TestRequestDeviceAuthorization_DefaultsIntervalTo5(t *testing.T) {
 	body := map[string]any{}
 	for k, v := range deviceAuthBody {


### PR DESCRIPTION
RFC 8628 §3.1 lets a device client name the user it expects to approve the code (`login_hint`). Basecamp's device verification page is growing support for it, so `basecamp auth login --login-hint <email>` can steer a shared machine — or a person with several identities — to the right sign-in. The server never treats the hint as authentication; approval still comes from whoever holds the session.

## What

- `oauth.WithDeviceLoginHint(hint)` — a `DeviceOption` that adds `login_hint` to the device authorization POST. Unset leaves the form exactly as it was.
- SPEC §16 `requestDeviceAuthorization` gains the optional `loginHint?` parameter, marked Go-only for now: no other SDK has a caller asking for it, and the option is additive, so parity can follow when one does.

## Consumer

basecamp-cli wires `--login-hint` through `LoginOptions.LoginHint` and appends this option once it bumps to an SDK that carries it (basecamp/basecamp-cli — "auth login --with-token" PR).

## Verification

- `cd go && go vet ./pkg/basecamp/oauth && go test ./pkg/basecamp/oauth` — green. New `TestRequestDeviceAuthorization_SendsLoginHintWhenSet` covers both the sent form and the omitted-when-unset form.
- `gofmt -l` clean. `make lint` did not run locally (golangci-lint on this machine predates the Go 1.27 export-data format and fails typecheck on every package, `main` included); CI's lint is the gate.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `oauth.WithDeviceLoginHint` so `oauth.RequestDeviceAuthorization` can include Basecamp’s optional RFC 8628 `login_hint`, steering shared or multi-identity machines to the intended sign-in. Without the option, requests are unchanged; the hint never authenticates, and approval still comes from whoever holds the session.

**Spec**
- Documents optional `loginHint?` support for device authorization and device login as Go-only until another SDK needs it.

<sup>Written for commit f9426ed146ef65e4e021efecac055fe57d3a006a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-sdk/pull/841?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

