### PR TITLE
feat(templates): model start_date on project construction

### DIFF
--- a/MIGRATING.md
+++ b/MIGRATING.md
@@ -11,6 +11,21 @@ what wrong behaviour you get if you ignore one. This file is that half.
 
 ---
 
+# Unreleased
+
+### Go: `TemplatesService.CreateProject` takes a variadic options argument (#856)
+
+`CreateProject(ctx, templateID, name, description)` gains a trailing
+`opts ...*CreateProjectOptions`, the carrier for the new `start_date` on
+project construction (`CreateProjectOptions{StartDate: "2026-09-01"}`; empty
+is omitted from the wire). Every existing call compiles unchanged. What does
+not: code that holds the method as a func value of the old type, or an
+interface of your own that names the old signature — both must add the
+variadic parameter. The other five SDKs take the project attributes as a
+struct or map and gain the optional field with no signature change.
+
+---
+
 # v0.17.0
 
 ### All SDKs: project client access and client enablement (#847)

--- a/SPEC.md
+++ b/SPEC.md
@@ -2776,6 +2776,7 @@ the category slug is the filename (basename, `_` written as `-`).
 | network-retry | `network-retry.json` | §7 Retry (network errors, Gate 2) |
 | pagination | `pagination.json` | §8 Pagination |
 | paths | `paths.json` | §3 Client Architecture (account path construction) |
+| project-constructions | `project_constructions.json` | §3 Client Architecture (account path construction), §10 Type Fidelity (an optional wire field sent when given and omitted, not nulled, when not), §11 Response Semantics |
 | retry | `retry.json` | §7 Retry |
 | schedule-entries-write | `schedule_entries_write.json` | §5 Merge-Safe Write Surface (Schedule Entries), §18 Hand-Written Composite Methods, §10 Type Fidelity (explicit-empty vs. omitted wire semantics) |
 | search | `search.json` | §10 Type Fidelity — the polymorphic search projection, whose file-attachment branch is recognized by the ABSENCE of the recording envelope's `id`/`title`/`type`/`url`/`app_url` |
@@ -4218,6 +4219,7 @@ what `make doc-constants-check` asserts — not a case-by-case index.
 | `upcoming_schedule.json` | The reduced calendar projection: entry, recurring occurrence, assignable, empty envelope (4 cases) | §10 (Type Fidelity) |
 | `search.json` | The polymorphic search projection: the generic recording envelope plus all four special branches, and the file-attachment branch in isolation (2 cases) | §10 (Type Fidelity) |
 | `template_library.json` | Library read, copy creation, completed-copy decoding, and people-confirmation validation (4 cases) | §3, §6, §10, §11 |
+| `project_constructions.json` | Project construction from a template: attributes nested under the `project` envelope, `start_date` carried when given and absent when omitted (2 cases) | §3, §10, §11 |
 | `live-my-surface.json` | Live schema validation, 31 read-surface cases (opt-in via `BASECAMP_LIVE`) | External governance (CONTRIBUTING.md, live canary) |
 <!-- @fixture-section-map:end -->
 

--- a/conformance/runner/go/main.go
+++ b/conformance/runner/go/main.go
@@ -521,6 +521,10 @@ func summarizeTemplateLibrary(library *basecamp.TemplateLibrary) map[string]inte
 	return result
 }
 
