### PR TITLE
Clear the open code-scanning alerts

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -30,6 +30,9 @@ paths-ignore:
   # out to be noisy (py/unused-import in every generated service), so codeql.yml's
   # SARIF filter now strips generated/ except services/_ — keeping both
   # hand-written files scanned.
+  # The actions analysis extracted this lockfile and reported a YAML syntax
+  # error (alert #239); no language analyses lockfiles.
+  - '**/Gemfile.lock'
   # Test infrastructure
   - conformance/
   - kotlin/conformance/

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -146,8 +146,10 @@ jobs:
           # Scan against the newest 1.26.x, not whatever patch the runner has cached.
           check-latest: true
 
+      # Pinned for Scorecard PinnedDependencies; the vulnerability database is
+      # fetched live at scan time regardless of the tool version.
       - name: Install govulncheck
-        run: go install golang.org/x/vuln/cmd/govulncheck@latest
+        run: go install golang.org/x/vuln/cmd/govulncheck@v1.8.0
 
       - name: Run govulncheck
         run: govulncheck ./...

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,20 @@ jobs:
         with:
           advanced-security: false
 
+  # setup-gradle already validates the wrapper jars on the Kotlin jobs;
+  # Scorecard's BinaryArtifacts check recognises only this dedicated action.
+  gradle-wrapper:
+    name: Gradle wrapper validation
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: gradle/actions/wrapper-validation@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
+
   smithy:
     uses: ./.github/workflows/smithy-verify.yml
     permissions:

--- a/python/src/basecamp/async_auth.py
+++ b/python/src/basecamp/async_auth.py
@@ -99,11 +99,12 @@ class AsyncOAuthTokenProvider:
 
         # SPEC §9: the httpx error retains the request it failed on — the form
         # body carrying refresh_token and client_secret — so a transport
-        # failure is constructed here and raised outside the handler.
-        transport_error: NetworkError | None = None
+        # failure is constructed here and raised outside the handler. Both arms
+        # bind one name so the continuing path is definitely assigned.
+        outcome: httpx.Response | NetworkError
         try:
             async with httpx.AsyncClient(timeout=30.0) as client:
-                response = await client.post(
+                outcome = await client.post(
                     self.TOKEN_URL,
                     data={
                         "type": "refresh",
@@ -114,9 +115,10 @@ class AsyncOAuthTokenProvider:
                     headers={"Content-Type": "application/x-www-form-urlencoded", "Accept": "application/json"},
                 )
         except httpx.HTTPError as e:
-            transport_error = NetworkError(f"Token refresh network error: {e}")
-        if transport_error is not None:
-            raise transport_error
+            outcome = NetworkError(f"Token refresh network error: {e}")
+        if isinstance(outcome, NetworkError):
+            raise outcome
+        response = outcome
 
         if response.status_code >= 400:
             raise AuthError(f"Token refresh failed: {response.status_code}")

--- a/python/src/basecamp/auth.py
+++ b/python/src/basecamp/auth.py
@@ -98,10 +98,11 @@ class OAuthTokenProvider:
 
         # SPEC §9: the httpx error retains the request it failed on — the form
         # body carrying refresh_token and client_secret — so a transport
-        # failure is constructed here and raised outside the handler.
-        transport_error: NetworkError | None = None
+        # failure is constructed here and raised outside the handler. Both arms
+        # bind one name so the continuing path is definitely assigned.
+        outcome: httpx.Response | NetworkError
         try:
-            response = httpx.post(
+            outcome = httpx.post(
                 self.TOKEN_URL,
                 data={
                     "type": "refresh",
@@ -113,9 +114,10 @@ class OAuthTokenProvider:
                 timeout=30.0,
             )
         except httpx.HTTPError as e:
-            transport_error = NetworkError(f"Token refresh network error: {e}")
-        if transport_error is not None:
-            raise transport_error
+            outcome = NetworkError(f"Token refresh network error: {e}")
+        if isinstance(outcome, NetworkError):
+            raise outcome
+        response = outcome
 
         if response.status_code >= 400:
             raise AuthError(f"Token refresh failed: {response.status_code}")

--- a/python/src/basecamp/oauth/device.py
+++ b/python/src/basecamp/oauth/device.py
@@ -147,12 +147,13 @@ def request_device_authorization(
 
     # SPEC §9: the httpx error retains the request it failed on, so a
     # transport failure is constructed here and raised outside the handler,
-    # chaining nothing (the poll below sends device_code the same way).
-    transport_error: DeviceFlowError | None = None
+    # chaining nothing (the poll below sends device_code the same way). Both
+    # arms bind one name so the continuing path is definitely assigned.
+    outcome: tuple[int, bytes] | DeviceFlowError
     try:
         # A non-2xx device-auth response is a hard failure whose body is unused —
         # skip draining it so a slow error body can't time out and look like transport.
-        status, body = _post_form_bounded(
+        outcome = _post_form_bounded(
             device_authorization_endpoint,
             params,
             timeout,
@@ -160,9 +161,10 @@ def request_device_authorization(
             read_body=lambda s: 200 <= s < 300,
         )
     except httpx.HTTPError as exc:
-        transport_error = DeviceFlowError("transport", f"Device authorization request failed: {exc}")
-    if transport_error is not None:
-        raise transport_error
+        outcome = DeviceFlowError("transport", f"Device authorization request failed: {exc}")
+    if isinstance(outcome, DeviceFlowError):
+        raise outcome
+    status, body = outcome
 
     # Check status BEFORE parsing (as discovery does): a non-2xx here is a hard
     # failure with no OAuth error semantics, so a non-JSON error body must surface

--- a/python/src/basecamp/oauth/exchange.py
+++ b/python/src/basecamp/oauth/exchange.py
@@ -117,8 +117,9 @@ def _token_request(token_endpoint: str, params: dict[str, str]) -> OAuthToken:
     # SPEC §9: the httpx error retains the request it failed on — the form
     # body carrying client_secret, code, code_verifier or refresh_token — so a
     # transport failure is constructed here and raised outside the handler,
-    # chaining nothing.
-    transport_error: OAuthError | None = None
+    # chaining nothing. Both arms bind one name so the continuing path is
+    # definitely assigned.
+    outcome: tuple[int, bytes] | OAuthError
     try:
         # request_bounded, not a bare httpx call: httpx's timeout is per
         # I/O phase (it resets on every received chunk), so a peer dripping
@@ -132,7 +133,7 @@ def _token_request(token_endpoint: str, params: dict[str, str]) -> OAuthToken:
         # the refused redirect statuses so they classify from the headers
         # with the body unread: a 302 whose body stalls forever is the typed
         # refusal below, never a timeout.
-        status, body = request_bounded(
+        outcome = request_bounded(
             "POST",
             token_endpoint,
             headers={
@@ -146,11 +147,12 @@ def _token_request(token_endpoint: str, params: dict[str, str]) -> OAuthToken:
             context="Token",
         )
     except httpx.TimeoutException:
-        transport_error = OAuthError("network", "Token request timed out", retryable=True)
+        outcome = OAuthError("network", "Token request timed out", retryable=True)
     except httpx.HTTPError as exc:
-        transport_error = OAuthError("network", f"Token request failed: {exc}", retryable=True)
-    if transport_error is not None:
-        raise transport_error
+        outcome = OAuthError("network", f"Token request failed: {exc}", retryable=True)
+    if isinstance(outcome, OAuthError):
+        raise outcome
+    status, body = outcome
 
     # A redirect is never a valid token-endpoint outcome and its Location is
     # never dialled — refuse it with the body unread.


### PR DESCRIPTION
## Scope

Every open CodeQL and Scorecard alert that is a code or workflow change. The remaining open alerts are governance settings (Scorecard #69 branch protection admin bypass, #83 approving reviews) and are not touched here; four Scorecard heuristics were dismissed on the alert with reasons (#222, #79 `npm install` in the release lockfile rewriter; #85 fuzzing; #84 best-practices badge).

| Alert | Rule | Verdict | Change |
|---|---|---|---|
| #232, #233 | CodeQL `py/uninitialized-local-variable` — `async_auth.py`, `auth.py` | false positive on a deliberate pattern; restructured so the analysis can prove it | one binding for both arms, narrow on it |
| #234, #235 | same — `oauth/device.py` | same | same |
| #236, #237 | same — `oauth/exchange.py` | same | same |
| #239 | CodeQL `actions/syntax-error` on `ruby/Gemfile.lock` | false positive: the actions analysis parsed a lockfile as YAML | `**/Gemfile.lock` in `paths-ignore` |
| #163 | Scorecard PinnedDependencies — `go install govulncheck@latest` | fix | pinned to `v1.8.0`; the vulnerability database is fetched live regardless |
| #70, #71 | Scorecard BinaryArtifacts — two `gradle-wrapper.jar` | jars match Gradle's published 9.7.1 SHA-256; setup-gradle already validates them, but Scorecard recognises only the dedicated action | `gradle/actions/wrapper-validation` job in `test.yml`, same SHA as the existing `setup-gradle` pin |

## The Python change

The six sites are SPEC §9 transport-failure handlers: the error is constructed inside `except` and raised after it so the httpx exception (which retains the request, whose form body carries `client_secret` / `refresh_token` / `device_code`) never lands in `__context__`. Before, the try arm bound `response` (or `status, body`) and the except arm bound `transport_error`, and the raise was guarded on `transport_error is not None`. That is correct, but a definite-assignment analysis cannot correlate the two names. Now both arms bind `outcome: Response | NetworkError` (or `tuple[int, bytes] | OAuthError`) and the continuing path is `if isinstance(outcome, Error): raise outcome`. Control flow, message text and no-chaining semantics are unchanged; mypy narrows the union without annotations.

Not changed: `device.py`'s token poll (`poll_error`) keeps its shape; CodeQL did not flag it and it has a `continue` arm that the union form would not simplify.

## Verification

- `make py-check` (1603 passed, mypy clean, ruff clean); full `make check` locally, see below.
- `actionlint` clean; `zizmor .` reports only the seven pre-existing `self-repository` lows on `uses: ./.github/workflows/smithy-verify.yml`, none from the new job.
- Scorecard runs on push to `main` and weekly; #70/#71 clear once `test.yml` has a green run on the latest `main` commit, #163 on the next scan. The CodeQL alerts close on the next `main` analysis.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clears the remaining open CodeQL and Scorecard alerts that are code or workflow changes, without changing runtime behavior.

**CodeQL**
- Restructured the six SPEC §9 transport-failure handlers so both try/except arms bind one name and the continuing path narrows on it; control flow, messages, and no-chaining semantics are unchanged.
- Added `**/Gemfile.lock` to `paths-ignore`; the actions analysis was parsing the lockfile as YAML.

**Scorecard**
- Pinned `govulncheck` to `v1.8.0`; the vulnerability database is still fetched live at scan time.
- Added a `gradle/actions/wrapper-validation` job to `test.yml`; the wrapper jars match Gradle's published checksum and `setup-gradle` already validates them, but Scorecard only recognizes the dedicated action.
- Remaining alerts are governance settings and dismissed heuristics, not touched here.

<sup>Written for commit 3afef347e8e33e6c4d3b9b3bd04c5ae889e2cbaa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-sdk/pull/851?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

