### PR TITLE
fix(gauges): absorb five spec drifts from the contract bc3 serves

### DIFF
--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -22,22 +22,40 @@ service surface, retry, pagination, hooks, structured errors, OAuth, and
 webhook verification; ETag caching and the §23 Event Feed connector are
 follow-ups. See [`rust/basecamp-sdk/README.md`](rust/basecamp-sdk/README.md).
 
-### Gauges: `UpdateGaugeNeedle` requires its `gauge_needle` wrapper, and Go's `Gauge.PreviousNeedlePosition` is a pointer (#731)
+### Gauges: `UpdateGaugeNeedle` requires its payload, `GaugeNeedle` gains a required `comment_count`, and Go's `Gauge.PreviousNeedlePosition` is a pointer (#731)
 
-Five drifts between the gauges spec and what bc3 serves, in one PR. Two are
-source-breaking.
+Five drifts between the gauges spec and what bc3 serves, in one PR. Three
+are source-breaking.
 
-- **`gauge_needle` is required on `UpdateGaugeNeedle`.** bc3's
-  `needle_params` opens with `params.require(:gauge_needle)`, so a body
-  without the wrapper was always a 400, never a no-op — the spec just let you
-  send one. TypeScript's `updateGaugeNeedle(id, { gaugeNeedle })` now types
-  the member required (and refuses a missing one before the wire, as a
-  `validation` error); Python's `update_gauge_needle(needle_id=, gauge_needle=)`
-  and Ruby's `update_gauge_needle(needle_id:, gauge_needle:)` drop the `None`
-  / `nil` default; Kotlin's `UpdateGaugeNeedleBody(gaugeNeedle)` and Swift's
-  `UpdateGaugeNeedleRequest(gaugeNeedle:)` take a non-optional payload. A
-  call that omitted it (or passed `nil`) stops compiling, or raises before
-  the request, instead of getting the 400 it always got.
+- **`gauge_needle`, and its `description`, are required on
+  `UpdateGaugeNeedle`.** bc3's `needle_params` opens with
+  `params.require(:gauge_needle)`, which rejects a missing wrapper and an
+  empty one alike, and `description` is the only member the update accepts —
+  so a body without either was always a 400, never a no-op; the spec just
+  let you send one. What changes per SDK:
+  - TypeScript: `updateGaugeNeedle(id, { gaugeNeedle: { description } })`
+    types both members required, and a missing `gaugeNeedle` is refused
+    before the wire as a `validation` error.
+  - Python and Ruby: `update_gauge_needle(needle_id=, gauge_needle=)` /
+    `update_gauge_needle(needle_id:, gauge_needle:)` drop the `None` / `nil`
+    default, so an **omitted** argument is a signature error. An explicit
+    `None` / `nil` is still compacted off the body and gets the server's 400,
+    as before; the dict-shaped SDKs do no runtime validation of the payload.
+  - Kotlin: `UpdateGaugeNeedleBody(gaugeNeedle)` takes a non-null
+    `JsonObject`.
+  - Swift: `UpdateGaugeNeedleRequest(gaugeNeedle:)` takes a non-optional
+    `GaugeNeedleUpdatePayload`, whose initializer is now
+    `init(description:)` with no default.
+  - Go: `UpdateGaugeNeedleRequest.Description` stays `*string`, but `nil` is
+    refused before the request as a usage error; it never left the
+    description untouched, it produced the 400.
+- **`GaugeNeedle.comment_count` is required.** bc3 emits the singular key
+  unconditionally (distinct from the envelope's plural `comments_count`), so
+  the spec models it `@required`: Swift's public `GaugeNeedle` initializer
+  gains a required `commentCount:` parameter, TypeScript's and Python's
+  model types gain a required member, and Go's `GaugeNeedle` gains
+  `CommentCount int32`. Code that constructs these values by hand has to
+  supply it; code that decodes them from the wire gets it for free.
 - **Go: `Gauge.PreviousNeedlePosition` is `*int32`, not `int32`.** bc3 emits
   the key as JSON `null` for a gauge whose only needle is its first, and the
   value type decoded that to `0` — the same value as a genuine move from
@@ -55,14 +73,10 @@ source-breaking.
   The OpenAPI member is `nullable: true` now, so TypeScript types it
   `number | null | undefined`; Kotlin and Swift already typed it optional.
 
-Not breaking, in the same PR: `GaugeNeedle` gains the singular
-`comment_count` bc3 emits unconditionally (Go `CommentCount`, Swift
-`commentCount`; required, so a Swift or Go struct literal you build by hand
-needs it), distinct from the envelope's plural `comments_count`;
-`ToggleGauge` declares `NotFoundError` for an unknown project; and the
-`notify` documentation on `CreateGaugeNeedle` names the values bc3 actually
-accepts — `everyone`, `default`, `custom` — where it used to name a
-`working_on` that silently notified nobody.
+Not breaking, in the same PR: `ToggleGauge` declares `NotFoundError` for an
+unknown project, and the `notify` documentation on `CreateGaugeNeedle`
+names the values bc3 actually accepts — `everyone`, `default`, `custom` —
+where it used to name a `working_on` that silently notified nobody.
 
 ---
 

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -22,6 +22,48 @@ service surface, retry, pagination, hooks, structured errors, OAuth, and
 webhook verification; ETag caching and the §23 Event Feed connector are
 follow-ups. See [`rust/basecamp-sdk/README.md`](rust/basecamp-sdk/README.md).
 
+### Gauges: `UpdateGaugeNeedle` requires its `gauge_needle` wrapper, and Go's `Gauge.PreviousNeedlePosition` is a pointer (#731)
+
+Five drifts between the gauges spec and what bc3 serves, in one PR. Two are
+source-breaking.
+
+- **`gauge_needle` is required on `UpdateGaugeNeedle`.** bc3's
+  `needle_params` opens with `params.require(:gauge_needle)`, so a body
+  without the wrapper was always a 400, never a no-op — the spec just let you
+  send one. TypeScript's `updateGaugeNeedle(id, { gaugeNeedle })` now types
+  the member required (and refuses a missing one before the wire, as a
+  `validation` error); Python's `update_gauge_needle(needle_id=, gauge_needle=)`
+  and Ruby's `update_gauge_needle(needle_id:, gauge_needle:)` drop the `None`
+  / `nil` default; Kotlin's `UpdateGaugeNeedleBody(gaugeNeedle)` and Swift's
+  `UpdateGaugeNeedleRequest(gaugeNeedle:)` take a non-optional payload. A
+  call that omitted it (or passed `nil`) stops compiling, or raises before
+  the request, instead of getting the 400 it always got.
+- **Go: `Gauge.PreviousNeedlePosition` is `*int32`, not `int32`.** bc3 emits
+  the key as JSON `null` for a gauge whose only needle is its first, and the
+  value type decoded that to `0` — the same value as a genuine move from
+  position 0. `nil` now means "no previous position". Value-receiver methods
+  do not help here; dereference after a nil check:
+
+  ```go
+  // Before
+  moved := g.PreviousNeedlePosition != g.LastNeedlePosition
+
+  // After
+  moved := g.PreviousNeedlePosition != nil && *g.PreviousNeedlePosition != g.LastNeedlePosition
+  ```
+
+  The OpenAPI member is `nullable: true` now, so TypeScript types it
+  `number | null | undefined`; Kotlin and Swift already typed it optional.
+
+Not breaking, in the same PR: `GaugeNeedle` gains the singular
+`comment_count` bc3 emits unconditionally (Go `CommentCount`, Swift
+`commentCount`; required, so a Swift or Go struct literal you build by hand
+needs it), distinct from the envelope's plural `comments_count`;
+`ToggleGauge` declares `NotFoundError` for an unknown project; and the
+`notify` documentation on `CreateGaugeNeedle` names the values bc3 actually
+accepts — `everyone`, `default`, `custom` — where it used to name a
+`working_on` that silently notified nobody.
+
 ---
 
 # v0.18.0

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -49,7 +49,8 @@ are source-breaking.
   - Go: `UpdateGaugeNeedleRequest.Description` stays `*string`, but `nil` is
     refused before the request as a usage error; it never left the
     description untouched, it produced the 400.
-  - Rust: `UpdateGaugeNeedleRequest { gauge_needle }` takes a
+  - Rust: `UpdateGaugeNeedleRequestContent { gauge_needle }` (re-exported
+    from the crate's `types` module) takes a
     `GaugeNeedleUpdatePayload` rather than an `Option`, and its
     `description` is a `String` rather than an `Option<String>`.
 - **`GaugeNeedle.comment_count` is required.** bc3 emits the singular key
@@ -75,7 +76,10 @@ are source-breaking.
   ```
 
   The OpenAPI member is `nullable: true` now, so TypeScript types it
-  `number | null | undefined`; Kotlin and Swift already typed it optional.
+  `number | null | undefined` and Python's `Gauge` TypedDict types it
+  `NotRequired[Optional[int]]` — a key-presence check no longer narrows it to
+  `int`, so check for `None` too. Kotlin, Swift and Rust already typed it
+  optional.
 
 Not breaking, in the same PR: `ToggleGauge` declares `NotFoundError` for an
 unknown project, and the `notify` documentation on `CreateGaugeNeedle`

--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -49,13 +49,17 @@ are source-breaking.
   - Go: `UpdateGaugeNeedleRequest.Description` stays `*string`, but `nil` is
     refused before the request as a usage error; it never left the
     description untouched, it produced the 400.
+  - Rust: `UpdateGaugeNeedleRequest { gauge_needle }` takes a
+    `GaugeNeedleUpdatePayload` rather than an `Option`, and its
+    `description` is a `String` rather than an `Option<String>`.
 - **`GaugeNeedle.comment_count` is required.** bc3 emits the singular key
   unconditionally (distinct from the envelope's plural `comments_count`), so
   the spec models it `@required`: Swift's public `GaugeNeedle` initializer
   gains a required `commentCount:` parameter, TypeScript's and Python's
-  model types gain a required member, and Go's `GaugeNeedle` gains
-  `CommentCount int32`. Code that constructs these values by hand has to
-  supply it; code that decodes them from the wire gets it for free.
+  model types gain a required member, Go's `GaugeNeedle` gains
+  `CommentCount int32`, and Rust's gains `comment_count: i32`. Code that
+  constructs these values by hand has to supply it; code that decodes them
+  from the wire gets it for free.
 - **Go: `Gauge.PreviousNeedlePosition` is `*int32`, not `int32`.** bc3 emits
   the key as JSON `null` for a gauge whose only needle is its first, and the
   value type decoded that to `0` — the same value as a genuine move from

--- a/SPEC.md
+++ b/SPEC.md
@@ -390,8 +390,12 @@ Every SDK exposes the same three-method, two-state surface over it:
 
   This still holds for `UpdateTodolistRequest` and `UpdateDocumentRequest`. It no
   longer holds for uploads: `UpdateUploadRequest.Description` and
-  `CreateUploadVersionRequest.Description` are `*string`, following the
-  gauge-needle precedent, so `Ptr("")` clears and `nil` leaves the field alone.
+  `CreateUploadVersionRequest.Description` are `*string`, so `Ptr("")` clears
+  and `nil` leaves the field alone. `UpdateGaugeNeedleRequest.Description` is
+  `*string` too but carries no third state: the description is the payload's
+  only member and bc3 requires it, so `nil` is refused as a usage error before
+  any request is sent — it never left the field alone; it bought the server's
+  400 — and there is nothing to clear.
   `BaseName` stays a plain `string` on both — `Upload#base_name=` guards on
   `new_base_name.present?`, so `""` and absent are the same write server-side and
   there is no third state a pointer could express.

--- a/go/pkg/basecamp/gauges.go
+++ b/go/pkg/basecamp/gauges.go
@@ -27,17 +27,22 @@ type Gauge struct {
 	Status                 string                `json:"status,omitempty"`
 	LastNeedleColor        string                `json:"last_needle_color,omitempty"`
 	LastNeedlePosition     int32                 `json:"last_needle_position,omitempty"`
-	PreviousNeedlePosition int32                 `json:"previous_needle_position,omitempty"`
-	InheritsStatus         bool                  `json:"inherits_status,omitempty"`
-	VisibleToClients       bool                  `json:"visible_to_clients,omitempty"`
-	Type                   string                `json:"type,omitempty"`
-	URL                    string                `json:"url,omitempty"`
-	AppURL                 string                `json:"app_url,omitempty"`
-	BookmarkURL            string                `json:"bookmark_url,omitempty"`
-	Creator                *Person               `json:"creator,omitempty"`
-	Bucket                 *Bucket               `json:"bucket,omitempty"`
-	CreatedAt              time.Time             `json:"created_at"`
-	UpdatedAt              time.Time             `json:"updated_at"`
+	// PreviousNeedlePosition is the position the needle moved from. BC3 emits
+	// it with the other needle keys whenever the gauge has needles, and as JSON
+	// null for a gauge whose only needle is its first — so it is a pointer: nil
+	// is "no previous position", distinct from a genuine move from 0, which a
+	// plain int32 could not tell apart from the null.
+	PreviousNeedlePosition *int32    `json:"previous_needle_position,omitempty"`
+	InheritsStatus         bool      `json:"inherits_status,omitempty"`
+	VisibleToClients       bool      `json:"visible_to_clients,omitempty"`
+	Type                   string    `json:"type,omitempty"`
+	URL                    string    `json:"url,omitempty"`
+	AppURL                 string    `json:"app_url,omitempty"`
+	BookmarkURL            string    `json:"bookmark_url,omitempty"`
+	Creator                *Person   `json:"creator,omitempty"`
+	Bucket                 *Bucket   `json:"bucket,omitempty"`
+	CreatedAt              time.Time `json:"created_at"`
+	UpdatedAt              time.Time `json:"updated_at"`
 }
 
 // GaugeNeedle represents a single needle (progress update) on a gauge.
@@ -59,19 +64,23 @@ type GaugeNeedle struct {
 	InheritsStatus         bool                 `json:"inherits_status,omitempty"`
 	VisibleToClients       bool                 `json:"visible_to_clients,omitempty"`
 	CommentsCount          int32                `json:"comments_count,omitempty"`
-	BoostsCount            int32                `json:"boosts_count,omitempty"`
-	Type                   string               `json:"type,omitempty"`
-	URL                    string               `json:"url,omitempty"`
-	AppURL                 string               `json:"app_url,omitempty"`
-	BookmarkURL            string               `json:"bookmark_url,omitempty"`
-	CommentsURL            string               `json:"comments_url,omitempty"`
-	BoostsURL              string               `json:"boosts_url,omitempty"`
-	SubscriptionURL        string               `json:"subscription_url,omitempty"`
-	Creator                *Person              `json:"creator,omitempty"`
-	Bucket                 *Bucket              `json:"bucket,omitempty"`
-	Parent                 *Parent              `json:"parent,omitempty"`
-	CreatedAt              time.Time            `json:"created_at"`
-	UpdatedAt              time.Time            `json:"updated_at"`
+	// CommentCount is the singular key the needle partial emits unconditionally,
+	// distinct from the envelope's plural CommentsCount, which a needle also
+	// carries. @required, so no omitempty.
+	CommentCount    int32     `json:"comment_count"`
+	BoostsCount     int32     `json:"boosts_count,omitempty"`
+	Type            string    `json:"type,omitempty"`
+	URL             string    `json:"url,omitempty"`
+	AppURL          string    `json:"app_url,omitempty"`
+	BookmarkURL     string    `json:"bookmark_url,omitempty"`
+	CommentsURL     string    `json:"comments_url,omitempty"`
+	BoostsURL       string    `json:"boosts_url,omitempty"`
+	SubscriptionURL string    `json:"subscription_url,omitempty"`
+	Creator         *Person   `json:"creator,omitempty"`
+	Bucket          *Bucket   `json:"bucket,omitempty"`
+	Parent          *Parent   `json:"parent,omitempty"`
+	CreatedAt       time.Time `json:"created_at"`
+	UpdatedAt       time.Time `json:"updated_at"`
 }
 
 // CreateGaugeNeedleRequest specifies parameters for creating a gauge needle.
@@ -82,7 +91,10 @@ type CreateGaugeNeedleRequest struct {
 	Color string `json:"color,omitempty"`
 	// Description is rich text (HTML) description of the progress update.
 	Description string `json:"description,omitempty"`
-	// Notify specifies who to notify: "everyone", "working_on", "custom", or omit for nobody.
+	// Notify specifies who to notify: "everyone", "default" (the project's
+	// existing subscribers), or "custom" (the people in Subscriptions). Omit for
+	// nobody: BC3 defaults notify to "custom", which with no subscriptions
+	// notifies no one, and any unrecognized value falls through to nobody too.
 	Notify string `json:"notify,omitempty"`
 	// Subscriptions is an array of people IDs to notify (only used when Notify is "custom").
 	Subscriptions []int64 `json:"subscriptions,omitempty"`
@@ -408,7 +420,7 @@ func (s *GaugesService) UpdateNeedle(ctx context.Context, needleID int64, req *U
 	}
 
 	body := generated.UpdateGaugeNeedleJSONRequestBody{
-		GaugeNeedle: &generated.GaugeNeedleUpdatePayload{
+		GaugeNeedle: generated.GaugeNeedleUpdatePayload{
 			Description: req.Description,
 		},
 	}

--- a/go/pkg/basecamp/gauges.go
+++ b/go/pkg/basecamp/gauges.go
@@ -102,11 +102,11 @@ type CreateGaugeNeedleRequest struct {
 
 // UpdateGaugeNeedleRequest specifies parameters for updating a gauge needle.
 type UpdateGaugeNeedleRequest struct {
-	// Description is rich text (HTML) description. Tri-state: nil leaves the
-	// existing description untouched, a pointer to "" clears it, and any other
-	// value replaces it. A plain string could not express "clear" — the empty
-	// value was indistinguishable from "not provided".
-	Description *string `json:"description,omitempty"`
+	// Description is the rich text (HTML) description, and it is required:
+	// it is the only member bc3's update accepts, and bc3 rejects an empty
+	// gauge_needle wrapper as missing (400), so nil is refused here as a
+	// usage error before the request. A pointer to "" clears the description.
+	Description *string `json:"description"`
 }
 
 // GaugeListOptions specifies pagination for listing gauges.
@@ -418,10 +418,14 @@ func (s *GaugesService) UpdateNeedle(ctx context.Context, needleID int64, req *U
 		err = ErrUsage("update needle request is required")
 		return nil, err
 	}
+	if req.Description == nil {
+		err = ErrUsage("update needle request requires a description")
+		return nil, err
+	}
 
 	body := generated.UpdateGaugeNeedleJSONRequestBody{
 		GaugeNeedle: generated.GaugeNeedleUpdatePayload{
-			Description: req.Description,
+			Description: *req.Description,
 		},
 	}
 

--- a/go/pkg/basecamp/gauges_test.go
+++ b/go/pkg/basecamp/gauges_test.go
@@ -80,6 +80,46 @@ func TestGaugeNeedle_DecodesDescriptionAttachments(t *testing.T) {
 	}
 }
 
+// bc3's needle partial emits the singular comment_count unconditionally,
+// next to the envelope's plural comments_count; before #731 the wrapper had
+// no field for it and the value was dropped on decode.
+func TestGaugeNeedle_DecodesTheSingularCommentCount(t *testing.T) {
+	body := []byte(`{"id": 42, "type": "Gauge::Needle", "comments_count": 2, "comment_count": 5, "description_attachments": []}`)
+
+	var needle GaugeNeedle
+	if err := json.Unmarshal(body, &needle); err != nil {
+		t.Fatalf("failed to unmarshal GaugeNeedle: %v", err)
+	}
+	if needle.CommentCount != 5 {
+		t.Errorf("expected CommentCount 5 from the singular key, got %d", needle.CommentCount)
+	}
+	if needle.CommentsCount != 2 {
+		t.Errorf("expected CommentsCount 2 from the envelope key, got %d", needle.CommentsCount)
+	}
+}
+
+// A gauge's first needle has no previous position, and bc3 sends the key as
+// JSON null. A plain int32 decoded that to 0 — the same value as a real move
+// from position 0 — so the field is a pointer: nil for the null, a non-nil 0
+// for the genuine zero.
+func TestGauge_PreviousNeedlePositionNullIsNotZero(t *testing.T) {
+	var first Gauge
+	if err := json.Unmarshal([]byte(`{"id": 7, "type": "Gauge", "last_needle_position": 30, "previous_needle_position": null}`), &first); err != nil {
+		t.Fatalf("failed to unmarshal first-needle gauge: %v", err)
+	}
+	if first.PreviousNeedlePosition != nil {
+		t.Errorf("expected nil PreviousNeedlePosition for a null, got %d", *first.PreviousNeedlePosition)
+	}
+
+	var fromZero Gauge
+	if err := json.Unmarshal([]byte(`{"id": 7, "type": "Gauge", "last_needle_position": 30, "previous_needle_position": 0}`), &fromZero); err != nil {
+		t.Fatalf("failed to unmarshal moved-from-zero gauge: %v", err)
+	}
+	if fromZero.PreviousNeedlePosition == nil || *fromZero.PreviousNeedlePosition != 0 {
+		t.Errorf("expected a non-nil 0 PreviousNeedlePosition for a wire 0, got %v", fromZero.PreviousNeedlePosition)
+	}
+}
+
 // TestGauge_DescriptionAttachments_PresenceContract pins Gauge's optional
 // array: an absent key stays nil, a server-sent [] decodes to a non-nil
 // zero-length slice.

--- a/go/pkg/basecamp/gauges_test.go
+++ b/go/pkg/basecamp/gauges_test.go
@@ -26,6 +26,7 @@ func TestGaugeNeedle_DecodesDescriptionAttachments(t *testing.T) {
 	body := []byte(`{
 		"id": 42,
 		"type": "Gauge::Needle",
+		"comment_count": 1,
 		"description": "<div>Progress update with files</div>",
 		"description_attachments": [
 			{
@@ -268,7 +269,7 @@ func TestGaugesService_ListNeedles_PageSelectsOnePage(t *testing.T) {
 		}
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
-		w.Write([]byte(`[{"id": 11, "type": "Gauge::Needle"}]`))
+		w.Write([]byte(`[{"id": 11, "type": "Gauge::Needle", "comment_count": 1}]`))
 	})
 
 	result, err := svc.ListNeedles(context.Background(), 7, &GaugeNeedleListOptions{Page: 2})
@@ -295,7 +296,7 @@ func TestGaugesService_ListNeedles_PinnedFinalPageIsNotTruncated(t *testing.T) {
 		requestCount++
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
-		w.Write([]byte(`[{"id": 11, "type": "Gauge::Needle"}]`))
+		w.Write([]byte(`[{"id": 11, "type": "Gauge::Needle", "comment_count": 1}]`))
 	})
 
 	result, err := svc.ListNeedles(context.Background(), 7, &GaugeNeedleListOptions{Page: 9})
@@ -348,7 +349,7 @@ func TestGaugesService_ListNeedles_PageComposesWithLimit(t *testing.T) {
 	svc := testGaugesServer(t, func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		w.WriteHeader(200)
-		w.Write([]byte(`[{"id": 11}, {"id": 12}, {"id": 13}]`))
+		w.Write([]byte(`[{"id": 11, "comment_count": 1}, {"id": 12, "comment_count": 1}, {"id": 13, "comment_count": 1}]`))
 	})
 
 	result, err := svc.ListNeedles(context.Background(), 7, &GaugeNeedleListOptions{Page: 2, Limit: 1})

--- a/go/pkg/basecamp/optional_presence_test.go
+++ b/go/pkg/basecamp/optional_presence_test.go
@@ -144,42 +144,44 @@ func TestUpdateHillChartSettings_NilOmitsAndEmptyTransmits(t *testing.T) {
 	}
 }
 
-// UpdateNeedle's Description is tri-state: nil leaves it alone, a pointer to
-// "" clears it. A plain string could not express the clear.
-func TestUpdateGaugeNeedle_DescriptionIsTriState(t *testing.T) {
-	capture := func(desc *string) (map[string]any, bool) {
-		t.Helper()
-		var got map[string]any
-		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			_ = json.NewDecoder(r.Body).Decode(&got)
-			w.Header().Set("Content-Type", "application/json")
-			_, _ = w.Write([]byte(`{"id":1,"type":"Gauge::Needle"}`))
-		}))
-		t.Cleanup(srv.Close)
+// UpdateNeedle's Description is required: bc3 rejects an empty gauge_needle
+// wrapper as missing, and description is the only member the update accepts,
+// so nil is refused before the request rather than sent as the 400 it always
+// was. A pointer to "" is a real value and clears the description.
+func TestUpdateGaugeNeedle_DescriptionIsRequired(t *testing.T) {
+	requests := 0
+	var got map[string]any
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		_ = json.NewDecoder(r.Body).Decode(&got)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"id":1,"type":"Gauge::Needle","description_attachments":[],"comment_count":0}`))
+	}))
+	t.Cleanup(srv.Close)
 
-		cfg := DefaultConfig()
-		cfg.BaseURL = srv.URL
-		svc := NewClient(cfg, &StaticTokenProvider{Token: "test-token"}).ForAccount("99999").Gauges()
-		if _, err := svc.UpdateNeedle(context.Background(), 1, &UpdateGaugeNeedleRequest{Description: desc}); err != nil {
-			t.Fatalf("UpdateNeedle: %v", err)
-		}
-		needle, _ := got["gauge_needle"].(map[string]any)
-		v, present := needle["description"]
-		if !present {
-			return nil, false
-		}
-		return map[string]any{"description": v}, true
+	cfg := DefaultConfig()
+	cfg.BaseURL = srv.URL
+	svc := NewClient(cfg, &StaticTokenProvider{Token: "test-token"}).ForAccount("99999").Gauges()
+
+	_, err := svc.UpdateNeedle(context.Background(), 1, &UpdateGaugeNeedleRequest{Description: nil})
+	var sdkErr *Error
+	if !errors.As(err, &sdkErr) || sdkErr.Code != CodeUsage {
+		t.Fatalf("expected a usage error for a nil Description, got %v", err)
+	}
+	if requests != 0 {
+		t.Fatalf("a nil Description must be refused before the wire; %d request(s) were made", requests)
 	}
 
-	if _, present := capture(nil); present {
-		t.Error("nil Description must be omitted (no change)")
+	if _, err := svc.UpdateNeedle(context.Background(), 1, &UpdateGaugeNeedleRequest{Description: ptr("")}); err != nil {
+		t.Fatalf("UpdateNeedle: %v", err)
 	}
-	body, present := capture(ptr(""))
+	needle, _ := got["gauge_needle"].(map[string]any)
+	v, present := needle["description"]
 	if !present {
 		t.Fatal(`Description: ptr("") must reach the wire to clear the description`)
 	}
-	if body["description"] != "" {
-		t.Errorf(`expected an explicit empty string, got %#v`, body["description"])
+	if v != "" {
+		t.Errorf(`expected an explicit empty string, got %#v`, v)
 	}
 }
 

--- a/go/pkg/generated/client.gen.go
+++ b/go/pkg/generated/client.gen.go
@@ -1533,8 +1533,11 @@ type GaugeNeedlePayload struct {
 
 // GaugeNeedleUpdatePayload defines model for GaugeNeedleUpdatePayload.
 type GaugeNeedleUpdatePayload struct {
-	// Description Rich text (HTML) description
-	Description *string `json:"description,omitempty"`
+	// Description Rich text (HTML) description. Required: it is the only member bc3's
+	// update accepts (`needle_params.except(:color, :position)`), and
+	// `params.require(:gauge_needle)` rejects an empty wrapper as missing, so a
+	// payload without it is the same 400 as no wrapper at all.
+	Description string `json:"description"`
 }
 
 // GaugeTogglePayload defines model for GaugeTogglePayload.

--- a/go/pkg/generated/client.gen.go
+++ b/go/pkg/generated/client.gen.go
@@ -744,7 +744,11 @@ type CreateFolderResponseContent = FolderWithProjects
 type CreateGaugeNeedleRequestContent struct {
 	GaugeNeedle GaugeNeedlePayload `json:"gauge_needle"`
 
-	// Notify Who to notify: "everyone", "working_on", "custom", or omit for nobody
+	// Notify Who to notify: "everyone", "default" (the project's existing
+	// subscribers), or "custom" (the people in `subscriptions`). Omit for
+	// nobody: bc3 defaults `notify` to "custom", which with no `subscriptions`
+	// notifies no one, and any unrecognized value (`Subscribers#find_subscribers`
+	// accepts exactly these three) falls through to nobody as well.
 	Notify *string `json:"notify,omitempty"`
 
 	// Subscriptions Array of people IDs to notify (only used when notify is "custom")
@@ -1467,23 +1471,35 @@ type Gauge struct {
 	InheritsStatus         *bool                `json:"inherits_status,omitempty"`
 	LastNeedleColor        *string              `json:"last_needle_color,omitempty"`
 	LastNeedlePosition     *int32               `json:"last_needle_position,omitempty"`
-	PreviousNeedlePosition *int32               `json:"previous_needle_position,omitempty"`
-	Status                 *string              `json:"status,omitempty"`
-	Title                  *string              `json:"title,omitempty"`
-	Type                   *string              `json:"type,omitempty"`
-	UpdatedAt              time.Time            `json:"updated_at"`
-	Url                    *string              `json:"url,omitempty"`
-	VisibleToClients       *bool                `json:"visible_to_clients,omitempty"`
+
+	// PreviousNeedlePosition Emitted alongside the other needle keys (so optional, like them), and
+	// JSON `null` for a gauge whose only needle is its first — there is no
+	// previous position yet. The enhance pass layers `nullable: true` onto the
+	// OpenAPI so the static SDKs type the value as nullable rather than
+	// flattening the first needle's null into a real 0.
+	PreviousNeedlePosition *int32    `json:"previous_needle_position,omitempty"`
+	Status                 *string   `json:"status,omitempty"`
+	Title                  *string   `json:"title,omitempty"`
+	Type                   *string   `json:"type,omitempty"`
+	UpdatedAt              time.Time `json:"updated_at"`
+	Url                    *string   `json:"url,omitempty"`
+	VisibleToClients       *bool     `json:"visible_to_clients,omitempty"`
 }
 
 // GaugeNeedle defines model for GaugeNeedle.
 type GaugeNeedle struct {
-	AppUrl                 *string              `json:"app_url,omitempty"`
-	BookmarkUrl            *string              `json:"bookmark_url,omitempty"`
-	BoostsCount            *int32               `json:"boosts_count,omitempty"`
-	BoostsUrl              *string              `json:"boosts_url,omitempty"`
-	Bucket                 *RecordingBucket     `json:"bucket,omitempty"`
-	Color                  *string              `json:"color,omitempty"`
+	AppUrl      *string          `json:"app_url,omitempty"`
+	BookmarkUrl *string          `json:"bookmark_url,omitempty"`
+	BoostsCount *int32           `json:"boosts_count,omitempty"`
+	BoostsUrl   *string          `json:"boosts_url,omitempty"`
+	Bucket      *RecordingBucket `json:"bucket,omitempty"`
+	Color       *string          `json:"color,omitempty"`
+
+	// CommentCount Comment count of the needle: the singular branch-partial key that
+	// gauges/needles/_needle.json.jbuilder emits unconditionally, distinct from
+	// the envelope's plural `comments_count`, which a needle also carries. The
+	// same pair SearchResult models.
+	CommentCount           int32                `json:"comment_count"`
 	CommentsCount          *int32               `json:"comments_count,omitempty"`
 	CommentsUrl            *string              `json:"comments_url,omitempty"`
 	CreatedAt              time.Time            `json:"created_at"`
@@ -4133,7 +4149,7 @@ type UpdateFolderResponseContent = FolderWithProjects
 
 // UpdateGaugeNeedleRequestContent defines model for UpdateGaugeNeedleRequestContent.
 type UpdateGaugeNeedleRequestContent struct {
-	GaugeNeedle *GaugeNeedleUpdatePayload `json:"gauge_needle,omitempty"`
+	GaugeNeedle GaugeNeedleUpdatePayload `json:"gauge_needle"`
 }
 
 // UpdateGaugeNeedleResponseContent defines model for UpdateGaugeNeedleResponseContent.
@@ -32415,6 +32431,7 @@ type ToggleGaugeResponse struct {
 	HTTPResponse *http.Response
 	JSON401      *UnauthorizedErrorResponseContent
 	JSON403      *ForbiddenErrorResponseContent
+	JSON404      *NotFoundErrorResponseContent
 	JSON429      *RateLimitErrorResponseContent
 	JSON500      *InternalServerErrorResponseContent
 }
@@ -46874,6 +46891,12 @@ func ParseToggleGaugeResponse(rsp *http.Response) (*ToggleGaugeResponse, error) 
 		var dest ForbiddenErrorResponseContent
 		if err := json.Unmarshal(bodyBytes, &dest); err == nil {
 			response.JSON403 = &dest
+		}
+
+	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 404:
+		var dest NotFoundErrorResponseContent
+		if err := json.Unmarshal(bodyBytes, &dest); err == nil {
+			response.JSON404 = &dest
 		}
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 429:

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/services/Types.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/services/Types.kt
@@ -607,7 +607,7 @@ data class ListForwardsOptions(
 
 /** Request body for UpdateGaugeNeedle. */
 data class UpdateGaugeNeedleBody(
-    val gaugeNeedle: JsonObject? = null
+    val gaugeNeedle: JsonObject
 )
 
 /** Request body for ToggleGauge. */

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/services/gauges.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/generated/services/gauges.kt
@@ -48,7 +48,7 @@ class GaugesService(client: AccountClient) : BaseService(client) {
         )
         return request(info, {
             httpPut("/gauge_needles/${needleId}", json.encodeToString(kotlinx.serialization.json.buildJsonObject {
-                body.gaugeNeedle?.let { put("gauge_needle", it) }
+                put("gauge_needle", body.gaugeNeedle)
             }), operationName = info.operation)
         }) { body ->
             json.decodeFromString<JsonElement>(body)

--- a/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/GaugesServiceTest.kt
+++ b/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/GaugesServiceTest.kt
@@ -122,6 +122,7 @@ class GaugesServiceTest {
         "bookmark_url": "https://3.basecampapi.com/$accountId/my/bookmarks/BAh7CEkiCGdpZAY6BkVU--abcd1234.json",
         "subscription_url": "https://3.basecampapi.com/$accountId/buckets/$projectId/recordings/$id/subscription.json",
         "comments_count": 2,
+        "comment_count": 2,
         "comments_url": "https://3.basecampapi.com/$accountId/buckets/$projectId/recordings/$id/comments.json",
         "boosts_count": 3,
         "boosts_url": "https://3.basecampapi.com/$accountId/buckets/$projectId/recordings/$id/boosts.json",
@@ -654,8 +655,11 @@ class GaugesServiceTest {
         client.close()
     }
 
+    // bc3's needle_params opens with params.require(:gauge_needle), so a body
+    // without the wrapper is a 400, not a no-op. The wrapper is required and
+    // goes on the wire even when the payload inside it is empty.
     @Test
-    fun updateGaugeNeedleOmitsTheWrapperEntirelyWhenNoAttributesAreGiven() = runTest {
+    fun updateGaugeNeedleAlwaysSendsTheWrapperEvenWhenThePayloadIsEmpty() = runTest {
         var capturedBody: String? = null
 
         val client = mockClient { request ->
@@ -667,10 +671,11 @@ class GaugesServiceTest {
             )
         }
 
-        client.forAccount(accountId).gauges.updateGaugeNeedle(needleId, UpdateGaugeNeedleBody())
+        client.forAccount(accountId).gauges.updateGaugeNeedle(needleId, UpdateGaugeNeedleBody(gaugeNeedle = buildJsonObject {}))
 
         val body = json.parseToJsonElement(capturedBody!!).jsonObject
-        assertTrue(body.isEmpty(), "a null gaugeNeedle sends no wrapper at all; got $capturedBody")
+        assertEquals(setOf("gauge_needle"), body.keys, "the wrapper must be present; got $capturedBody")
+        assertTrue(body["gauge_needle"]!!.jsonObject.isEmpty())
 
         client.close()
     }

--- a/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/GaugesServiceTest.kt
+++ b/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/GaugesServiceTest.kt
@@ -655,31 +655,6 @@ class GaugesServiceTest {
         client.close()
     }
 
-    // bc3's needle_params opens with params.require(:gauge_needle), so a body
-    // without the wrapper is a 400, not a no-op. The wrapper is required and
-    // goes on the wire even when the payload inside it is empty.
-    @Test
-    fun updateGaugeNeedleAlwaysSendsTheWrapperEvenWhenThePayloadIsEmpty() = runTest {
-        var capturedBody: String? = null
-
-        val client = mockClient { request ->
-            capturedBody = request.body.toByteArray().decodeToString()
-            respond(
-                content = needleJson(),
-                status = HttpStatusCode.OK,
-                headers = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString()),
-            )
-        }
-
-        client.forAccount(accountId).gauges.updateGaugeNeedle(needleId, UpdateGaugeNeedleBody(gaugeNeedle = buildJsonObject {}))
-
-        val body = json.parseToJsonElement(capturedBody!!).jsonObject
-        assertEquals(setOf("gauge_needle"), body.keys, "the wrapper must be present; got $capturedBody")
-        assertTrue(body["gauge_needle"]!!.jsonObject.isEmpty())
-
-        client.close()
-    }
-
     @Test
     fun updateGaugeNeedleNotFoundThrowsNotFoundWithStatusCodeAndServerMessage() = runTest {
         val client = errorClient(HttpStatusCode.NotFound, """{"error": "Needle not found"}""")

--- a/openapi.json
+++ b/openapi.json
@@ -9146,7 +9146,8 @@
                 "$ref": "#/components/schemas/UpdateGaugeNeedleRequestContent"
               }
             }
-          }
+          },
+          "required": true
         },
         "parameters": [
           {
@@ -14250,6 +14251,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ForbiddenErrorResponseContent"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "NotFoundError 404 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundErrorResponseContent"
                 }
               }
             }
@@ -30008,7 +30019,7 @@
           },
           "notify": {
             "type": "string",
-            "description": "Who to notify: \"everyone\", \"working_on\", \"custom\", or omit for nobody"
+            "description": "Who to notify: \"everyone\", \"default\" (the project's existing\nsubscribers), or \"custom\" (the people in `subscriptions`). Omit for\nnobody: bc3 defaults `notify` to \"custom\", which with no `subscriptions`\nnotifies no one, and any unrecognized value (`Subscribers#find_subscribers`\naccepts exactly these three) falls through to nobody as well."
           },
           "subscriptions": {
             "type": "array",
@@ -31637,7 +31648,9 @@
           },
           "previous_needle_position": {
             "type": "integer",
-            "format": "int32"
+            "description": "Emitted alongside the other needle keys (so optional, like them), and\nJSON `null` for a gauge whose only needle is its first — there is no\nprevious position yet. The enhance pass layers `nullable: true` onto the\nOpenAPI so the static SDKs type the value as nullable rather than\nflattening the first needle's null into a real 0.",
+            "format": "int32",
+            "nullable": true
           }
         },
         "required": [
@@ -31732,9 +31745,15 @@
           "position": {
             "type": "integer",
             "format": "int32"
+          },
+          "comment_count": {
+            "type": "integer",
+            "description": "Comment count of the needle: the singular branch-partial key that\ngauges/needles/_needle.json.jbuilder emits unconditionally, distinct from\nthe envelope's plural `comments_count`, which a needle also carries. The\nsame pair SearchResult models.",
+            "format": "int32"
           }
         },
         "required": [
+          "comment_count",
           "created_at",
           "description_attachments",
           "id",
@@ -37071,7 +37090,10 @@
           "gauge_needle": {
             "$ref": "#/components/schemas/GaugeNeedleUpdatePayload"
           }
-        }
+        },
+        "required": [
+          "gauge_needle"
+        ]
       },
       "UpdateGaugeNeedleResponseContent": {
         "$ref": "#/components/schemas/GaugeNeedle"

--- a/openapi.json
+++ b/openapi.json
@@ -31786,9 +31786,12 @@
         "properties": {
           "description": {
             "type": "string",
-            "description": "Rich text (HTML) description"
+            "description": "Rich text (HTML) description. Required: it is the only member bc3's\nupdate accepts (`needle_params.except(:color, :position)`), and\n`params.require(:gauge_needle)` rejects an empty wrapper as missing, so a\npayload without it is the same 400 as no wrapper at all."
           }
-        }
+        },
+        "required": [
+          "description"
+        ]
       },
       "GaugeTogglePayload": {
         "type": "object",

--- a/python/src/basecamp/generated/services/gauges.py
+++ b/python/src/basecamp/generated/services/gauges.py
@@ -24,7 +24,7 @@ class GaugesService(BaseService):
             operation="GetGaugeNeedle",
         )
 