+func summarizeProjectConstruction(construction *basecamp.ProjectConstruction) map[string]interface{} {
+	return map[string]interface{}{"id": construction.ID, "status": construction.Status}
+}
+
 func summarizeTemplateLibraryCopy(copy *basecamp.TemplateLibraryCopy) map[string]interface{} {
 	result := map[string]interface{}{"id": copy.ID, "status": copy.Status}
 	if copy.DestinationTodolist != nil {
@@ -788,6 +792,20 @@ func executeOperation(ctx context.Context, account *basecamp.AccountClient, tc T
 			return operationResult{err: err}
 		}
 		return operationResult{result: summarizeTemplateLibraryCopy(libraryCopy)}
+
+	case "CreateProjectFromTemplate":
+		templateID, parseErr := getExactInt64Param(tc.PathParams, "templateId")
+		if parseErr != nil {
+			return operationResult{err: basecamp.ErrUsage(parseErr.Error())}
+		}
+		construction, err := account.Templates().CreateProject(ctx, templateID,
+			getStringParam(tc.RequestBody, "name"),
+			getStringParam(tc.RequestBody, "description"),
+			&basecamp.CreateProjectOptions{StartDate: getStringParam(tc.RequestBody, "start_date")})
+		if err != nil {
+			return operationResult{err: err}
+		}
+		return operationResult{result: summarizeProjectConstruction(construction)}
 
 	case "GetTemplateLibraryCopy":
 		copyID, parseErr := getExactInt64Param(tc.PathParams, "copyId")

--- a/conformance/runner/python/runner.py
+++ b/conformance/runner/python/runner.py
@@ -501,6 +501,16 @@ def _summarize_template_library(library: dict[str, Any]) -> dict[str, Any]:
     }
 
 
+def _compact_project_attributes(body: dict[str, Any]) -> dict[str, Any]:
+    """Nest the fixture's flat attributes under the project envelope, dropping the
+    ones the case did not set so an omitted start_date stays off the wire."""
+    return {key: body[key] for key in ("name", "description", "start_date") if key in body}
+
+
+def _summarize_project_construction(construction: dict[str, Any]) -> dict[str, Any]:
+    return {"id": construction["id"], "status": construction["status"]}
+
+
 def _summarize_template_library_copy(copy: dict[str, Any]) -> dict[str, Any]:
     """Expose copy state and its decoded destination list as portable scalars."""
     summary = {"id": copy["id"], "status": copy["status"]}
@@ -688,6 +698,13 @@ class OperationMapper:
                         template_recording_id=body["template_recording_id"],
                         destination_parent_id=body["destination_parent_id"],
                         adding_people_confirmed=body.get("adding_people_confirmed"),
+                    )
+                )
+            case "CreateProjectFromTemplate":
+                return _summarize_project_construction(
+                    self._account.templates.create_project(
+                        template_id=path_params["templateId"],
+                        project=_compact_project_attributes(body),
                     )
                 )
             case "GetTemplateLibraryCopy":

--- a/conformance/runner/ruby/runner.rb
+++ b/conformance/runner/ruby/runner.rb
@@ -430,6 +430,13 @@ class OperationMapper
           adding_people_confirmed: body["adding_people_confirmed"]
         )
       )
+    when "CreateProjectFromTemplate"
+      summarize_project_construction(
+        @account.templates.create_project(
+          template_id: path_params["templateId"],
+          project: body.slice("name", "description", "start_date")
+        )
+      )
     when "GetTemplateLibraryCopy"
       summarize_template_library_copy(
         @account.templates.get_library_copy(copy_id: path_params["copyId"])
@@ -805,6 +812,10 @@ class OperationMapper
       "todoset_id" => library.dig("todoset", "id"),
       "first_todolist_id" => library.dig("todolists", 0, "id"),
     }
+  end
+
+  def summarize_project_construction(construction)
+    { "id" => construction["id"], "status" => construction["status"] }
   end
 
   def summarize_template_library_copy(copy)

--- a/conformance/runner/swift/Sources/ConformanceRunner/Dispatch.swift
+++ b/conformance/runner/swift/Sources/ConformanceRunner/Dispatch.swift
@@ -351,6 +351,19 @@ func dispatchOperation(_ tc: TestCase, _ account: AccountClient) async throws ->
                 templateRecordingId: rb.longParam("template_recording_id")))
         return DispatchResult(resultJSON: summarizeTemplateLibraryCopy(libraryCopy))
 
+    case "CreateProjectFromTemplate":
+        let construction = try await account.templates.createProject(
+            templateId: pathParams.longParam("templateId"),
+            req: CreateProjectFromTemplateRequest(
+                project: ProjectConstructionAttributes(
+                    name: rb.stringParam("name"),
+                    description: rb.optString("description"),
+                    startDate: rb.optString("start_date"))))
+        return DispatchResult(resultJSON: .object([
+            "id": .int(Int64(construction.id)),
+            "status": .string(construction.status),
+        ]))
+
     case "GetTemplateLibraryCopy":
         let libraryCopy = try await account.templates.getLibraryCopy(copyId: pathParams.longParam("copyId"))
         return DispatchResult(resultJSON: summarizeTemplateLibraryCopy(libraryCopy))

--- a/conformance/runner/typescript/runner.test.ts
+++ b/conformance/runner/typescript/runner.test.ts
@@ -512,6 +512,17 @@ async function executeOperation(
         return { result: summarizeTemplateLibraryCopy(libraryCopy) };
       }
 
