### PR TITLE
conformance: a path-less requestBody assertion pins the whole body

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -2744,7 +2744,7 @@ undocumented:
 | `errorRaised` | Operation failed, without naming how — the code-agnostic inverse of `noError`. For cases the SDKs refuse by *different* mechanisms (a hand-written guard raises `api_error`; a model decoder raises its own language's decode failure), so no single `errorType` is assertable and what all six agree on is that the call fails at all. Declaring it also tells the decoder-backed runners that a decode failure is the behaviour under test rather than a stale fixture body, which switches the stop-on-mismatch policy off for that case — so every fixture declaring it must have a non-`errorRaised` control sibling whose decoded body differs in exactly one field, enforced by `conformance/check_kill_case_controls.py`. |
 | `requestPath` | URL path of the outgoing request |
 | `requestMethod` | HTTP method of the outgoing request |
-| `requestBody` | Value at `path` (dot-notation key) inside the captured JSON request body. A request that sent no JSON body fails, as does a body that omits the key. |
+| `requestBody` | Value at `path` (dot-notation key) inside the captured JSON request body — or, with `path` omitted, the **whole** body: `expected` must equal it exactly, so a key the SDK added is a failure, not an unnoticed extra. A request that sent no JSON body fails in either form, as does a body that omits the named key. |
 | `requestBodyAbsent` | The `path` key is **not** present in the captured JSON request body — the assertion that pins body compaction (§18) and, for a merge-semantic endpoint, that an unaddressed field is left off the wire rather than echoed back. A request with no JSON body at all satisfies it. |
 | `errorCode` | Error code in structured error |
 | `errorMessage` | Error message text |
@@ -2761,6 +2761,14 @@ The per-request assertions — `headerPresent`, `headerAbsent`, `headerInjected`
 optional `index` naming which recorded request to inspect (0-based; negative
 counts from the end, so `-1` is the last request). It defaults to `0`, and an
 index past the number of recorded requests fails rather than passing vacuously.
+
+`path` is optional for `requestBody` alone, because its path-less form has a
+meaning (the whole body, above). Every other path-taking type — `errorField`,
+`headerAbsent`, `headerInjected`, `headerPresent`, `headerValue`,
+`requestBodyAbsent`, `responseBody`, `responseMeta` — requires it, and
+`conformance/schema.json` rejects a fixture that omits it, so the form reaches
+`make conformance-fixtures-check` with a message naming the field rather than a
+runner that cannot execute it (#587).
 
 ### Test Categories and Owning Sections
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -2768,7 +2768,10 @@ meaning (the whole body, above). Every other path-taking type — `errorField`,
 `requestBodyAbsent`, `responseBody`, `responseMeta` — requires it, and
 `conformance/schema.json` rejects a fixture that omits it, so the form reaches
 `make conformance-fixtures-check` with a message naming the field rather than a
-runner that cannot execute it (#587).
+runner that cannot execute it (#587). The same schema requires `expected` on a
+`requestBody` assertion, since a path-less one has nothing else to say: without
+it, `{"type": "requestBody"}` was schema-valid and failed in a different way per
+runner.
 
 ### Test Categories and Owning Sections
 

--- a/conformance/runner/go/main.go
+++ b/conformance/runner/go/main.go
@@ -1950,14 +1950,26 @@ func checkAssertion(
 		}
 
 	case "requestBody":
+		// Path names one key; empty, Expected is the WHOLE body, compared
+		// exactly, so a key the SDK added fails rather than slipping past.
 		fieldPath := assertion.Path
 		idx := assertionIndex(assertion)
+		what := "request body"
+		if fieldPath != "" {
+			what = fmt.Sprintf("request body field %q", fieldPath)
+		}
 		i, ok := resolveIndex(idx, len(requestBodies))
 		if !ok {
-			return fail(tc, fmt.Sprintf("Expected request body field %q on request index %d, but only %d requests were recorded", fieldPath, idx, len(requestBodies)))
+			return fail(tc, fmt.Sprintf("Expected %s on request index %d, but only %d requests were recorded", what, idx, len(requestBodies)))
 		}
 		if requestBodies[i] == nil {
-			return fail(tc, fmt.Sprintf("Expected request body field %q on request index %d, but request had no JSON body", fieldPath, idx))
+			return fail(tc, fmt.Sprintf("Expected %s on request index %d, but request had no JSON body", what, idx))
+		}
+		if fieldPath == "" {
+			if !jsonEqual(assertion.Expected, requestBodies[i]) {
+				return fail(tc, fmt.Sprintf("Expected request body on request index %d to equal %s exactly, got %s", idx, jsonString(assertion.Expected), jsonString(requestBodies[i])))
+			}
+			break
 		}
 		actual, present := digPath(requestBodies[i], fieldPath)
 		if !present {

--- a/conformance/runner/python/runner.py
+++ b/conformance/runner/python/runner.py
@@ -1371,14 +1371,21 @@ class TestRunner:
                         failures.append(f"Expected request method {expected!r} on request index {idx}, got {request['method']!r}")
 
                 case "requestBody":
-                    body_path = assertion["path"]
+                    # `path` names one key; absent, `expected` is the WHOLE
+                    # body, compared exactly, so a key the SDK added fails
+                    # rather than slipping past.
+                    body_path = assertion.get("path")
                     expected = assertion["expected"]
                     idx = assertion.get("index", 0)
+                    what = "request body" if body_path is None else f"request body {body_path}"
                     request = self._request_at(idx)
                     if request is None:
-                        failures.append(f"Expected request body {body_path} = {expected!r} on request index {idx}, but only {self._tracker.request_count} requests were recorded")
+                        failures.append(f"Expected {what} = {expected!r} on request index {idx}, but only {self._tracker.request_count} requests were recorded")
                     elif request["body"] is None:
-                        failures.append(f"Expected request body {body_path} = {expected!r} on request index {idx}, but the request had no JSON body")
+                        failures.append(f"Expected {what} = {expected!r} on request index {idx}, but the request had no JSON body")
+                    elif body_path is None:
+                        if request["body"] != expected:
+                            failures.append(f"Expected request body on request index {idx} to equal {expected!r} exactly, got {request['body']!r}")
                     else:
                         actual = _dig_body(request["body"], body_path)
                         if actual is _MISSING:

--- a/conformance/runner/python/runner.py
+++ b/conformance/runner/python/runner.py
@@ -1384,13 +1384,13 @@ class TestRunner:
                     elif request["body"] is None:
                         failures.append(f"Expected {what} = {expected!r} on request index {idx}, but the request had no JSON body")
                     elif body_path is None:
-                        if request["body"] != expected:
+                        if not _json_equal(expected, request["body"]):
                             failures.append(f"Expected request body on request index {idx} to equal {expected!r} exactly, got {request['body']!r}")
                     else:
                         actual = _dig_body(request["body"], body_path)
                         if actual is _MISSING:
                             failures.append(f"Expected request body {body_path} = {expected!r} on request index {idx}, but the key is absent")
-                        elif actual != expected:
+                        elif not _json_equal(expected, actual):
                             failures.append(f"Expected request body {body_path} = {expected!r} on request index {idx}, got {actual!r}")
 
                 case "requestBodyAbsent":
@@ -1518,6 +1518,21 @@ def _dig_path(obj: Any, path: str) -> Any:
         else:
             obj = getattr(obj, key, None)
     return obj
+
+
+def _json_equal(expected: Any, actual: Any) -> bool:
+    """Equality at the JSON level, not Python's: `False == 0` and `True == 1` in
+    Python, so native comparison lets a body that sent `0` where the fixture says
+    `false` pass. The other runners reject that wire-type mismatch; so does this."""
+    if isinstance(expected, bool) or isinstance(actual, bool):
+        return isinstance(expected, bool) and isinstance(actual, bool) and expected is actual
+    if isinstance(expected, dict) and isinstance(actual, dict):
+        return expected.keys() == actual.keys() and all(_json_equal(v, actual[k]) for k, v in expected.items())
+    if isinstance(expected, list) and isinstance(actual, list):
+        return len(expected) == len(actual) and all(_json_equal(e, a) for e, a in zip(expected, actual))
+    if isinstance(expected, (dict, list)) or isinstance(actual, (dict, list)):
+        return False
+    return expected == actual
 
 
 def _dig_body(obj: Any, path: str) -> Any:

--- a/conformance/runner/python/test_request_body.py
+++ b/conformance/runner/python/test_request_body.py
@@ -1,0 +1,30 @@
+"""JSON-level equality for the requestBody assertion (#854).
+
+Python's native comparison says ``False == 0`` and ``True == 1``, so a body that
+sent ``0`` where the fixture says ``false`` passed the path-less whole-body form
+and the keyed form alike, while every other runner rejected the wire-type
+mismatch. ``_json_equal`` is what both forms compare with now.
+"""
+from __future__ import annotations
+
+from runner import _json_equal
+
+
+def test_bool_and_int_are_distinct():
+    assert not _json_equal(False, 0)
+    assert not _json_equal(True, 1)
+    assert not _json_equal({"highlighted": False}, {"highlighted": 0})
+    assert _json_equal({"highlighted": False}, {"highlighted": False})
+
+
+def test_containers_compare_recursively_and_exactly():
+    assert _json_equal({"a": [1, {"b": "c"}]}, {"a": [1, {"b": "c"}]})
+    assert not _json_equal({"a": 1}, {"a": 1, "b": 2})
+    assert not _json_equal([1, 2], [1, 2, 3])
+    assert not _json_equal({"a": 1}, [1])
+
+
+def test_numbers_compare_numerically_and_strings_stay_strings():
+    assert _json_equal(1, 1.0)
+    assert not _json_equal("42", 42)
+    assert _json_equal(None, None)

--- a/conformance/runner/ruby/runner.rb
+++ b/conformance/runner/ruby/runner.rb
@@ -1480,14 +1480,21 @@ class TestRunner
         end
 
       when "requestBody"
+        # `path` names one key; absent, `expected` is the WHOLE body, compared
+        # exactly, so a key the SDK added fails rather than slipping past.
         key_path = assertion["path"]
         expected = assertion["expected"]
         idx = assertion["index"] || 0
+        what = key_path.nil? ? "request body" : "request body #{key_path}"
         request = request_at(idx)
         if request.nil?
-          failures << "Expected request body #{key_path} on request index #{idx}, but only #{@tracker.request_count} requests were recorded"
+          failures << "Expected #{what} on request index #{idx}, but only #{@tracker.request_count} requests were recorded"
         elsif request[:body].nil?
-          failures << "Expected request body #{key_path} on request index #{idx}, but the request had no JSON body"
+          failures << "Expected #{what} on request index #{idx}, but the request had no JSON body"
+        elsif key_path.nil?
+          unless request[:body] == expected
+            failures << "Expected request body on request index #{idx} to equal #{expected.inspect} exactly, got #{request[:body].inspect}"
+          end
         else
           present, actual = fetch_body_key(request[:body], key_path)
           if !present

--- a/conformance/runner/rust/src/assertions.rs
+++ b/conformance/runner/rust/src/assertions.rs
@@ -231,15 +231,32 @@ fn check(run: &Run, assertion: &Assertion) -> Result<(), String> {
             }
         }
         "requestBody" => {
+            // Path names one key; empty, `expected` is the WHOLE body, compared
+            // exactly, so a key the SDK added fails rather than slipping past.
             let path = &assertion.path;
+            let what = if path.is_empty() {
+                "request body".to_string()
+            } else {
+                format!("request body field {path:?}")
+            };
             let (i, index) = pick(assertion, recorded.bodies.len(), || {
-                format!("Expected request body field {path:?}")
+                format!("Expected {what}")
             })?;
             let Some(body) = &recorded.bodies[i] else {
                 return Err(format!(
-                    "Expected request body field {path:?} on request index {index}, but request had no JSON body"
+                    "Expected {what} on request index {index}, but request had no JSON body"
                 ));
             };
+            if path.is_empty() {
+                return if assertion.expected == *body {
+                    Ok(())
+                } else {
+                    Err(format!(
+                        "Expected request body on request index {index} to equal {} exactly, got {body}",
+                        assertion.expected
+                    ))
+                };
+            }
             let actual = lookup(body, path).ok_or_else(|| {
                 format!("Expected request body field {path:?} on request index {index}, but it was absent")
             })?;
@@ -623,6 +640,37 @@ mod tests {
                 .contains("Expected request body position = 42")
         );
         recorded.bodies[0] = Some(json!({"position": 42}));
+        let run = Run {
+            case: &case,
+            outcome: &Ok(Outcome::Unit),
+            recorded: &recorded,
+        };
+        assert_eq!(check_all(&run), Ok(()));
+    }
+
+    #[test]
+    fn a_path_less_request_body_assertion_pins_the_whole_body() {
+        let case: TestCase = serde_json::from_value(json!({
+            "name": "a", "method": "PUT",
+            "assertions": [{"type": "requestBody", "expected": {"summary": "Team Meeting"}}]
+        }))
+        .unwrap();
+        let mut recorded = Recorded::default();
+        recorded.methods.push("PUT".into());
+        recorded
+            .bodies
+            .push(Some(json!({"summary": "Team Meeting", "all_day": false})));
+        let run = Run {
+            case: &case,
+            outcome: &Ok(Outcome::Unit),
+            recorded: &recorded,
+        };
+        assert!(
+            check_all(&run)
+                .unwrap_err()
+                .contains("Expected request body on request index 0 to equal")
+        );
+        recorded.bodies[0] = Some(json!({"summary": "Team Meeting"}));
         let run = Run {
             case: &case,
             outcome: &Ok(Outcome::Unit),

--- a/conformance/runner/swift/Sources/ConformanceRunner/Assertions.swift
+++ b/conformance/runner/swift/Sources/ConformanceRunner/Assertions.swift
@@ -312,17 +312,29 @@ func evaluateAssertions(
             }
 
         case "requestBody":
+            // `path` names one key; empty, `expected` is the WHOLE body,
+            // compared exactly, so a key the SDK added fails rather than
+            // slipping past.
             let key = assertion.fieldPath
+            let label = key.isEmpty
+                ? "requestBody[\(assertion.requestIndex)]"
+                : "requestBody.\(key)[\(assertion.requestIndex)]"
             guard let idx = resolveRequestIndex(assertion.requestIndex, requestCount) else {
-                return .fail("requestBody.\(key)[\(assertion.requestIndex)]: no request recorded at that index (\(requestCount) requests)")
+                return .fail("\(label): no request recorded at that index (\(requestCount) requests)")
             }
             guard let body = captured[idx].bodyJSON else {
-                return .fail("requestBody.\(key)[\(assertion.requestIndex)]: request has no JSON body")
+                return .fail("\(label): request has no JSON body")
             }
-            guard let actual = body.navigate(key) else {
-                return .fail("requestBody.\(key)[\(assertion.requestIndex)]: key not present in request body")
+            let actual: JSON
+            if key.isEmpty {
+                actual = body
+            } else {
+                guard let navigated = body.navigate(key) else {
+                    return .fail("\(label): key not present in request body")
+                }
+                actual = navigated
             }
-            if let failure = compareJSON("requestBody.\(key)[\(assertion.requestIndex)]", assertion.expected, actual) {
+            if let failure = compareJSON(label, assertion.expected, actual) {
                 return .fail(failure)
             }
 

--- a/conformance/runner/typescript/runner.test.ts
+++ b/conformance/runner/typescript/runner.test.ts
@@ -1533,20 +1533,30 @@ function checkAssertions(
       }
 
       case "requestBody": {
-        const key = assertion.path!;
+        // `path` names one key; absent, `expected` is the WHOLE body, compared
+        // exactly, so a key the SDK added fails rather than slipping past.
+        const key = assertion.path;
         const idx = assertion.index ?? 0;
+        const what = key === undefined ? "request body" : `request body key ${key}`;
         const bodies = tracker.requestBodies();
         const i = resolveRequestIndex(bodies.length, idx);
         if (i === undefined) {
           throw new Error(
-            `[${tc.name}] expected request body key ${key} on request index ${idx}, but only ${bodies.length} requests were recorded`,
+            `[${tc.name}] expected ${what} on request index ${idx}, but only ${bodies.length} requests were recorded`,
           );
         }
         const body = bodies[i];
         if (body === undefined) {
           throw new Error(
-            `[${tc.name}] expected request body key ${key} on request index ${idx}, but the request had no JSON body`,
+            `[${tc.name}] expected ${what} on request index ${idx}, but the request had no JSON body`,
           );
+        }
+        if (key === undefined) {
+          expect(
+            body,
+            `[${tc.name}] expected request body on request index ${idx} to equal ${JSON.stringify(assertion.expected)} exactly, got ${JSON.stringify(body)}`,
+          ).toStrictEqual(assertion.expected);
+          break;
         }
         const { present, value } = lookupBodyPath(body, key);
         if (!present) {

--- a/conformance/schema.json
+++ b/conformance/schema.json
@@ -184,6 +184,10 @@
               }
             },
             "then": { "required": ["path"] }
+          },
+          {
+            "if": { "properties": { "type": { "const": "requestBody" } } },
+            "then": { "required": ["expected"] }
           }
         ]
       }

--- a/conformance/schema.json
+++ b/conformance/schema.json
@@ -115,7 +115,7 @@
       "items": {
         "type": "object",
         "required": ["type"],
-        "$comment": "errorRaised is the inverse of noError and takes no `expected`: the dispatch must fail SOMEHOW, without pinning which canonical code. It exists for the malformed-response family (#576), where the six SDKs refuse the same body by six different mechanisms — a hand-written guard in TypeScript/Python/Ruby, and the model decoder in Go/Kotlin/Swift — so no single errorType is assertable. A fixture declaring it also tells the Kotlin and Swift runners that a decoder rejection is the POINT of the case rather than a malformed-fixture bug.",
+        "$comment": "errorRaised is the inverse of noError and takes no `expected`: the dispatch must fail SOMEHOW, without pinning which canonical code. It exists for the malformed-response family (#576), where the six SDKs refuse the same body by six different mechanisms — a hand-written guard in TypeScript/Python/Ruby, and the model decoder in Go/Kotlin/Swift — so no single errorType is assertable. A fixture declaring it also tells the Kotlin and Swift runners that a decoder rejection is the POINT of the case rather than a malformed-fixture bug. The allOf below requires `path` on every path-taking type except requestBody: an absent key, header or field cannot be named without one, and no runner implements a path-less form of those, so requiring it fails the fixture at conformance-fixtures-check with a message naming the field instead of six different crashes downstream (#587). requestBody is the exception because its path-less form IS defined — whole-body equality.",
         "properties": {
           "type": {
             "type": "string",
@@ -157,13 +157,34 @@
           },
           "path": {
             "type": "string",
-            "description": "JSONPath or dot-notation path for nested value assertions. For requestBody / requestBodyAbsent, the key (dot-notation) inside the captured request body."
+            "description": "JSONPath or dot-notation path for nested value assertions. For requestBody / requestBodyAbsent, the key (dot-notation) inside the captured request body. Optional for requestBody alone: omitted, `expected` is the WHOLE captured body and must equal it exactly, so a key the SDK added fails rather than passing unseen. Every other path-taking type requires it (the allOf below), so a path-less fixture is rejected here instead of reaching a runner that cannot execute it."
           },
           "index": {
             "type": "integer",
             "description": "Request index for per-request assertions: headerPresent / headerAbsent / headerInjected / requestPath / requestMethod / requestBody / requestBodyAbsent (0-based; negative values index from the end, e.g. -1 = last request). Default 0. For delayBetweenRequests it selects a single inter-request GAP (gap i is between request i and i+1); omit it to require the minimum on every gap. A delayBetweenRequests assertion never passes vacuously: a named gap the run did not produce FAILS, an omitted index on a run with no gaps FAILS, and a negative gap index is rejected rather than wrapping to the end — a timing pin exists to catch a dropped backoff, and a dropped backoff is exactly what removes the gap."
           }
-        }
+        },
+        "allOf": [
+          {
+            "if": {
+              "properties": {
+                "type": {
+                  "enum": [
+                    "errorField",
+                    "headerAbsent",
+                    "headerInjected",
+                    "headerPresent",
+                    "headerValue",
+                    "requestBodyAbsent",
+                    "responseBody",
+                    "responseMeta"
+                  ]
+                }
+              }
+            },
+            "then": { "required": ["path"] }
+          }
+        ]
       }
     },
     "configOverrides": {

--- a/conformance/schema.json
+++ b/conformance/schema.json
@@ -157,7 +157,8 @@
           },
           "path": {
             "type": "string",
-            "description": "JSONPath or dot-notation path for nested value assertions. For requestBody / requestBodyAbsent, the key (dot-notation) inside the captured request body. Optional for requestBody alone: omitted, `expected` is the WHOLE captured body and must equal it exactly, so a key the SDK added fails rather than passing unseen. Every other path-taking type requires it (the allOf below), so a path-less fixture is rejected here instead of reaching a runner that cannot execute it."
+            "minLength": 1,
+            "description": "JSONPath or dot-notation path for nested value assertions. For requestBody / requestBodyAbsent, the key (dot-notation) inside the captured request body. Optional for requestBody alone: omitted, `expected` is the WHOLE captured body and must equal it exactly, so a key the SDK added fails rather than passing unseen. Every other path-taking type requires it (the allOf below), so a path-less fixture is rejected here instead of reaching a runner that cannot execute it. Never empty: three runners treat \"\" as an absent path and three as a lookup of the empty key, so minLength keeps that disagreement out of any schema-valid fixture."
           },
           "index": {
             "type": "integer",

--- a/conformance/tests/schedule_entries_write.json
+++ b/conformance/tests/schedule_entries_write.json
@@ -123,6 +123,15 @@
         "index": 0
       },
       {
+        "type": "requestBody",
+        "expected": {
+          "summary": "Team Meeting",
+          "starts_at": "2026-06-05T06:00:00Z",
+          "ends_at": "2026-06-05T08:30:00Z"
+        },
+        "index": 0
+      },
+      {
         "type": "noError"
       }
     ],

--- a/kotlin/conformance/src/main/kotlin/com/basecamp/sdk/conformance/Main.kt
+++ b/kotlin/conformance/src/main/kotlin/com/basecamp/sdk/conformance/Main.kt
@@ -719,15 +719,23 @@ private fun runTest(tc: TestCase): TestResult {
             }
 
             "requestBody" -> {
+                // `path` names one key; empty, `expected` is the WHOLE body,
+                // compared exactly, so a key the SDK added fails rather than
+                // slipping past.
                 val requestIndex = assertion.index ?: 0
                 val key = assertion.path
+                val label = if (key.isEmpty()) "requestBody[$requestIndex]" else "requestBody.$key[$requestIndex]"
                 val idx = resolveRequestIndex(requestIndex, requestBodies.size)
-                    ?: return TestResult(false, "requestBody.$key[$requestIndex]: no request recorded at that index (${requestBodies.size} requests)")
+                    ?: return TestResult(false, "$label: no request recorded at that index (${requestBodies.size} requests)")
                 val body = requestBodies[idx]
-                    ?: return TestResult(false, "requestBody.$key[$requestIndex]: request has no JSON body")
-                val actual = navigateJsonPath(body, key)
-                    ?: return TestResult(false, "requestBody.$key[$requestIndex]: key not present in request body")
-                val result = compareJsonValues("requestBody.$key[$requestIndex]", assertion.expected, actual)
+                    ?: return TestResult(false, "$label: request has no JSON body")
+                val actual = if (key.isEmpty()) {
+                    body
+                } else {
+                    navigateJsonPath(body, key)
+                        ?: return TestResult(false, "$label: key not present in request body")
+                }
+                val result = compareJsonValues(label, assertion.expected, actual)
                 if (result != null) return result
             }
 

--- a/rust/basecamp-sdk/tests/composites_support/mod.rs
+++ b/rust/basecamp-sdk/tests/composites_support/mod.rs
@@ -123,12 +123,18 @@ fn check(assertion: &Value, requests: &[Request], error: Option<&Error>) {
             "request path"
         ),
         "requestBody" => {
-            let path = assertion["path"].as_str().expect("body path");
-            assert_eq!(
-                member(&body_of(request_at(requests, assertion)), path),
-                Some(&assertion["expected"]),
-                "request body member {path}"
-            );
+            // `path` names one member; absent, `expected` is the WHOLE body,
+            // compared exactly, so a key the SDK added fails rather than
+            // slipping past (conformance/schema.json).
+            let body = body_of(request_at(requests, assertion));
+            match assertion["path"].as_str() {
+                Some(path) => assert_eq!(
+                    member(&body, path),
+                    Some(&assertion["expected"]),
+                    "request body member {path}"
+                ),
+                None => assert_eq!(body, assertion["expected"], "request body"),
+            }
         }
         "requestBodyAbsent" => {
             let path = assertion["path"].as_str().expect("body path");


### PR DESCRIPTION
## Summary

`conformance/schema.json` declared `path` optional on a `requestBody` assertion, and no runner implemented the path-less form: each of the six dereferenced `path` unconditionally, so a schema-valid fixture produced a different crash or a misleading "key not present" per language.

This takes the first of the issue's two options. A `requestBody` assertion with no `path` now means **the whole captured body equals `expected`, exactly** — a strictly stronger pin than the per-key form, because a key the SDK adds on its own is a failure instead of an unnoticed extra. All six runners implement it, and `conformance/schema.json` plus SPEC §19 document both forms.

The other half of the class is closed by the schema rather than by six more branches: every other path-taking assertion type (`errorField`, `headerAbsent`, `headerInjected`, `headerPresent`, `headerValue`, `requestBodyAbsent`, `responseBody`, `responseMeta`) has no meaning without a path, so an `allOf`/`if`/`then` now requires it for those. A path-less fixture of that shape fails `make conformance-fixtures-check` with a message naming the field instead of reaching a runner. A census of `conformance/tests/*.json` shows the split is already clean: those eight always carry `path` today, and no other type ever does.

## Red-proof

The fixture landed first. `schedule_entries_write.json` "replace-omission-clears" — whose description already says the raw replace sends exactly what the caller passed — gained a path-less `requestBody` pinning the whole three-key body. Against the unmodified runners:

| Runner | Failure |
|---|---|
| Go | `Expected request body field "" on request index 0, but it was absent` |
| Python | `KeyError: 'path'` |
| Ruby | `runner.rb:1311:in 'TestRunner#fetch_body_key': undefined method 'split' for nil (NoMethodError)` |
| TypeScript | `TypeError: Cannot read properties of undefined (reading 'split')` at `lookupBodyPath` |
| Kotlin / Swift | `navigateJsonPath(body, "")` / `body.navigate("")` look up the empty key and report "key not present in request body" |

With the change, all six pass it, and the existing per-key and `requestBodyAbsent` assertions on the same case stay as they were.

## Runner semantics

Shared across the six: no path → whole-body exact equality; a request with no JSON body fails; the failure message names the full expected and actual bodies. Each runner compares with the same helper it already used for the per-key form (`jsonEqual`, `toStrictEqual`, `==`, `compareJsonValues`, `compareJSON`), so number and nesting handling is unchanged.

Fixes #587

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #587 by implementing the path-less `requestBody` assertion that `conformance/schema.json` allowed but no runner handled. A `requestBody` assertion without `path` now means the whole captured body must equal `expected` exactly, and the other eight path-taking assertion types now require `path` in the schema.

**Details**
- Whole-body pinning is strictly stronger than the per-key form: a key the SDK adds on its own is a failure instead of an unnoticed extra.
- All seven runners compare with the same helper they already used for the per-key form; Python now uses a shared `_json_equal` so `false` and `0` are distinct, matching the other runners' wire-type strictness. A request with no JSON body fails in either form.
- The schema rejects a path-less fixture of the other types at `make conformance-fixtures-check` with a message naming the field, and also requires `expected` on `requestBody`, which previously was schema-valid with nothing to say.
- The schema rejects an empty `path` string: three runners treat `""` as absent and four as a lookup of the empty key, so `minLength: 1` keeps that disagreement out of any schema-valid fixture.
- `schedule_entries_write.json` gained a path-less `requestBody` pinning the whole three-key body, which previously failed on every runner with different errors, and the Rust SDK's composites harness now takes the same form.

<sup>Written for commit a6e6d46440f858d87fa4fa2fd885fc62d433f1b7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-sdk/pull/854?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