-    def update_gauge_needle(self, *, needle_id: int, gauge_needle: dict | None = None) -> dict[str, Any]:
+    def update_gauge_needle(self, *, needle_id: int, gauge_needle: dict) -> dict[str, Any]:
         """Update a gauge needle's description. Position and color are immutable.
 
         Args:
@@ -96,7 +96,11 @@ class GaugesService(BaseService):
         Args:
             project_id: The project id.
             gauge_needle: The gauge needle.
-            notify: Who to notify: "everyone", "working_on", "custom", or omit for nobody
+            notify: Who to notify: "everyone", "default" (the project's existing subscribers), or
+                "custom" (the people in `subscriptions`). Omit for nobody: bc3 defaults `notify` to
+                "custom", which with no `subscriptions` notifies no one, and any unrecognized value
+                (`Subscribers#find_subscribers` accepts exactly these three) falls through to nobody
+                as well.
             subscriptions: Array of people IDs to notify (only used when notify is "custom")
         """
         return self._request(
@@ -145,7 +149,7 @@ class AsyncGaugesService(AsyncBaseService):
             operation="GetGaugeNeedle",
         )
 
-    async def update_gauge_needle(self, *, needle_id: int, gauge_needle: dict | None = None) -> dict[str, Any]:
+    async def update_gauge_needle(self, *, needle_id: int, gauge_needle: dict) -> dict[str, Any]:
         """Update a gauge needle's description. Position and color are immutable.
 
         Args:
@@ -217,7 +221,11 @@ class AsyncGaugesService(AsyncBaseService):
         Args:
             project_id: The project id.
             gauge_needle: The gauge needle.
-            notify: Who to notify: "everyone", "working_on", "custom", or omit for nobody
+            notify: Who to notify: "everyone", "default" (the project's existing subscribers), or
+                "custom" (the people in `subscriptions`). Omit for nobody: bc3 defaults `notify` to
+                "custom", which with no `subscriptions` notifies no one, and any unrecognized value
+                (`Subscribers#find_subscribers` accepts exactly these three) falls through to nobody
+                as well.
             subscriptions: Array of people IDs to notify (only used when notify is "custom")
         """
         return await self._request(

--- a/python/src/basecamp/generated/types.py
+++ b/python/src/basecamp/generated/types.py
@@ -902,7 +902,7 @@ class Gauge(TypedDict):
     inherits_status: NotRequired[bool]
     last_needle_color: NotRequired[str]
     last_needle_position: NotRequired[int]
-    previous_needle_position: NotRequired[int]
+    previous_needle_position: NotRequired[Optional[int]]
     status: NotRequired[str]
     title: NotRequired[str]
     type: NotRequired[str]
@@ -918,6 +918,7 @@ class GaugeNeedle(TypedDict):
     boosts_url: NotRequired[str]
     bucket: NotRequired[RecordingBucket]
     color: NotRequired[str]
+    comment_count: int
     comments_count: NotRequired[int]
     comments_url: NotRequired[str]
     created_at: str
@@ -2122,7 +2123,7 @@ class UpdateFolderRequestContent(TypedDict):
 
 
 class UpdateGaugeNeedleRequestContent(TypedDict):
-    gauge_needle: NotRequired[GaugeNeedleUpdatePayload]
+    gauge_needle: GaugeNeedleUpdatePayload
 
 
 class UpdateGoogleDocumentRequestContent(TypedDict):

--- a/python/src/basecamp/generated/types.py
+++ b/python/src/basecamp/generated/types.py
@@ -945,7 +945,7 @@ class GaugeNeedlePayload(TypedDict):
 
 
 class GaugeNeedleUpdatePayload(TypedDict):
-    description: NotRequired[str]
+    description: str
 
 
 class GaugeTogglePayload(TypedDict):

--- a/python/tests/services/test_gauges_service.py
+++ b/python/tests/services/test_gauges_service.py
@@ -39,7 +39,7 @@ def _gauge_stub(gauge_id: int) -> dict:
 
 
 def _needle_stub(needle_id: int) -> dict:
-    return {"id": needle_id, "type": "Gauge::Needle", "color": "green", "position": 50}
+    return {"id": needle_id, "type": "Gauge::Needle", "color": "green", "position": 50, "comment_count": 1}
 
 
 def _link_to(url: str) -> dict[str, str]:

--- a/ruby/lib/basecamp/generated/services/gauges_service.rb
+++ b/ruby/lib/basecamp/generated/services/gauges_service.rb
@@ -18,9 +18,9 @@ module Basecamp
 
       # Update a gauge needle's description. Position and color are immutable.
       # @param needle_id [Integer] needle id ID
-      # @param gauge_needle [Hash, nil] gauge needle
+      # @param gauge_needle [Hash] gauge needle
       # @return [Hash] response data
-      def update_gauge_needle(needle_id:, gauge_needle: nil)
+      def update_gauge_needle(needle_id:, gauge_needle:)
         with_operation(service: "gauges", operation: "update_gauge_needle", is_mutation: true, resource_id: needle_id) do
           http_put("/gauge_needles/#{needle_id}", body: compact_params(gauge_needle: gauge_needle)).json
         end
@@ -62,7 +62,11 @@ module Basecamp
       # Create a gauge needle (progress update) for a project
       # @param project_id [Integer] project id ID
       # @param gauge_needle [Hash] gauge needle
-      # @param notify [String, nil] Who to notify: "everyone", "working_on", "custom", or omit for nobody
+      # @param notify [String, nil] Who to notify: "everyone", "default" (the project's existing
+      #   subscribers), or "custom" (the people in `subscriptions`). Omit for
+      #   nobody: bc3 defaults `notify` to "custom", which with no `subscriptions`
+      #   notifies no one, and any unrecognized value (`Subscribers#find_subscribers`
+      #   accepts exactly these three) falls through to nobody as well.
       # @param subscriptions [Array, nil] Array of people IDs to notify (only used when notify is "custom")
       # @return [Hash] response data
       def create_gauge_needle(project_id:, gauge_needle:, notify: nil, subscriptions: nil)

--- a/ruby/lib/basecamp/generated/types.rb
+++ b/ruby/lib/basecamp/generated/types.rb
@@ -2277,6 +2277,11 @@ module Basecamp
       include TypeHelpers
       attr_accessor :description
 
+      # @return [Array<Symbol>]
+      def self.required_fields
+        %i[description].freeze
+      end
+
       def initialize(data = {})
         @description = data["description"]
       end

--- a/ruby/lib/basecamp/generated/types.rb
+++ b/ruby/lib/basecamp/generated/types.rb
@@ -2175,14 +2175,15 @@ module Basecamp
     # GaugeNeedle
     class GaugeNeedle
       include TypeHelpers
-      attr_accessor :created_at, :description_attachments, :id, :updated_at, :app_url, :bookmark_url, :boosts_count, :boosts_url, :bucket, :color, :comments_count, :comments_url, :creator, :description, :inherits_status, :parent, :position, :status, :subscription_url, :title, :type, :url, :visible_to_clients
+      attr_accessor :comment_count, :created_at, :description_attachments, :id, :updated_at, :app_url, :bookmark_url, :boosts_count, :boosts_url, :bucket, :color, :comments_count, :comments_url, :creator, :description, :inherits_status, :parent, :position, :status, :subscription_url, :title, :type, :url, :visible_to_clients
 
       # @return [Array<Symbol>]
       def self.required_fields
-        %i[created_at description_attachments id updated_at].freeze
+        %i[comment_count created_at description_attachments id updated_at].freeze
       end
 
       def initialize(data = {})
+        @comment_count = parse_integer(data["comment_count"])
         @created_at = parse_datetime(data["created_at"])
         @description_attachments = parse_array(data["description_attachments"], "RichTextAttachment")
         @id = parse_integer(data["id"])
@@ -2210,6 +2211,7 @@ module Basecamp
 
       def to_h
         {
+          "comment_count" => @comment_count,
           "created_at" => @created_at,
           "description_attachments" => @description_attachments,
           "id" => @id,

--- a/rust/basecamp-sdk/src/generated/types.rs
+++ b/rust/basecamp-sdk/src/generated/types.rs
@@ -1265,7 +1265,11 @@ pub type CreateFolderResponseContent = FolderWithProjects;
 pub struct CreateGaugeNeedleRequestContent {
     /// `gauge_needle`.
     pub gauge_needle: GaugeNeedlePayload,
-    /// Who to notify: "everyone", "working_on", "custom", or omit for nobody
+    /// Who to notify: "everyone", "default" (the project's existing
+    /// subscribers), or "custom" (the people in `subscriptions`). Omit for
+    /// nobody: bc3 defaults `notify` to "custom", which with no `subscriptions`
+    /// notifies no one, and any unrecognized value (`Subscribers#find_subscribers`
+    /// accepts exactly these three) falls through to nobody as well.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub notify: Option<String>,
     /// Array of people IDs to notify (only used when notify is "custom")
@@ -2411,7 +2415,11 @@ pub struct Gauge {
     /// `last_needle_position`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub last_needle_position: Option<i32>,
-    /// `previous_needle_position`.
+    /// Emitted alongside the other needle keys (so optional, like them), and
+    /// JSON `null` for a gauge whose only needle is its first — there is no
+    /// previous position yet. The enhance pass layers `nullable: true` onto the
+    /// OpenAPI so the static SDKs type the value as nullable rather than
+    /// flattening the first needle's null into a real 0.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub previous_needle_position: Option<i32>,
 }
@@ -2485,6 +2493,11 @@ pub struct GaugeNeedle {
     /// `position`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub position: Option<i32>,
+    /// Comment count of the needle: the singular branch-partial key that
+    /// gauges/needles/_needle.json.jbuilder emits unconditionally, distinct from
+    /// the envelope's plural `comments_count`, which a needle also carries. The
+    /// same pair SearchResult models.
+    pub comment_count: i32,
 }
 
 /// The `GaugeNeedlePayload` shape of the Basecamp API.
@@ -2503,9 +2516,11 @@ pub struct GaugeNeedlePayload {
 /// The `GaugeNeedleUpdatePayload` shape of the Basecamp API.
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct GaugeNeedleUpdatePayload {
-    /// Rich text (HTML) description
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub description: Option<String>,
+    /// Rich text (HTML) description. Required: it is the only member bc3's
+    /// update accepts (`needle_params.except(:color, :position)`), and
+    /// `params.require(:gauge_needle)` rejects an empty wrapper as missing, so a
+    /// payload without it is the same 400 as no wrapper at all.
+    pub description: String,
 }
 
 /// The `GaugeTogglePayload` shape of the Basecamp API.
@@ -6142,8 +6157,7 @@ pub type UpdateFolderResponseContent = FolderWithProjects;
 #[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct UpdateGaugeNeedleRequestContent {
     /// `gauge_needle`.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub gauge_needle: Option<GaugeNeedleUpdatePayload>,
+    pub gauge_needle: GaugeNeedleUpdatePayload,
 }
 
 /// `UpdateGaugeNeedleResponseContent`.

--- a/rust/basecamp-sdk/tests/services.rs
+++ b/rust/basecamp-sdk/tests/services.rs
@@ -503,7 +503,7 @@ async fn gauges_gauge_needle_reaches_the_wire() {
         .and(header("Authorization", "Bearer test-token"))
         .and(header("Accept", "application/json"))
         .and(header("User-Agent", basecamp_sdk::version::default_user_agent().as_str()))
-        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"created_at": "2025-01-01T00:00:00Z", "description_attachments": [], "id": 1, "updated_at": "2025-01-01T00:00:00Z"})))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({"comment_count": 0, "created_at": "2025-01-01T00:00:00Z", "description_attachments": [], "id": 1, "updated_at": "2025-01-01T00:00:00Z"})))
         .expect(1)
         .mount(&server)
         .await;