+      case "CreateProjectFromTemplate": {
+        const construction = await client.templates.createProject(Number(params.templateId), {
+          project: {
+            name: String(body.name),
+            description: typeof body.description === "string" ? body.description : undefined,
+            start_date: typeof body.start_date === "string" ? body.start_date : undefined,
+          },
+        });
+        return { result: { id: construction.id, status: construction.status } };
+      }
+
       case "GetTemplateLibraryCopy": {
         const libraryCopy = await client.templates.getLibraryCopy(Number(params.copyId));
         return { result: summarizeTemplateLibraryCopy(libraryCopy) };

--- a/conformance/tests/project_constructions.json
+++ b/conformance/tests/project_constructions.json
@@ -1,0 +1,71 @@
+[
+  {
+    "name": "project construction sends name, description and start_date under the project envelope",
+    "description": "Verifies that constructing a project from a template nests every attribute under `project` and carries `start_date` on the wire, the ISO 8601 date the server anchors the template's relative dates to (Sunday of that week).",
+    "operation": "CreateProjectFromTemplate",
+    "method": "POST",
+    "path": "/templates/{templateId}/project_constructions.json",
+    "pathParams": { "templateId": 2085958507 },
+    "requestBody": {
+      "name": "Marketing Campaign",
+      "description": "For Client: Xyz Corp Conference",
+      "start_date": "2026-09-01"
+    },
+    "mockResponses": [
+      {
+        "status": 201,
+        "headers": { "Content-Type": "application/json" },
+        "body": {
+          "id": 598194962,
+          "status": "pending",
+          "url": "https://3.basecampapi.com/999/templates/2085958507/project_constructions/598194962.json"
+        }
+      }
+    ],
+    "assertions": [
+      { "type": "noError" },
+      { "type": "requestCount", "expected": 1 },
+      { "type": "requestMethod", "expected": "POST" },
+      { "type": "requestPath", "expected": "/999/templates/2085958507/project_constructions.json" },
+      { "type": "requestBody", "path": "project.name", "expected": "Marketing Campaign" },
+      { "type": "requestBody", "path": "project.description", "expected": "For Client: Xyz Corp Conference" },
+      { "type": "requestBody", "path": "project.start_date", "expected": "2026-09-01" },
+      { "type": "requestBodyAbsent", "path": "name" },
+      { "type": "requestBodyAbsent", "path": "start_date" },
+      { "type": "responseBody", "path": "id", "expected": 598194962 },
+      { "type": "responseBody", "path": "status", "expected": "pending" }
+    ],
+    "tags": ["templates", "project-construction", "write"]
+  },
+  {
+    "name": "project construction omits start_date when none is given",
+    "description": "Verifies that a construction without a start date leaves `start_date` off the wire entirely rather than sending null or an empty string, so the server anchors the template's dates to the week of construction.",
+    "operation": "CreateProjectFromTemplate",
+    "method": "POST",
+    "path": "/templates/{templateId}/project_constructions.json",
+    "pathParams": { "templateId": 2085958507 },
+    "requestBody": {
+      "name": "Marketing Campaign"
+    },
+    "mockResponses": [
+      {
+        "status": 201,
+        "headers": { "Content-Type": "application/json" },
+        "body": {
+          "id": 598194963,
+          "status": "pending",
+          "url": "https://3.basecampapi.com/999/templates/2085958507/project_constructions/598194963.json"
+        }
+      }
+    ],
+    "assertions": [
+      { "type": "noError" },
+      { "type": "requestCount", "expected": 1 },
+      { "type": "requestBody", "path": "project.name", "expected": "Marketing Campaign" },
+      { "type": "requestBodyAbsent", "path": "project.start_date" },
+      { "type": "requestBodyAbsent", "path": "project.description" },
+      { "type": "responseBody", "path": "id", "expected": 598194963 }
+    ],
+    "tags": ["templates", "project-construction", "write"]
+  }
+]

--- a/go/pkg/basecamp/templates.go
+++ b/go/pkg/basecamp/templates.go
@@ -40,6 +40,14 @@ type ProjectConstruction struct {
 	Project *Project `json:"project,omitempty"`
 }
 
+// CreateProjectOptions specifies optional parameters for creating a project from a template.
+type CreateProjectOptions struct {
+	// StartDate is the date the new project starts on (ISO 8601, e.g. "2026-09-01").
+	// Template dates are anchored to the Sunday on or before it. Empty anchors them
+	// to the week the construction is created.
+	StartDate string
+}
+
 // TemplateLibrary contains the account's to-do list templates and their parent resources.
 type TemplateLibrary struct {
 	Bucket    Bucket     `json:"bucket"`
@@ -346,7 +354,7 @@ func (s *TemplatesService) Delete(ctx context.Context, templateID int64) (err er
 
 // CreateProject creates a new project from a template.
 // This operation is asynchronous; use GetConstruction to check the status.
-func (s *TemplatesService) CreateProject(ctx context.Context, templateID int64, name, description string) (result *ProjectConstruction, err error) {
+func (s *TemplatesService) CreateProject(ctx context.Context, templateID int64, name, description string, opts ...*CreateProjectOptions) (result *ProjectConstruction, err error) {
 	op := OperationInfo{
 		Service: "Templates", Operation: "CreateProject",
 		ResourceType: "project_construction", IsMutation: true,
@@ -361,6 +369,11 @@ func (s *TemplatesService) CreateProject(ctx context.Context, templateID int64, 
 	ctx = s.client.parent.hooks.OnOperationStart(ctx, op)
 	defer func() { s.client.parent.hooks.OnOperationEnd(ctx, op, err, time.Since(start)) }()
 
+	if len(opts) > 1 {
+		err = ErrUsage("CreateProject accepts at most one CreateProjectOptions argument")
+		return nil, err
+	}
+
 	if name == "" {
 		err = ErrUsage("project name is required")
 		return nil, err
@@ -371,6 +384,9 @@ func (s *TemplatesService) CreateProject(ctx context.Context, templateID int64, 
 			Name:        name,
 			Description: omitzero(description),
 		},
+	}
+	if len(opts) > 0 && opts[0] != nil {
+		body.Project.StartDate = omitzero(opts[0].StartDate)
 	}
 
 	resp, err := s.client.parent.gen.CreateProjectFromTemplateWithResponse(ctx, s.client.accountID, templateID, body)

--- a/go/pkg/basecamp/templates.go
+++ b/go/pkg/basecamp/templates.go
@@ -44,7 +44,7 @@ type ProjectConstruction struct {
 type CreateProjectOptions struct {
 	// StartDate is the date the new project starts on (ISO 8601, e.g. "2026-09-01").
 	// Template dates are anchored to the Sunday on or before it. Empty anchors them
-	// to the week the construction is created.
+	// to the week in which the asynchronous construction is processed.
 	StartDate string
 }
 

--- a/go/pkg/basecamp/templates_test.go
+++ b/go/pkg/basecamp/templates_test.go
@@ -288,6 +288,23 @@ func TestTemplatesService_CreateProjectStartDate(t *testing.T) {
 	}
 }
 
+func TestTemplatesService_CreateProjectMultipleOptions(t *testing.T) {
+	svc := testTemplatesServer(t, func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("expected no request, got %s %s", r.Method, r.URL.Path)
+	})
+
+	_, err := svc.CreateProject(context.Background(), 2085958507, "Marketing Campaign", "",
+		&CreateProjectOptions{StartDate: "2026-09-01"},
+		&CreateProjectOptions{StartDate: "2026-09-08"})
+	if err == nil {
+		t.Fatal("expected error for multiple options")
+	}
+	apiErr, ok := errors.AsType[*Error](err)
+	if !ok || apiErr.Code != CodeUsage {
+		t.Errorf("expected usage error, got: %v", err)
+	}
+}
+
 func TestTemplatesService_GetLibrary(t *testing.T) {
 	var receivedMethod, receivedPath string
 	svc := testTemplatesServer(t, func(w http.ResponseWriter, r *http.Request) {

--- a/go/pkg/basecamp/templates_test.go
+++ b/go/pkg/basecamp/templates_test.go
@@ -242,6 +242,52 @@ func TestTemplatesService_CreateProjectEnvelope(t *testing.T) {
 	}
 }
 
+// TestTemplatesService_CreateProjectStartDate verifies the optional start date
+// rides under the "project" envelope as start_date, and stays off the wire when
+// no options are given, so the server anchors to the week of construction.
+func TestTemplatesService_CreateProjectStartDate(t *testing.T) {
+	fixture := loadTemplatesFixture(t, "project_construction.json")
+
+	var receivedBody map[string]any
+	svc := testTemplatesServer(t, func(w http.ResponseWriter, r *http.Request) {
+		receivedBody = decodeRequestBody(t, r)
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		w.Write(fixture)
+	})
+
+	_, err := svc.CreateProject(context.Background(), 2085958507, "Marketing Campaign", "For Client: Xyz Corp Conference",
+		&CreateProjectOptions{StartDate: "2026-09-01"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	project, ok := receivedBody["project"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected params nested under \"project\" envelope, got body: %v", receivedBody)
+	}
+	if project["start_date"] != "2026-09-01" {
+		t.Errorf("expected project.start_date '2026-09-01', got %v", project["start_date"])
+	}
+	if _, flat := receivedBody["start_date"]; flat {
+		t.Error("expected no top-level \"start_date\"; params must be nested under \"project\"")
+	}
+
+	_, err = svc.CreateProject(context.Background(), 2085958507, "Marketing Campaign", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	project = receivedBody["project"].(map[string]any)
+	if _, present := project["start_date"]; present {
+		t.Errorf("expected start_date omitted when no options are given, got %v", project["start_date"])
+	}
+	if _, present := project["description"]; present {
+		t.Errorf("expected description omitted when blank, got %v", project["description"])
+	}
+}
+
 func TestTemplatesService_GetLibrary(t *testing.T) {
 	var receivedMethod, receivedPath string
 	svc := testTemplatesServer(t, func(w http.ResponseWriter, r *http.Request) {

--- a/go/pkg/generated/client.gen.go
+++ b/go/pkg/generated/client.gen.go
@@ -2468,6 +2468,13 @@ type ProjectConstruction struct {
 type ProjectConstructionAttributes struct {
 	Description *string `json:"description,omitempty"`
 	Name        string  `json:"name"`
+
+	// StartDate Date the new project starts on. Template dates are relative to the start
+	// of the template's first week, and template weeks start on a Sunday, so
+	// the project's dates are anchored to the Sunday on or before this date.
+	// Omitted, they are anchored to the week in which the construction is
+	// processed.
+	StartDate *string `json:"start_date,omitempty"`
 }
 
 // ProjectLimitErrorResponseContent The account has reached its project limit. Raised by CreateProject and by

--- a/kotlin/conformance/src/main/kotlin/com/basecamp/sdk/conformance/Main.kt
+++ b/kotlin/conformance/src/main/kotlin/com/basecamp/sdk/conformance/Main.kt
@@ -1030,6 +1030,26 @@ private suspend fun dispatchOperation(tc: TestCase, account: AccountClient): Dis
             DispatchResult(resultJson = summarizeTemplateLibraryCopy(libraryCopy))
         }
 
+        "CreateProjectFromTemplate" -> {
+            val rb = tc.requestBody
+            val construction = account.templates.createProject(
+                tc.pathParams.longParam("templateId"),
+                CreateProjectFromTemplateBody(
+                    project = buildJsonObject {
+                        put("name", rb.stringParam("name"))
+                        rb?.get("description")?.let { put("description", it) }
+                        rb?.get("start_date")?.let { put("start_date", it) }
+                    },
+                ),
+            ).jsonObject
+            DispatchResult(
+                resultJson = buildJsonObject {
+                    put("id", construction.getValue("id"))
+                    put("status", construction.getValue("status"))
+                },
+            )
+        }
+
         "GetTemplateLibraryCopy" -> {
             val libraryCopy = account.templates.getLibraryCopy(tc.pathParams.longParam("copyId"))
             DispatchResult(resultJson = summarizeTemplateLibraryCopy(libraryCopy))

--- a/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/TemplatesServiceTest.kt
+++ b/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/TemplatesServiceTest.kt
@@ -70,6 +70,41 @@ class TemplatesServiceTest {
     }
 
     @Test
+    fun createProjectSendsStartDateUnderProjectEnvelope() = runTest {
+        var capturedBody: String? = null
+
+        val client = mockClient { request ->
+            capturedBody = request.body.toByteArray().decodeToString()
+
+            respond(
+                content = """{"id": 598194962, "status": "pending"}""",
+                status = HttpStatusCode.Created,
+                headers = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString()),
+            )
+        }
+
+        val account = client.forAccount("12345")
+        account.templates.createProject(
+            templateId = 2085958507,
+            body = CreateProjectFromTemplateBody(
+                project = buildJsonObject {
+                    put("name", "Marketing Campaign")
+                    put("description", "For Client: Xyz Corp Conference")
+                    put("start_date", "2026-09-01")
+                },
+            ),
+        )
+
+        val bodyJson = json.parseToJsonElement(capturedBody!!).jsonObject
+        assertFalse(bodyJson.containsKey("start_date"))
+        val project = bodyJson["project"]!!.jsonObject
+        assertEquals("2026-09-01", project["start_date"]!!.jsonPrimitive.content)
+        assertEquals("Marketing Campaign", project["name"]!!.jsonPrimitive.content)
+
+        client.close()
+    }
+
+    @Test
     fun createLibraryCopyExposesPeopleRequiringConfirmation() = runTest {
         val client = mockClient {
             respond(

--- a/openapi.json
+++ b/openapi.json
@@ -33913,6 +33913,10 @@
           },
           "description": {
             "type": "string"
+          },
+          "start_date": {
+            "type": "string",
+            "description": "Date the new project starts on. Template dates are relative to the start\nof the template's first week, and template weeks start on a Sunday, so\nthe project's dates are anchored to the Sunday on or before this date.\nOmitted, they are anchored to the week in which the construction is\nprocessed."
           }
         },
         "required": [

--- a/python/src/basecamp/generated/types.py
+++ b/python/src/basecamp/generated/types.py
@@ -1351,6 +1351,7 @@ class ProjectConstruction(TypedDict):
 class ProjectConstructionAttributes(TypedDict):
     description: NotRequired[str]
     name: str
+    start_date: NotRequired[str]
 
 
 class ProjectLimitErrorResponseContent(TypedDict):

--- a/python/tests/services/test_templates_service.py
+++ b/python/tests/services/test_templates_service.py
@@ -43,6 +43,32 @@ class TestSyncTemplates:
         assert result["id"] == 900
 
     @respx.mock
+    def test_create_project_sends_start_date_under_project_envelope(self):
+        route = respx.post("https://3.basecampapi.com/12345/templates/2085958507/project_constructions.json").mock(
+            return_value=httpx.Response(201, json=_construction())
+        )
+
+        account = Client(access_token="test-token").for_account("12345")
+        account.templates.create_project(
+            template_id=2085958507,
+            project={
+                "name": "Marketing Campaign",
+                "description": "For Client: Xyz Corp Conference",
+                "start_date": "2026-09-01",
+            },
+        )
+
+        body = json.loads(route.calls[0].request.content)
+        assert body == {
+            "project": {
+                "name": "Marketing Campaign",
+                "description": "For Client: Xyz Corp Conference",
+                "start_date": "2026-09-01",
+            }
+        }
+        assert "start_date" not in body
+
+    @respx.mock
     def test_get_library(self):
         route = respx.get("https://3.basecampapi.com/12345/template_library.json").mock(
             return_value=httpx.Response(

--- a/ruby/lib/basecamp/generated/metadata.json
+++ b/ruby/lib/basecamp/generated/metadata.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://basecamp.com/schemas/sdk-metadata.json",
   "version": "1.0.0",
-  "generated": "2026-09-08T23:57:38Z",
+  "generated": "2026-09-10T03:48:29Z",
   "operations": {
     "GetAccount": {
       "retry": {

--- a/ruby/lib/basecamp/generated/types.rb
+++ b/ruby/lib/basecamp/generated/types.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 # Auto-generated from OpenAPI spec. Do not edit manually.
-# Generated: 2026-09-08T23:57:39Z
+# Generated: 2026-09-10T03:48:29Z
 
 require "json"
 require "time"
@@ -3391,7 +3391,7 @@ module Basecamp
     # ProjectConstructionAttributes
     class ProjectConstructionAttributes
       include TypeHelpers
-      attr_accessor :name, :description
+      attr_accessor :name, :description, :start_date
 
       # @return [Array<Symbol>]
       def self.required_fields
@@ -3401,12 +3401,14 @@ module Basecamp
       def initialize(data = {})
         @name = data["name"]
         @description = data["description"]
+        @start_date = data["start_date"]
       end
 
       def to_h
         {
           "name" => @name,
           "description" => @description,
+          "start_date" => @start_date,
         }.compact
       end
 

--- a/ruby/test/basecamp/services/templates_service_test.rb
+++ b/ruby/test/basecamp/services/templates_service_test.rb
@@ -69,6 +69,20 @@ class TemplatesServiceTest < Minitest::Test
     assert_equal "processing", result["status"]
   end
 
+  def test_create_project_with_start_date
+    response = { "id" => 598194962, "status" => "pending" }
+
+    stub_request(:post, "https://3.basecampapi.com/12345/templates/2085958507/project_constructions.json")
+      .with(body: { project: { name: "Marketing Campaign", description: "For Client: Xyz Corp Conference", start_date: "2026-09-01" } })
+      .to_return(status: 201, body: response.to_json, headers: { "Content-Type" => "application/json" })
+
+    result = @account.templates.create_project(
+      template_id: 2085958507,
+      project: { name: "Marketing Campaign", description: "For Client: Xyz Corp Conference", start_date: "2026-09-01" }
+    )
+    assert_equal "pending", result["status"]
+  end
+
   def test_get_construction
     response = { "id" => 1, "status" => "completed", "project" => { "id" => 100 } }
 

--- a/spec/basecamp.smithy
+++ b/spec/basecamp.smithy
@@ -8649,6 +8649,13 @@ structure ProjectConstructionAttributes {
   name: String
 
   description: String
+
+  /// Date the new project starts on. Template dates are relative to the start
+  /// of the template's first week, and template weeks start on a Sunday, so
+  /// the project's dates are anchored to the Sunday on or before this date.
+  /// Omitted, they are anchored to the week in which the construction is
+  /// processed.
+  start_date: ISO8601Date
 }
 
 structure CreateProjectFromTemplateOutput {

--- a/swift/Sources/Basecamp/Generated/Models/ProjectConstructionAttributes.swift
+++ b/swift/Sources/Basecamp/Generated/Models/ProjectConstructionAttributes.swift
@@ -4,9 +4,11 @@ import Foundation
 public struct ProjectConstructionAttributes: Codable, Sendable {
     public let name: String
     public var description: String?
+    public var startDate: String?
 
-    public init(name: String, description: String? = nil) {
+    public init(name: String, description: String? = nil, startDate: String? = nil) {
         self.name = name
         self.description = description
+        self.startDate = startDate
     }
 }

--- a/swift/Tests/BasecampTests/GeneratedServiceTests.swift
+++ b/swift/Tests/BasecampTests/GeneratedServiceTests.swift
@@ -95,6 +95,35 @@ final class GeneratedServiceTests: XCTestCase {
         XCTAssertEqual(project["description"] as? String, "From template")
     }
 
+    func testCreateProjectFromTemplateSendsStartDateUnderProjectEnvelope() async throws {
+        let responseJSON: [String: Any] = ["id": 598194962, "status": "pending"]
+        let responseData = try JSONSerialization.data(withJSONObject: responseJSON)
+
+        let transport = MockTransport(statusCode: 201, data: responseData)
+        let account = makeTestAccountClient(transport: transport)
+
+        let req = CreateProjectFromTemplateRequest(
+            project: ProjectConstructionAttributes(
+                name: "Marketing Campaign",
+                description: "For Client: Xyz Corp Conference",
+                startDate: "2026-09-01")
+        )
+        _ = try await account.templates.createProject(templateId: 2085958507, req: req)
+
+        let sentBody = transport.lastRequest!.request.httpBody!
+        let sentJSON = try JSONSerialization.jsonObject(with: sentBody) as! [String: Any]
+        XCTAssertNil(sentJSON["start_date"], "start_date must not appear at the top level")
+        let project = sentJSON["project"] as! [String: Any]
+        XCTAssertEqual(project["start_date"] as? String, "2026-09-01")
+        XCTAssertEqual(project["name"] as? String, "Marketing Campaign")
+
+        let bare = CreateProjectFromTemplateRequest(project: ProjectConstructionAttributes(name: "Marketing Campaign"))
+        _ = try await account.templates.createProject(templateId: 2085958507, req: bare)
+        let bareJSON = try JSONSerialization.jsonObject(with: transport.lastRequest!.request.httpBody!) as! [String: Any]
+        let bareProject = bareJSON["project"] as! [String: Any]
+        XCTAssertNil(bareProject["start_date"], "start_date must be omitted, not null, when unset")
+    }
+
     // MARK: - requestVoid path (DELETE)
 
     func testListRecentProjectsDecodesBookmarkedOnlyProjection() async throws {

--- a/typescript/src/generated/metadata.ts
+++ b/typescript/src/generated/metadata.ts
@@ -37,7 +37,7 @@ export interface MetadataOutput {
 const metadata: MetadataOutput = {
   "$schema": "https://basecamp.com/schemas/sdk-metadata.json",
   "version": "1.0.0",
-  "generated": "2026-09-08T23:57:37.921Z",
+  "generated": "2026-09-10T03:48:28.545Z",
   "operations": {
     "GetAccount": {
       "retry": {

--- a/typescript/src/generated/openapi-stripped.json
+++ b/typescript/src/generated/openapi-stripped.json
@@ -30926,6 +30926,10 @@
           },
           "description": {
             "type": "string"
+          },
+          "start_date": {
+            "type": "string",
+            "description": "Date the new project starts on. Template dates are relative to the start\nof the template's first week, and template weeks start on a Sunday, so\nthe project's dates are anchored to the Sunday on or before this date.\nOmitted, they are anchored to the week in which the construction is\nprocessed."
           }
         },
         "required": [

--- a/typescript/src/generated/schema.d.ts
+++ b/typescript/src/generated/schema.d.ts
@@ -5623,6 +5623,14 @@ export interface components {
         ProjectConstructionAttributes: {
             name: string;
             description?: string;
+            /**
+             * @description Date the new project starts on. Template dates are relative to the start
+             *     of the template's first week, and template weeks start on a Sunday, so
+             *     the project's dates are anchored to the Sunday on or before this date.
+             *     Omitted, they are anchored to the week in which the construction is
+             *     processed.
+             */
+            start_date?: string;
         };
         /**
          * @description The account has reached its project limit. Raised by CreateProject and by

--- a/typescript/tests/services/templates.test.ts
+++ b/typescript/tests/services/templates.test.ts
@@ -194,6 +194,42 @@ describe("TemplatesService", () => {
       expect(construction.status).toBe("pending");
     });
 
+    it("sends start_date under the project envelope", async () => {
+      const templateId = 2085958507;
+      let sentBody: unknown;
+
+      server.use(
+        http.post(
+          `${BASE_URL}/templates/${templateId}/project_constructions.json`,
+          async ({ request }) => {
+            sentBody = await request.json();
+            return HttpResponse.json(
+              { id: 598194962, status: "pending", url: "https://basecamp.com/constructions/598194962" },
+              { status: 201 }
+            );
+          }
+        )
+      );
+
+      await client.templates.createProject(templateId, {
+        project: {
+          name: "Marketing Campaign",
+          description: "For Client: Xyz Corp Conference",
+          start_date: "2026-09-01",
+        },
+      });
+      expect(sentBody).toEqual({
+        project: {
+          name: "Marketing Campaign",
+          description: "For Client: Xyz Corp Conference",
+          start_date: "2026-09-01",
+        },
+      });
+
+      await client.templates.createProject(templateId, { project: { name: "Marketing Campaign" } });
+      expect(sentBody).toEqual({ project: { name: "Marketing Campaign" } });
+    });
+
     // Client-side validation short-circuits before any HTTP call. No MSW handler
     // is registered here, so a leaked request fails via onUnhandledRequest: "error".
     it("rejects a missing project", async () => {


### PR DESCRIPTION
## What

`POST /templates/:id/project_constructions.json` has accepted `project[start_date]` since 2022 (bc3 `project_operations.rb#project_from_template_params`), but `ProjectConstructionAttributes` modeled only `name` and `description`, so no SDK could anchor a constructed project's template dates to a chosen week. Surfaced by [basecamp-cli#659](https://github.com/basecamp/basecamp-cli/issues/659); tracked on [this card](https://app.basecamp.com/2914079/buckets/46292715/card_tables/cards/10288896939). The bc3 doc side is [basecamp/bc3#13259](https://github.com/basecamp/bc3/pull/13259).

- `spec/basecamp.smithy`: `ProjectConstructionAttributes.start_date: ISO8601Date`, optional, with the anchoring rule in its doc comment — template dates are relative to the template's first week, weeks start on Sunday, so the project's dates land on the Sunday on or before `start_date`; omitted, they anchor to the week the construction is processed (`Template::RelativeDates#rebase`, `Template::ProjectBuilder#new_project_start_date`).
- All six SDKs regenerated (`make generate`). Five of them take the request body as a generated struct or plain map, so they pick the field up with no hand-written change. The Go wrapper's `CreateProject(ctx, templateID, name, description)` is positional, so it gains a variadic `...*CreateProjectOptions{StartDate}` in the `CreateLine`/`CreateLineOptions` idiom; the existing call shape compiles unchanged, and an empty `StartDate` is omitted from the wire rather than sent blank.
- Not a repin: the field predates the current provenance pin, so `spec/api-provenance.json` is untouched.

## Tests

- `conformance/tests/project_constructions.json` (2 cases), dispatched in all six runners — `CreateProjectFromTemplate` had no dispatch arm anywhere until now. Case 1 pins the literal wire body `{"project":{"name","description","start_date":"2026-09-01"}}` via nested `requestBody` assertions plus `requestBodyAbsent` on the top-level keys; case 2 pins that an unset `start_date` is absent, not `null`/`""`. SPEC §19 Test Categories and Appendix D carry the new fixture's rows.
- Per-SDK unit tests from each SDK's own request capture: Go (`TestTemplatesService_CreateProjectStartDate`, both the carried and the omitted shape), TypeScript, Ruby, Python, Kotlin, Swift.

## Gate

`make check-targets -k` locally on macOS: every target green including all six conformance runners (228 cases, my two executed in each) and `check-fixture-execution`, except `lint-actions`, which reports the 7 pre-existing zizmor `self-repository` lows that are unrelated to this change. `doc-constants-check` re-run after the SPEC rows.

## `breaking` label

CI's apidiff reports one incompatible change: `(*TemplatesService).CreateProject` changed from `func(context.Context, int64, string, string)` to `func(context.Context, int64, string, string, ...*CreateProjectOptions)`. Every existing call compiles unchanged; only a func value or an interface naming the old signature has to add the parameter. The label acknowledges the verdict, and MIGRATING.md carries the note under Unreleased. The other five SDKs take the attributes as a struct or map and are additive (`ProjectConstructionAttributes.StartDate` and `CreateProjectOptions` are apidiff's two compatible additions).

I'm babysitting the review loop on this PR through to convergence.

Release note: **Features** (`enhancement`).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds optional `start_date` to project construction so SDKs can anchor a template-built project's dates to a chosen week. The endpoint has accepted `project[start_date]` since 2022, but `ProjectConstructionAttributes` only modeled `name` and `description`.

- Regenerates all six SDKs; the Go wrapper takes the field via a new variadic `CreateProjectOptions` (more than one options argument is rejected), so existing `CreateProject` calls compile unchanged.
- Adds two conformance cases pinning the wire body: `start_date` under the `project` envelope when given, omitted when not.
- Template dates anchor to the Sunday on or before `start_date`; omitted, they anchor to the week the construction is processed.
- `MIGRATING.md` documents the Go signature change; code holding `CreateProject` as a func value or in an interface must add the variadic parameter.

<sup>Written for commit 9610e51f759dfdae75e2a3a621b77b7056d5a072. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-sdk/pull/856?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

