### PR TITLE
fix(typescript): raise js-yaml override past high-severity advisory

### DIFF
--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -2169,9 +2169,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
-      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
       "dev": true,
       "funding": [
         {

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -72,6 +72,6 @@
     "minimatch": ">=10.2.1",
     "brace-expansion": ">=5.0.9",
     "fast-uri": ">=3.1.7 <4",
-    "js-yaml": ">=4.3.1 <5"
+    "js-yaml": ">=4.3.2 <5"
   }
 }


### PR DESCRIPTION
## Problem

The **npm Audit (TypeScript SDK)** CI step (`npm audit --audit-level=high` in `typescript/`) fails on `main` and every open PR (e.g. #847, [run 34295807964](https://github.com/basecamp/basecamp-sdk/actions/runs/34295807964)):

```
js-yaml  4.0.0 - 4.3.1
Severity: high
js-yaml: maxTotalMergeKeys does not limit CPU use for empty merge sources - https://github.com/advisories/GHSA-2883-xcg3-v3hh
node_modules/js-yaml
1 high severity vulnerability
```

- **Package:** `js-yaml`, high severity, fixed in `4.3.2`.
- **Path:** transitive, dev-only — `openapi-typescript` (devDependency) → `@redocly/openapi-core` → `js-yaml`. No runtime/published exposure.
- **Root cause:** the existing `overrides` entry pins `js-yaml` to the 4.x patched line (`>=4.3.1 <5`, from #385), but its lower bound still permitted the now-vulnerable `4.3.1`. The advisory was disclosed after `main`'s last green audit, so the same pinned resolution that passed before now fails.

## Fix

Raise the existing override bound to `>=4.3.2 <5` and regenerate `package-lock.json` (same shape as #840 for `fast-uri`). Stays within the 4.x major, so `@redocly/openapi-core`'s declared `^4.1.0` range is still honoured; js-yaml 5 remains excluded as a major bump for the transitive use.

Diff scope: `typescript/package.json` (one override bound) and `typescript/package-lock.json` (js-yaml `4.3.1` → `4.3.2` version/resolved/integrity only — 6 lines). Lockfile regenerated with npm 11.19 / Node 24 as in the audit job, so no unrelated metadata churn.

## Verification (local, Node 24.20 / npm 11.19 as in CI)

- `npm audit --audit-level=high` → **found 0 vulnerabilities**
- `npm ci` → pass; `scripts/assert-lockfiles-unchanged --verify-clean` → manifests match the committed tree
- `npm run build` → pass
- `npm run typecheck` → pass
- `npm run lint`, `npm run lint:test-timers` → pass
- `npm test` → **1711 passed (88 files)**


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raises the `js-yaml` override bound from `>=4.3.1 <5` to `>=4.3.2 <5` so the TypeScript SDK's `npm audit --audit-level=high` passes again.

The old bound allowed `4.3.1`, which is flagged by GHSA-2883-xcg3-v3hh as high severity. `js-yaml` reaches the tree transitively via `openapi-typescript` → `@redocly/openapi-core` as a dev-only dependency, so there's no runtime exposure. The lockfile is regenerated to resolve `4.3.2` within the 4.x major, keeping `@redocly/openapi-core`'s `^4.1.0` range intact.

<sup>Written for commit 213d88b9dab76e6abf89fbd1e2778d46a5876ec0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-sdk/pull/848?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