--- a/scripts/enhance-openapi-go-types.sh
+++ b/scripts/enhance-openapi-go-types.sh
@@ -434,6 +434,15 @@ walk(
 |
 .components.schemas.UpcomingAssignable.properties.starts_on += { "nullable": true }
 |
+# Fifth-h pass: Gauge.previous_needle_position is nullable-when-present.
+# app/views/api/gauges/_gauge.json.jbuilder emits it with the other needle keys
+# whenever the gauge has needles, and a gauge whose only needle is its first
+# has no previous position, so the value is JSON null (gauges.md shows exactly
+# that). Optional (not @required, like its siblings) and nullable, so the
+# static SDKs type it `integer | null | undefined` and Go takes the optional
+# pointer, whose nil is distinguishable from a genuine "moved from 0".
+.components.schemas.Gauge.properties.previous_needle_position += { "nullable": true }
+|
 # Sixth pass: Person.id → types.FlexibleInt64
 # The API sometimes returns person IDs as JSON strings (e.g. in notification
 # responses); Go rejects those into int64 fields. Scoped to Person schema only.

--- a/spec/basecamp.smithy
+++ b/spec/basecamp.smithy
@@ -10606,7 +10606,11 @@ structure CreateGaugeNeedleInput {
   @required
   gauge_needle: GaugeNeedlePayload
 
-  /// Who to notify: "everyone", "working_on", "custom", or omit for nobody
+  /// Who to notify: "everyone", "default" (the project's existing
+  /// subscribers), or "custom" (the people in `subscriptions`). Omit for
+  /// nobody: bc3 defaults `notify` to "custom", which with no `subscriptions`
+  /// notifies no one, and any unrecognized value (`Subscribers#find_subscribers`
+  /// accepts exactly these three) falls through to nobody as well.
   notify: String
 
   /// Array of people IDs to notify (only used when notify is "custom")
@@ -10650,6 +10654,10 @@ structure UpdateGaugeNeedleInput {
   @httpLabel
   needleId: GaugeNeedleId
 
+  /// Required by bc3, not just by convention: `Gauges::NeedlesController#needle_params`
+  /// opens with `params.require(:gauge_needle)`, so a body without the wrapper
+  /// is a 400, not a no-op update. Same rule as CreateGaugeNeedle.
+  @required
   gauge_needle: GaugeNeedleUpdatePayload
 }
 
@@ -10694,7 +10702,7 @@ structure DestroyGaugeNeedleOutput {}
 operation ToggleGauge {
   input: ToggleGaugeInput
   output: ToggleGaugeOutput
-  errors: [ForbiddenError, UnauthorizedError, RateLimitError, InternalServerError]
+  errors: [NotFoundError, ForbiddenError, UnauthorizedError, RateLimitError, InternalServerError]
 }
 
 structure ToggleGaugeInput {
@@ -10755,6 +10763,11 @@ structure Gauge {
   enabled: Boolean
   last_needle_color: String
   last_needle_position: Integer
+  /// Emitted alongside the other needle keys (so optional, like them), and
+  /// JSON `null` for a gauge whose only needle is its first — there is no
+  /// previous position yet. The enhance pass layers `nullable: true` onto the
+  /// OpenAPI so the static SDKs type the value as nullable rather than
+  /// flattening the first needle's null into a real 0.
   previous_needle_position: Integer
 }
 
@@ -10786,6 +10799,12 @@ structure GaugeNeedle {
   description_attachments: RichTextAttachmentList
   color: String
   position: Integer
+  /// Comment count of the needle: the singular branch-partial key that
+  /// gauges/needles/_needle.json.jbuilder emits unconditionally, distinct from
+  /// the envelope's plural `comments_count`, which a needle also carries. The
+  /// same pair SearchResult models.
+  @required
+  comment_count: Integer
 }
 
 // =============================================================================

--- a/spec/basecamp.smithy
+++ b/spec/basecamp.smithy
@@ -10662,7 +10662,11 @@ structure UpdateGaugeNeedleInput {
 }
 
 structure GaugeNeedleUpdatePayload {
-  /// Rich text (HTML) description
+  /// Rich text (HTML) description. Required: it is the only member bc3's
+  /// update accepts (`needle_params.except(:color, :position)`), and
+  /// `params.require(:gauge_needle)` rejects an empty wrapper as missing, so a
+  /// payload without it is the same 400 as no wrapper at all.
+  @required
   description: String
 }
 

--- a/spec/fixtures/gauges/get_first_needle.json
+++ b/spec/fixtures/gauges/get_first_needle.json
@@ -1,28 +1,15 @@
 {
-  "id": 1069479850,
+  "id": 1069479800,
   "status": "active",
   "visible_to_clients": false,
-  "created_at": "2022-11-28T14:12:00.000Z",
+  "created_at": "2022-11-22T08:40:00.000Z",
   "updated_at": "2022-11-28T14:12:00.000Z",
-  "title": "Moved the needle",
+  "title": "How far along are we?",
   "inherits_status": true,
-  "type": "Gauge::Needle",
-  "url": "https://3.basecampapi.com/999999999/projects/2085958500/gauge/needles/1069479850.json",
-  "app_url": "https://3.basecamp.com/999999999/projects/2085958500/gauge/needles/1069479850",
-  "bookmark_url": "https://3.basecampapi.com/999999999/my/bookmarks/BAh7CEkiCGdpZAY6BkVUSSIuZ2lkOi8vYmMzL1JlY29yZGluZy8xMDY5NDc5ODUwP2V4cGlyZXNfaW4GOwBUSSIMcHVycG9zZQY7AFRJIg1yZWFkYWJsZQY7AFRJIg9leHBpcmVzX2F0BjsAVDA=--abcd1234.json",
-  "subscription_url": "https://3.basecampapi.com/999999999/buckets/2085958500/recordings/1069479850/subscription.json",
-  "comments_count": 2,
-  "comment_count": 2,
-  "comments_url": "https://3.basecampapi.com/999999999/buckets/2085958500/recordings/1069479850/comments.json",
-  "boosts_count": 3,
-  "boosts_url": "https://3.basecampapi.com/999999999/buckets/2085958500/recordings/1069479850/boosts.json",
-  "parent": {
-    "id": 1069479800,
-    "title": "How far along are we?",
-    "type": "Gauge",
-    "url": "https://3.basecampapi.com/999999999/projects/2085958500/gauge.json",
-    "app_url": "https://3.basecamp.com/999999999/projects/2085958500/gauge"
-  },
+  "type": "Gauge",
+  "url": "https://3.basecampapi.com/999999999/projects/2085958500/gauge.json",
+  "app_url": "https://3.basecamp.com/999999999/projects/2085958500/gauge",
+  "bookmark_url": "https://3.basecampapi.com/999999999/my/bookmarks/BAh7CEkiCGdpZAY6BkVUSSIuZ2lkOi8vYmMzL1JlY29yZGluZy8xMDY5NDc5ODAwP2V4cGlyZXNfaW4GOwBUSSIMcHVycG9zZQY7AFRJIg1yZWFkYWJsZQY7AFRJIg9leHBpcmVzX2F0BjsAVDA=--abcd1234.json",
   "bucket": {
     "id": 2085958500,
     "name": "The Leto Laptop",
@@ -77,6 +64,8 @@
       "thumbnail_url": "https://3.basecampapi.com/999999999/blobs/BAh7CEkiCGdpZAY6BkVUSSIsZ2lkOi8vYmMzL0FjdGl2ZVN0b3JhZ2U6OkJsb2IvMTA2OTQ4MDA0MQY6BkVU--gauge002/thumbnails/retro-notes.pdf"
     }
   ],
-  "color": "green",
-  "position": 72
+  "enabled": true,
+  "last_needle_color": "green",
+  "last_needle_position": 72,
+  "previous_needle_position": null
 }

--- a/spec/fixtures/manifest.yaml
+++ b/spec/fixtures/manifest.yaml
@@ -321,16 +321,22 @@ targets:
     fixture: gauges/get.json
     pointer: ""
     schema: Gauge
+  # The first-needle variant: the same has-needles partial, with
+  # previous_needle_position JSON null because there is no earlier needle to
+  # have moved from (doc/api/sections/gauges.md shows it). Pins that the
+  # member is nullable-when-present in the projection.
+  - id: gauge-get-first-needle
+    fixture: gauges/get_first_needle.json
+    pointer: ""
+    schema: Gauge
   # gauges/needles/_needle.json.jbuilder renders the base partial WITH
   # commentable + boostable, then rich text, color, and position. `url`/`app_url`
   # are the project_gauge_needle route (Gauge::Needle#route) while the envelope's
   # subscription/comments/boosts URLs stay bucket_recording_*-scoped, and `title`
   # is the model's fixed "Moved the needle".
-  # KNOWN INCOMPLETE: bc3 also emits a singular `comment_count` unconditionally
-  # (_needle.json.jbuilder:8), distinct from the envelope's `comments_count`.
-  # GaugeNeedle does not model it — SearchResult already does — so the fixture
-  # cannot carry it until the spec does. Tracked in the follow-up issue filed
-  # alongside this manifest note.
+  # bc3 also emits a singular `comment_count` unconditionally
+  # (_needle.json.jbuilder:8), distinct from the envelope's `comments_count`;
+  # the fixture carries both, as a needle does.
   - id: gauge-needle-get
     fixture: gauges/needle_get.json
     pointer: ""

--- a/swift/Sources/Basecamp/Generated/Models/GaugeNeedle.swift
+++ b/swift/Sources/Basecamp/Generated/Models/GaugeNeedle.swift
@@ -2,6 +2,7 @@
 import Foundation
 
 public struct GaugeNeedle: Codable, Sendable {
+    public let commentCount: Int32
     public let createdAt: String
     public let descriptionAttachments: [RichTextAttachment]
     public let id: Int
@@ -27,6 +28,7 @@ public struct GaugeNeedle: Codable, Sendable {
     public var visibleToClients: Bool?
 
     public init(
+        commentCount: Int32,
         createdAt: String,
         descriptionAttachments: [RichTextAttachment],
         id: Int,
@@ -51,6 +53,7 @@ public struct GaugeNeedle: Codable, Sendable {
         url: String? = nil,
         visibleToClients: Bool? = nil
     ) {
+        self.commentCount = commentCount
         self.createdAt = createdAt
         self.descriptionAttachments = descriptionAttachments
         self.id = id

--- a/swift/Sources/Basecamp/Generated/Models/GaugeNeedleUpdatePayload.swift
+++ b/swift/Sources/Basecamp/Generated/Models/GaugeNeedleUpdatePayload.swift
@@ -2,9 +2,9 @@
 import Foundation
 
 public struct GaugeNeedleUpdatePayload: Codable, Sendable {
-    public var description: String?
+    public let description: String
 
-    public init(description: String? = nil) {
+    public init(description: String) {
         self.description = description
     }
 }

--- a/swift/Sources/Basecamp/Generated/Models/UpdateGaugeNeedleRequest.swift
+++ b/swift/Sources/Basecamp/Generated/Models/UpdateGaugeNeedleRequest.swift
@@ -2,9 +2,9 @@
 import Foundation
 
 public struct UpdateGaugeNeedleRequest: Codable, Sendable {
-    public var gaugeNeedle: GaugeNeedleUpdatePayload?
+    public let gaugeNeedle: GaugeNeedleUpdatePayload
 
-    public init(gaugeNeedle: GaugeNeedleUpdatePayload? = nil) {
+    public init(gaugeNeedle: GaugeNeedleUpdatePayload) {
         self.gaugeNeedle = gaugeNeedle
     }
 }

--- a/swift/Sources/BasecampPublicAPIConsumer/PublicAPIConsumer.swift
+++ b/swift/Sources/BasecampPublicAPIConsumer/PublicAPIConsumer.swift
@@ -39,20 +39,22 @@ import Foundation
 public enum PublicAPIConsumer {
     // MARK: - The #735 case: all-optional request payloads
 
-    /// `GaugeNeedleUpdatePayload` has one optional member and no required one.
-    /// Before #735 this function could not be written outside the module: the
-    /// payload had no `public init`, so `UpdateGaugeNeedleRequest(gaugeNeedle:)`
-    /// could only ever be handed `nil` — an empty `{}` PUT that bc3 rejects.
+    /// `GaugeNeedleUpdatePayload` had one optional member and no required one
+    /// when #735 found it: the payload had no `public init`, so
+    /// `UpdateGaugeNeedleRequest(gaugeNeedle:)` could only ever be handed
+    /// `nil` — an empty `{}` PUT that bc3 rejects. #731 then made both the
+    /// wrapper and its `description` required, which is what bc3 always
+    /// demanded, so this is now written the way a consumer writes a
+    /// required-member payload; `PreferencesPayload` below keeps the
+    /// all-optional shape #735 was about.
     public static func updateGaugeNeedleDescription(
         account: AccountClient,
         needleId: Int,
         description: String
     ) async throws -> GaugeNeedle {
-        var payload = GaugeNeedleUpdatePayload()
-        payload.description = description
-        return try await account.gauges.updateGaugeNeedle(
+        try await account.gauges.updateGaugeNeedle(
             needleId: needleId,
-            req: UpdateGaugeNeedleRequest(gaugeNeedle: payload)
+            req: UpdateGaugeNeedleRequest(gaugeNeedle: GaugeNeedleUpdatePayload(description: description))
         )
     }
 
@@ -110,7 +112,6 @@ public enum PublicAPIConsumer {
         _ = DoorService()
         _ = EventDetails()
         _ = EverythingFile()
-        _ = GaugeNeedleUpdatePayload()
         _ = GetAssignedTodosResponseContent()
         _ = GetMyAssignmentsResponseContent()
         _ = GetOverdueTodosResponseContent()

--- a/swift/Tests/BasecampTests/GaugesServiceTests.swift
+++ b/swift/Tests/BasecampTests/GaugesServiceTests.swift
@@ -102,6 +102,7 @@ final class GaugesServiceTests: XCTestCase {
             "subscription_url":
                 "https://3.basecampapi.com/999999999/buckets/\(bucketId)/recordings/\(id)/subscription.json",
             "comments_count": 2,
+            "comment_count": 2,
             "comments_url":
                 "https://3.basecampapi.com/999999999/buckets/\(bucketId)/recordings/\(id)/comments.json",
             "boosts_count": 3,
@@ -308,6 +309,8 @@ final class GaugesServiceTests: XCTestCase {
         XCTAssertEqual(needle.color, "green")
         XCTAssertEqual(needle.position, 72)
         XCTAssertEqual(needle.commentsCount, 2)
+        // The singular branch-partial key, distinct from the envelope's plural.
+        XCTAssertEqual(needle.commentCount, 2)
         XCTAssertEqual(needle.boostsCount, 3)
         XCTAssertNotNil(needle.subscriptionUrl)
         XCTAssertNotNil(needle.commentsUrl)

--- a/swift/Tests/BasecampTests/GaugesServiceTests.swift
+++ b/swift/Tests/BasecampTests/GaugesServiceTests.swift
@@ -537,8 +537,7 @@ final class GaugesServiceTests: XCTestCase {
         let transport = MockTransport(statusCode: 200, data: data)
         let account = makeTestAccountClient(transport: transport)
 
-        var payload = GaugeNeedleUpdatePayload()
-        payload.description = "<div>Revised note</div>"
+        let payload = GaugeNeedleUpdatePayload(description: "<div>Revised note</div>")
         let needle = try await account.gauges.updateGaugeNeedle(
             needleId: Self.needleId, req: UpdateGaugeNeedleRequest(gaugeNeedle: payload))
 
@@ -562,8 +561,7 @@ final class GaugesServiceTests: XCTestCase {
         let transport = MockTransport(statusCode: 404, data: body)
         let account = makeTestAccountClient(transport: transport)
 
-        var payload = GaugeNeedleUpdatePayload()
-        payload.description = "<div>Revised note</div>"
+        let payload = GaugeNeedleUpdatePayload(description: "<div>Revised note</div>")
 
         do {
             _ = try await account.gauges.updateGaugeNeedle(

--- a/typescript/src/generated/openapi-stripped.json
+++ b/typescript/src/generated/openapi-stripped.json
@@ -8206,7 +8206,8 @@
                 "$ref": "#/components/schemas/UpdateGaugeNeedleRequestContent"
               }
             }
-          }
+          },
+          "required": true
         },
         "parameters": [
           {
@@ -12717,6 +12718,16 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/ForbiddenErrorResponseContent"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "NotFoundError 404 response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/NotFoundErrorResponseContent"
                 }
               }
             }
@@ -27021,7 +27032,7 @@
           },
           "notify": {
             "type": "string",
-            "description": "Who to notify: \"everyone\", \"working_on\", \"custom\", or omit for nobody"
+            "description": "Who to notify: \"everyone\", \"default\" (the project's existing\nsubscribers), or \"custom\" (the people in `subscriptions`). Omit for\nnobody: bc3 defaults `notify` to \"custom\", which with no `subscriptions`\nnotifies no one, and any unrecognized value (`Subscribers#find_subscribers`\naccepts exactly these three) falls through to nobody as well."
           },
           "subscriptions": {
             "type": "array",
@@ -28650,7 +28661,9 @@
           },
           "previous_needle_position": {
             "type": "integer",
-            "format": "int32"
+            "description": "Emitted alongside the other needle keys (so optional, like them), and\nJSON `null` for a gauge whose only needle is its first — there is no\nprevious position yet. The enhance pass layers `nullable: true` onto the\nOpenAPI so the static SDKs type the value as nullable rather than\nflattening the first needle's null into a real 0.",
+            "format": "int32",
+            "nullable": true
           }
         },
         "required": [
@@ -28745,9 +28758,15 @@
           "position": {
             "type": "integer",
             "format": "int32"
+          },
+          "comment_count": {
+            "type": "integer",
+            "description": "Comment count of the needle: the singular branch-partial key that\ngauges/needles/_needle.json.jbuilder emits unconditionally, distinct from\nthe envelope's plural `comments_count`, which a needle also carries. The\nsame pair SearchResult models.",
+            "format": "int32"
           }
         },
         "required": [
+          "comment_count",
           "created_at",
           "description_attachments",
           "id",
@@ -34084,7 +34103,10 @@
           "gauge_needle": {
             "$ref": "#/components/schemas/GaugeNeedleUpdatePayload"
           }
-        }
+        },
+        "required": [
+          "gauge_needle"
+        ]
       },
       "UpdateGaugeNeedleResponseContent": {
         "$ref": "#/components/schemas/GaugeNeedle"

--- a/typescript/src/generated/openapi-stripped.json
+++ b/typescript/src/generated/openapi-stripped.json
@@ -28799,9 +28799,12 @@
         "properties": {
           "description": {
             "type": "string",
-            "description": "Rich text (HTML) description"
+            "description": "Rich text (HTML) description. Required: it is the only member bc3's\nupdate accepts (`needle_params.except(:color, :position)`), and\n`params.require(:gauge_needle)` rejects an empty wrapper as missing, so a\npayload without it is the same 400 as no wrapper at all."
           }
-        }
+        },
+        "required": [
+          "description"
+        ]
       },
       "GaugeTogglePayload": {
         "type": "object",

--- a/typescript/src/generated/schema.d.ts
+++ b/typescript/src/generated/schema.d.ts
@@ -4968,8 +4968,13 @@ export interface components {
             description?: string;
         };
         GaugeNeedleUpdatePayload: {
-            /** @description Rich text (HTML) description */
-            description?: string;
+            /**
+             * @description Rich text (HTML) description. Required: it is the only member bc3's
+             *     update accepts (`needle_params.except(:color, :position)`), and
+             *     `params.require(:gauge_needle)` rejects an empty wrapper as missing, so a
+             *     payload without it is the same 400 as no wrapper at all.
+             */
+            description: string;
         };
         GaugeTogglePayload: {
             enabled: boolean;

--- a/typescript/src/generated/schema.d.ts
+++ b/typescript/src/generated/schema.d.ts
@@ -4288,7 +4288,13 @@ export interface components {
         CreateFolderResponseContent: components["schemas"]["FolderWithProjects"];
         CreateGaugeNeedleRequestContent: {
             gauge_needle: components["schemas"]["GaugeNeedlePayload"];
-            /** @description Who to notify: "everyone", "working_on", "custom", or omit for nobody */
+            /**
+             * @description Who to notify: "everyone", "default" (the project's existing
+             *     subscribers), or "custom" (the people in `subscriptions`). Omit for
+             *     nobody: bc3 defaults `notify` to "custom", which with no `subscriptions`
+             *     notifies no one, and any unrecognized value (`Subscribers#find_subscribers`
+             *     accepts exactly these three) falls through to nobody as well.
+             */
             notify?: string;
             /** @description Array of people IDs to notify (only used when notify is "custom") */
             subscriptions?: number[];
@@ -4903,8 +4909,15 @@ export interface components {
             last_needle_color?: string;
             /** Format: int32 */
             last_needle_position?: number;
-            /** Format: int32 */
-            previous_needle_position?: number;
+            /**
+             * Format: int32
+             * @description Emitted alongside the other needle keys (so optional, like them), and
+             *     JSON `null` for a gauge whose only needle is its first — there is no
+             *     previous position yet. The enhance pass layers `nullable: true` onto the
+             *     OpenAPI so the static SDKs type the value as nullable rather than
+             *     flattening the first needle's null into a real 0.
+             */
+            previous_needle_position?: number | null;
         };
         GaugeNeedle: {
             /** Format: int64 */
@@ -4934,6 +4947,14 @@ export interface components {
             color?: string;
             /** Format: int32 */
             position?: number;
+            /**
+             * Format: int32
+             * @description Comment count of the needle: the singular branch-partial key that
+             *     gauges/needles/_needle.json.jbuilder emits unconditionally, distinct from
+             *     the envelope's plural `comments_count`, which a needle also carries. The
+             *     same pair SearchResult models.
+             */
+            comment_count: number;
         };
         GaugeNeedlePayload: {
             /**
@@ -7220,7 +7241,7 @@ export interface components {
         };
         UpdateFolderResponseContent: components["schemas"]["FolderWithProjects"];
         UpdateGaugeNeedleRequestContent: {
-            gauge_needle?: components["schemas"]["GaugeNeedleUpdatePayload"];
+            gauge_needle: components["schemas"]["GaugeNeedleUpdatePayload"];
         };
         UpdateGaugeNeedleResponseContent: components["schemas"]["GaugeNeedle"];
         UpdateGoogleDocumentRequestContent: {
@@ -13107,7 +13128,7 @@ export interface operations {
             };
             cookie?: never;
         };
-        requestBody?: {
+        requestBody: {
             content: {
                 "application/json": components["schemas"]["UpdateGaugeNeedleRequestContent"];
             };
@@ -16306,6 +16327,15 @@ export interface operations {
                 };
                 content: {
                     "application/json": components["schemas"]["ForbiddenErrorResponseContent"];
+                };
+            };
+            /** @description NotFoundError 404 response */
+            404: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": components["schemas"]["NotFoundErrorResponseContent"];
                 };
             };
             /** @description RateLimitError 429 response */

--- a/typescript/src/generated/services/gauges.ts
+++ b/typescript/src/generated/services/gauges.ts
@@ -20,7 +20,7 @@ import { Errors } from "../../errors.js";
  */
 export interface UpdateGaugeNeedleGaugeRequest {
   /** Gauge needle */
-  gaugeNeedle?: components["schemas"]["GaugeNeedleUpdatePayload"];
+  gaugeNeedle: components["schemas"]["GaugeNeedleUpdatePayload"];
 }
 
 /**
@@ -45,7 +45,11 @@ export interface ListGaugeNeedlesGaugeOptions extends PaginationOptions {
 export interface CreateGaugeNeedleGaugeRequest {
   /** Gauge needle */
   gaugeNeedle: components["schemas"]["GaugeNeedlePayload"];
-  /** Who to notify: "everyone", "working_on", "custom", or omit for nobody */
+  /** Who to notify: "everyone", "default" (the project's existing
+subscribers), or "custom" (the people in `subscriptions`). Omit for
+nobody: bc3 defaults `notify` to "custom", which with no `subscriptions`
+notifies no one, and any unrecognized value (`Subscribers#find_subscribers`
+accepts exactly these three) falls through to nobody as well. */
   notify?: string;
   /** Array of people IDs to notify (only used when notify is "custom") */
   subscriptions?: number[];
@@ -110,10 +114,13 @@ export class GaugesService extends BaseService {
    *
    * @example
    * ```ts
-   * const result = await client.gauges.updateGaugeNeedle(123, { });
+   * const result = await client.gauges.updateGaugeNeedle(123, { gaugeNeedle: {  } });
    * ```
    */
   async updateGaugeNeedle(needleId: number, req: UpdateGaugeNeedleGaugeRequest): Promise<components["schemas"]["UpdateGaugeNeedleResponseContent"]> {
+    if (!req.gaugeNeedle) {
+      throw Errors.validation("Gauge needle is required");
+    }
     const response = await this.request(
       {
         service: "Gauges",

--- a/typescript/src/generated/services/gauges.ts
+++ b/typescript/src/generated/services/gauges.ts
@@ -114,7 +114,7 @@ export class GaugesService extends BaseService {
    *
    * @example
    * ```ts
-   * const result = await client.gauges.updateGaugeNeedle(123, { gaugeNeedle: {  } });
+   * const result = await client.gauges.updateGaugeNeedle(123, { gaugeNeedle: { description: "Details here" } });
    * ```
    */
   async updateGaugeNeedle(needleId: number, req: UpdateGaugeNeedleGaugeRequest): Promise<components["schemas"]["UpdateGaugeNeedleResponseContent"]> {

--- a/typescript/tests/services/gauges.test.ts
+++ b/typescript/tests/services/gauges.test.ts
@@ -484,6 +484,31 @@ describe("GaugesService", () => {
       expect(needle.position).toBe(72);
     });
 
+    // bc3's needle_params opens with params.require(:gauge_needle), so a body
+    // without the wrapper was always a 400. The generated method refuses it
+    // before the wire; no request is made.
+    it("refuses a missing gauge_needle wrapper as a validation error before the request", async () => {
+      let requests = 0;
+      server.use(
+        http.put(`${BASE_URL}/gauge_needles/${needleFixture.id}`, () => {
+          requests += 1;
+          return HttpResponse.json(sampleNeedle(needleFixture.id));
+        })
+      );
+
+      const error = asBasecampError(
+        await rejection(
+          client.gauges.updateGaugeNeedle(
+            needleFixture.id,
+            {} as unknown as Parameters<typeof client.gauges.updateGaugeNeedle>[1]
+          )
+        )
+      );
+      expect(error.code).toBe("validation");
+      expect(error.message).toBe("Gauge needle is required");
+      expect(requests).toBe(0);
+    });
+
     it("maps a 404 on an unknown needle to not_found", async () => {
       server.use(
         http.put(`${BASE_URL}/gauge_needles/999`, () =>


### PR DESCRIPTION
## Summary

Five drifts between the gauges spec and the contract bc3 serves at the pinned revision, all read off the jbuilder/controller source and `doc/api/sections/gauges.md`, fixed in the spec (and the one Go hand-written wrapper) and regenerated into all six SDKs:

1. **`GaugeNeedle.comment_count`** — `_needle.json.jbuilder` emits the singular key unconditionally, next to the envelope's plural `comments_count`. Modeled `@required`, with the same doc note `SearchResult.comment_count` carries. Go `GaugeNeedle.CommentCount`, Swift `commentCount`; the dict-shaped SDKs already passed it through. `spec/fixtures/gauges/needle_get.json` now carries it and the manifest's KNOWN INCOMPLETE note is gone.
2. **`UpdateGaugeNeedleInput.gauge_needle` is `@required`, and so is its `description`** — `needle_params` opens with `params.require(:gauge_needle)`, which rejects a missing wrapper and an empty one alike, and `description` is the only member the update accepts (`needle_params.except(:color, :position)`). So the wrapper-less and empty-wrapper bodies every SDK permitted were a 400, never a no-op. Matches `CreateGaugeNeedle`. Go's wrapper keeps `Description *string` and refuses `nil` before the wire as a usage error.
3. **`notify` doc string** — names `everyone`, `default`, `custom`, which is exactly what `Subscribers#find_subscribers` accepts; the previous `working_on` was invented and silently notified nobody. Surfaced in generated docs in all six SDKs.
4. **`Gauge.previous_needle_position` is nullable** — JSON `null` for a gauge's first needle (`gauges.md` shows it). `nullable: true` layered in `enhance-openapi-go-types.sh` like the other nullable-when-present members; Go's wrapper field becomes `*int32` so the null is distinguishable from a genuine move from 0. A second fixture, `gauges/get_first_needle.json`, pins the null against the schema.
5. **`ToggleGauge` declares `NotFoundError`** — `ProjectScoped` raises `RecordNotFound` for an unknown project, as `ListGaugeNeedles` on the same label already declared.

The three "noted, not proposed" items in the issue (`.json` suffix asymmetry, `maxPageSize: 50`, comma-joined `bucket_ids`) are left as they are.

## Red-proof, from the literal wire bodies

- Go: `TestGaugeNeedle_DecodesTheSingularCommentCount` (`comment_count: 5` next to `comments_count: 2` — the field did not exist before) and `TestGauge_PreviousNeedlePositionNullIsNotZero` (`null` → nil, wire `0` → non-nil 0; the value type decoded both to 0).
- Swift: `GaugeNeedle` is typed, so the test fixture gained `comment_count` and the decode test asserts `commentCount` — before the spec change the field was discarded.
- Kotlin: the "omits the wrapper when no attributes are given" test is replaced by one pinning that the wrapper always goes on the wire, since bc3 requires it.
- Fixtures: `make check-fixture-coverage` validates `needle_get.json` against the now-required member and `get_first_needle.json`'s null against the now-nullable one.

## Breaking

Labelled `breaking`; the `# Unreleased` section in `MIGRATING.md` covers both:

- `gauge_needle` and its `description` become required on `UpdateGaugeNeedle` in TypeScript, Python, Ruby, Kotlin and Swift (a call that omitted them stops compiling or raises before the wire — it always got a 400; an explicit `None`/`nil` in Python/Ruby still compacts to an empty body and gets the 400).
- `GaugeNeedle.comment_count` is required, so Swift's public initializer and the TypeScript/Python model types gain a required member.
- Go `Gauge.PreviousNeedlePosition` is `*int32` (apidiff flags the type change).

Fixes #731
