### PR TITLE
fix(go): FlexibleTime marshals back the form it parsed

### DIFF
--- a/go/pkg/basecamp/schedules_test.go
+++ b/go/pkg/basecamp/schedules_test.go
@@ -1236,13 +1236,14 @@ func TestSchedulesService_EditEntryHooksObserveGetEntryAndReplaceEntry(t *testin
 // carry that string through untouched.
 //
 // The trap this pins: ScheduleEntry.StartsAt is types.FlexibleTime, whose
-// UnmarshalJSON accepts the bare date by treating it as midnight UTC, and whose
-// MarshalJSON then renders time.Time's RFC3339 form. Round-tripping the DECODED
-// value would therefore rewrite "2026-06-01" into "2026-06-01T00:00:00Z", which
-// BC3 re-parses in the account's own zone — west of UTC that lands on the
-// previous day and moves the entry. ScheduleEntryFields carries strings for
-// exactly this reason, sourced from the raw response bytes rather than the
-// decoded time.
+// UnmarshalJSON accepts the bare date by treating it as midnight UTC. Until
+// #633 its MarshalJSON then rendered time.Time's RFC3339 form, so
+// round-tripping the DECODED value rewrote "2026-06-01" into
+// "2026-06-01T00:00:00Z", which BC3 re-parses in the account's own zone — west
+// of UTC that lands on the previous day and moves the entry. FlexibleTime now
+// re-emits the form it parsed; ScheduleEntryFields still carries strings,
+// sourced from the raw response bytes, because that read is also what proves
+// the key was present at all (see scheduleEntryFieldsFrom).
 func TestSchedulesService_EditEntryRoundTripsAnAllDayBareDate(t *testing.T) {
 	get := patchScheduleEntryFixture(t, scheduleEntryReadBack(t), map[string]any{
 		"all_day":   true,
@@ -1273,23 +1274,31 @@ func TestSchedulesService_EditEntryRoundTripsAnAllDayBareDate(t *testing.T) {
 	}
 }
 
-// The other half of that finding, stated directly: this is what the composite
-// would have sent had it re-rendered the decoded value. If FlexibleTime ever
-// learns to preserve its source text, this test is the thing that says so.
-func TestFlexibleTimeMarshalRewritesABareDate(t *testing.T) {
+// The other half of that finding, stated directly at the model layer: an
+// entry decoded from the wire re-marshals its all-day bound as the bare date
+// bc3 sent, not as the midnight-UTC instant it decoded to. Before #633 this
+// produced "2026-06-01T00:00:00Z".
+func TestScheduleEntry_MarshalPreservesABareDateBound(t *testing.T) {
 	var entry ScheduleEntry
-	if err := json.Unmarshal([]byte(`{"starts_at":"2026-06-01","all_day":true}`), &entry); err != nil {
+	if err := json.Unmarshal([]byte(`{"starts_at":"2026-06-01","ends_at":"2026-06-03","all_day":true}`), &entry); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	out, err := json.Marshal(entry.StartsAt)
+	out, err := json.Marshal(entry)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if string(out) == `"2026-06-01"` {
-		t.Skip("FlexibleTime now round-trips its source text; ScheduleEntryFields could carry the decoded value")
+	var body map[string]any
+	if err := json.Unmarshal(out, &body); err != nil {
+		t.Fatalf("unexpected error: %v", err)
 	}
-	if string(out) != `"2026-06-01T00:00:00Z"` {
-		t.Errorf("expected the midnight-UTC rewrite %q, got %s", "2026-06-01T00:00:00Z", out)
+	if body["starts_at"] != "2026-06-01" {
+		t.Errorf("expected starts_at %q verbatim, got %v", "2026-06-01", body["starts_at"])
+	}
+	if body["ends_at"] != "2026-06-03" {
+		t.Errorf("expected ends_at %q verbatim, got %v", "2026-06-03", body["ends_at"])
+	}
+	if !entry.StartsAt.DateOnly() || !entry.EndsAt.DateOnly() {
+		t.Error("expected both bounds to report DateOnly()")
 	}
 }
 

--- a/go/pkg/types/flexible_time.go
+++ b/go/pkg/types/flexible_time.go
@@ -11,13 +11,28 @@ import (
 // or date-only ("2006-01-02") strings. Date-only values are treated as midnight
 // UTC. This supports API responses where all-day schedule entries return dates
 // without times.
+//
+// It remembers which form it parsed and marshals that form back: a bare date
+// re-emits as a bare date, a timestamp as a timestamp. BC3 re-parses a
+// timestamp in the account's own time zone, so an all-day bound rendered as
+// "2026-08-04T00:00:00Z" lands on the previous day anywhere west of UTC — a
+// read-modify-write that widened the date on input and narrowed it on output
+// moved the entry (#633).
 type FlexibleTime struct {
 	time.Time
+	dateOnly bool
+}
+
+// DateOnly reports whether the value was parsed from a bare date, in which
+// case it marshals back as one.
+func (ft FlexibleTime) DateOnly() bool {
+	return ft.dateOnly
 }
 
 // UnmarshalJSON implements json.Unmarshaler for FlexibleTime.
 func (ft *FlexibleTime) UnmarshalJSON(data []byte) error {
 	s := strings.Trim(string(data), `"`)
+	ft.dateOnly = false
 	if s == "null" || s == "" {
 		ft.Time = time.Time{}
 		return nil
@@ -38,6 +53,7 @@ func (ft *FlexibleTime) UnmarshalJSON(data []byte) error {
 	// Try date-only → midnight UTC
 	if t, err := time.Parse("2006-01-02", s); err == nil {
 		ft.Time = t
+		ft.dateOnly = true
 		return nil
 	}
 
@@ -45,10 +61,14 @@ func (ft *FlexibleTime) UnmarshalJSON(data []byte) error {
 }
 
 // MarshalJSON implements json.Marshaler for FlexibleTime.
-// Zero times marshal as null; non-zero times use time.Time's JSON encoding.
+// Zero times marshal as null; a value parsed from a bare date marshals as that
+// date; any other non-zero time uses time.Time's JSON encoding.
 func (ft FlexibleTime) MarshalJSON() ([]byte, error) {
 	if ft.IsZero() {
 		return []byte("null"), nil
+	}
+	if ft.dateOnly {
+		return []byte(`"` + ft.Format("2006-01-02") + `"`), nil
 	}
 	return ft.Time.MarshalJSON()
 }

--- a/go/pkg/types/flexible_time.go
+++ b/go/pkg/types/flexible_time.go
@@ -32,8 +32,22 @@ func (ft FlexibleTime) DateOnly() bool {
 // UnmarshalJSON implements json.Unmarshaler for FlexibleTime.
 func (ft *FlexibleTime) UnmarshalJSON(data []byte) error {
 	s := strings.Trim(string(data), `"`)
+	if s == "null" {
+		ft.Time = time.Time{}
+		ft.dateOnly = false
+		return nil
+	}
+	return ft.UnmarshalText([]byte(s))
+}
+
+// UnmarshalText implements encoding.TextUnmarshaler. Defined here rather than
+// promoted from the embedded time.Time so that every decode path, not only
+// JSON, records which form it parsed — a promoted UnmarshalText would replace
+// the time and leave a stale bare-date flag behind.
+func (ft *FlexibleTime) UnmarshalText(data []byte) error {
+	s := string(data)
 	ft.dateOnly = false
-	if s == "null" || s == "" {
+	if s == "" {
 		ft.Time = time.Time{}
 		return nil
 	}
@@ -60,15 +74,26 @@ func (ft *FlexibleTime) UnmarshalJSON(data []byte) error {
 	return fmt.Errorf("cannot parse %q as RFC3339, RFC3339Nano, or date-only", s)
 }
 
-// MarshalJSON implements json.Marshaler for FlexibleTime.
-// Zero times marshal as null; a value parsed from a bare date marshals as that
-// date; any other non-zero time uses time.Time's JSON encoding.
-func (ft FlexibleTime) MarshalJSON() ([]byte, error) {
-	if ft.IsZero() {
-		return []byte("null"), nil
+// MarshalText implements encoding.TextMarshaler: the bare date when one was
+// parsed, otherwise time.Time's RFC3339 text.
+func (ft FlexibleTime) MarshalText() ([]byte, error) {
+	if ft.dateOnly {
+		return []byte(ft.Format("2006-01-02")), nil
 	}
+	return ft.Time.MarshalText()
+}
+
+// MarshalJSON implements json.Marshaler for FlexibleTime.
+// A value parsed from a bare date marshals as that date, even "0001-01-01",
+// which is Go's zero time and would otherwise collapse to null; a zero time
+// that was never parsed from a date marshals as null; any other time uses
+// time.Time's JSON encoding.
+func (ft FlexibleTime) MarshalJSON() ([]byte, error) {
 	if ft.dateOnly {
 		return []byte(`"` + ft.Format("2006-01-02") + `"`), nil
+	}
+	if ft.IsZero() {
+		return []byte("null"), nil
 	}
 	return ft.Time.MarshalJSON()
 }

--- a/go/pkg/types/flexible_time.go
+++ b/go/pkg/types/flexible_time.go
@@ -83,6 +83,17 @@ func (ft FlexibleTime) MarshalText() ([]byte, error) {
 	return ft.Time.MarshalText()
 }
 
+// AppendText implements encoding.TextAppender with the same form MarshalText
+// emits; the promoted time.Time.AppendText would append the RFC3339 form of
+// a bare date.
+func (ft FlexibleTime) AppendText(b []byte) ([]byte, error) {
+	text, err := ft.MarshalText()
+	if err != nil {
+		return b, err
+	}
+	return append(b, text...), nil
+}
+
 // MarshalJSON implements json.Marshaler for FlexibleTime.
 // A value parsed from a bare date marshals as that date, even "0001-01-01",
 // which is Go's zero time and would otherwise collapse to null; a zero time

--- a/go/pkg/types/flexible_time_test.go
+++ b/go/pkg/types/flexible_time_test.go
@@ -90,3 +90,61 @@ func TestFlexibleTime_DateOnlyMidnightUTC(t *testing.T) {
 		t.Errorf("expected 2026-03-02, got %v", ft.Time)
 	}
 }
+
+// Both directions, because a one-directional test passes today: the bare
+// date must come back as a bare date (this failed before the fix), and a real
+// timestamp must come back unchanged (this guards against "fixing" it by
+// always emitting a date).
+func TestFlexibleTime_RoundTripPreservesTheParsedForm(t *testing.T) {
+	tests := []struct {
+		name     string
+		wire     string
+		dateOnly bool
+	}{
+		{"bare date", `"2026-08-04"`, true},
+		{"UTC timestamp", `"2026-08-04T00:00:00Z"`, false},
+		{"offset timestamp", `"2026-08-04T09:30:00-07:00"`, false},
+		{"fractional timestamp", `"2022-11-01T10:00:00.123456Z"`, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var ft FlexibleTime
+			if err := json.Unmarshal([]byte(tt.wire), &ft); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if ft.DateOnly() != tt.dateOnly {
+				t.Errorf("DateOnly() = %v, want %v", ft.DateOnly(), tt.dateOnly)
+			}
+			out, err := json.Marshal(ft)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if string(out) != tt.wire {
+				t.Errorf("round trip rewrote %s as %s", tt.wire, out)
+			}
+		})
+	}
+}
+
+// The form is a property of the last decode, not of the variable: a value
+// reused across decodes must not carry a stale bare-date flag into a
+// timestamp, or a stale timestamp into a null.
+func TestFlexibleTime_ReuseResetsTheParsedForm(t *testing.T) {
+	var ft FlexibleTime
+	for _, wire := range []string{`"2026-08-04"`, `"2026-08-04T10:00:00Z"`, `"2026-08-05"`, `null`} {
+		if err := json.Unmarshal([]byte(wire), &ft); err != nil {
+			t.Fatalf("unexpected error decoding %s: %v", wire, err)
+		}
+		out, err := json.Marshal(ft)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if string(out) != wire {
+			t.Errorf("after decoding %s, marshal gave %s", wire, out)
+		}
+	}
+	if ft.DateOnly() {
+		t.Error("a null must not read as date-only")
+	}
+}

--- a/go/pkg/types/flexible_time_test.go
+++ b/go/pkg/types/flexible_time_test.go
@@ -102,6 +102,7 @@ func TestFlexibleTime_RoundTripPreservesTheParsedForm(t *testing.T) {
 		dateOnly bool
 	}{
 		{"bare date", `"2026-08-04"`, true},
+		{"bare date at Go's zero time", `"0001-01-01"`, true},
 		{"UTC timestamp", `"2026-08-04T00:00:00Z"`, false},
 		{"offset timestamp", `"2026-08-04T09:30:00-07:00"`, false},
 		{"fractional timestamp", `"2022-11-01T10:00:00.123456Z"`, false},
@@ -146,5 +147,39 @@ func TestFlexibleTime_ReuseResetsTheParsedForm(t *testing.T) {
 	}
 	if ft.DateOnly() {
 		t.Error("a null must not read as date-only")
+	}
+}
+
+// The flag must follow every decode path, not only JSON: a FlexibleTime that
+// decoded a bare date and is then fed a timestamp through UnmarshalText (the
+// path text-based decoders and map keys take) must not keep the date flag.
+func TestFlexibleTime_TextRoundTripPreservesTheParsedForm(t *testing.T) {
+	var ft FlexibleTime
+	if err := json.Unmarshal([]byte(`"2026-08-04"`), &ft); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if err := ft.UnmarshalText([]byte("2026-08-04T10:00:00Z")); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if ft.DateOnly() {
+		t.Error("UnmarshalText of a timestamp left the bare-date flag set")
+	}
+	out, err := json.Marshal(ft)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(out) != `"2026-08-04T10:00:00Z"` {
+		t.Errorf("expected the timestamp back, got %s", out)
+	}
+
+	if err := ft.UnmarshalText([]byte("2026-08-05")); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	text, err := ft.MarshalText()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(text) != "2026-08-05" {
+		t.Errorf("expected MarshalText to emit the bare date, got %s", text)
 	}
 }

--- a/go/pkg/types/flexible_time_test.go
+++ b/go/pkg/types/flexible_time_test.go
@@ -182,4 +182,11 @@ func TestFlexibleTime_TextRoundTripPreservesTheParsedForm(t *testing.T) {
 	if string(text) != "2026-08-05" {
 		t.Errorf("expected MarshalText to emit the bare date, got %s", text)
 	}
+	appended, err := ft.AppendText([]byte("at "))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if string(appended) != "at 2026-08-05" {
+		t.Errorf("expected AppendText to agree with MarshalText, got %q", appended)
+	}
 }

--- a/scripts/enhance-openapi-go-types.sh
+++ b/scripts/enhance-openapi-go-types.sh
@@ -310,10 +310,11 @@ walk(
 #
 # time.Time cannot hold that value: it marshals RFC3339 unconditionally, so a
 # bare date could not be SENT even after being parsed. types.FlexibleTime is not
-# the fix either — it decodes a bare date but marshals it back as a midnight
-# timestamp (issue #633), the same loss one layer down. The bound is opaque on
-# the way in and must round-trip verbatim, which is how the hand-marshaled body
-# of ReplaceScheduleEntryRequest already treats it.
+# the fix either: it round-trips the form it DECODED (#633), but a request bound
+# is never decoded — the caller supplies it, and a string carries whichever
+# form they chose without a parse in between. The bound is opaque on the way in
+# and must reach the wire verbatim, which is how the hand-marshaled body of
+# ReplaceScheduleEntryRequest already treats it.
 #
 # Go was alone in this. Every other SDK generates `string` here straight from
 # the OpenAPI type, so create and replace agreed everywhere but Go, where a


### PR DESCRIPTION
## Summary

`types.FlexibleTime` accepted a bare date (`"2026-08-04"`) on decode and marshaled it back as `"2026-08-04T00:00:00Z"`. BC3 re-parses that timestamp in the account's time zone, so an all-day bound read and written back landed on the previous day anywhere west of UTC — silent data corruption on the read-modify-write path.

`FlexibleTime` now remembers which form it parsed and re-emits it: a bare date round-trips as a bare date, a timestamp as a timestamp, null as null. `DateOnly()` exposes the parsed form so a caller can tell an all-day bound from a midnight instant without re-reading the wire.

## Red-proof, both directions

- `TestFlexibleTime_RoundTripPreservesTheParsedForm` — `"2026-08-04"` → marshal → `"2026-08-04"` (failed before: produced the midnight timestamp), and `"2026-08-04T00:00:00Z"`, an offset timestamp, and a fractional one all come back unchanged (guards against "fixing" it by always emitting a date).
- `TestFlexibleTime_ReuseResetsTheParsedForm` — the flag is a property of the last decode: reusing one variable across date, timestamp, date, null re-emits each faithfully.
- `TestScheduleEntry_MarshalPreservesABareDateBound` — the model layer, from the literal wire body `{"starts_at":"2026-06-01","ends_at":"2026-06-03","all_day":true}`. This replaces `TestFlexibleTimeMarshalRewritesABareDate`, which pinned the defect and carried a `t.Skip` for the day it was fixed.

## What did not change, and why

- The Go schedule composites still carry `starts_at`/`ends_at` as strings sourced from the raw response bytes. That read is also what proves the keys were present (`scheduleEntryFieldsFrom`), which the decoded struct cannot, so it stays; the comments now say so instead of describing this defect as the reason.
- Request bodies stay plain `string` (the #634 fix). A request bound is never decoded, so `FlexibleTime` has nothing to preserve there; the `enhance-openapi-go-types.sh` comment that cited #633 as a live loss is updated.
- Siblings checked per the issue: `types.Date` parses only `YYYY-MM-DD` and emits the same, so it cannot widen; `types.FlexInt` (`1024.0` → `1024`) and `types.FlexibleInt64` (`"123"` → `123`) narrow the spelling of an integer whose value BC3 treats identically either way — no day-shift class there.
- Other SDKs: TypeScript, Ruby, Python, Kotlin and Swift generate `string` for these members straight from the OpenAPI type and pass the bound through verbatim, so Go was the only SDK with the asymmetry.

`apidiff` against `main`: one compatible change (`FlexibleTime.DateOnly` added). Adding the unexported field does not affect keyed literals or comparability.

Fixes #633

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `types.FlexibleTime` so all-day schedule bounds round-trip verbatim: a bare date like `"2026-08-04"` previously re-marshaled as a midnight-UTC timestamp, which BC3 re-parses in the account's time zone and shifts a day earlier west of UTC on read-modify-write. The type now remembers which form it parsed and re-emits it; timestamps and null are unchanged. Adds `DateOnly()` so callers can tell the parsed form without re-reading the wire.

- Form tracking also covers the text decode path (`UnmarshalText`, used by map keys and text-based decoders), `AppendText` agrees with `MarshalText`, and a zero-time bare date (`"0001-01-01"`) marshals as a date rather than collapsing to null.
- Go was the only SDK with this asymmetry; TypeScript, Ruby, Python, Kotlin, and Swift already pass these members through verbatim as strings.
- Compatible change: `apidiff` reports only the new method, and request bodies keep using plain strings since they are never decoded.

<sup>Written for commit 03946c4fdd00c1da72ded1be9ff123e8a6250d05. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-sdk/pull/852?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

