### PR TITLE
Port the seed review's four Rust fixes back from basecamp/sdk#15

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -611,15 +611,18 @@ OIDC exchange; the first real tag after step 5 is the first end-to-end test.
 1. On `main`, with a clean tree and `make check` green.
 2. Mint a crates.io API token scoped to `publish-new` and `change-owners`, with a
    one-day expiry.
-3. Publish from the workspace, reproducibly:
+3. Publish from the workspace, reproducibly, with the token from step 2 in the
+   environment (never `cargo login`: that writes it to `~/.cargo/credentials.toml`):
    ```bash
+   export CARGO_REGISTRY_TOKEN=<token from step 2>
    cd rust && SOURCE_DATE_EPOCH=$(git log -1 --format=%ct) cargo publish -p basecamp-sdk --locked
    ```
-4. Hand ownership to the team: `cargo owner --add github:basecamp:cli basecamp-sdk`.
+4. Hand ownership to the team, still under that token:
+   `cargo owner --add github:basecamp:cli basecamp-sdk`.
 5. On the crate's settings page, configure Trusted Publishing: owner `basecamp`,
    repository `basecamp-sdk`, workflow `release-rust.yml`, environment
    `release-crates`.
-6. Revoke the token from step 2.
+6. Revoke the token from step 2 and `unset CARGO_REGISTRY_TOKEN`.
 7. `make release VERSION=…` from the same SHA, so the tag and the published
    crate agree.
 

--- a/rust/basecamp-sdk/src/error.rs
+++ b/rust/basecamp-sdk/src/error.rs
@@ -219,7 +219,7 @@ impl Error {
                     .as_ref()
                     .and_then(|value| value.get("message").and_then(Value::as_str))
             })
-            .map(truncate);
+            .map(str::to_string);
         let mut message = scalar
             .clone()
             .unwrap_or_else(|| format!("Request failed (HTTP {status_code})"));
@@ -706,6 +706,24 @@ mod tests {
             assert_eq!(error.request_id(), Some("req-1"));
             assert_eq!(error.message(), format!("Request failed (HTTP {status})"));
         }
+    }
+
+    #[test]
+    fn a_composed_validation_message_is_truncated_once() {
+        // 496 ASCII bytes, a three-byte character straddling the cut, then more: cutting the
+        // scalar before composition would leave an ellipsis for the final cut to land in.
+        let scalar = format!("{}\u{20ac}bb", "a".repeat(MAX_ERROR_MESSAGE_LENGTH - 4));
+        let body = serde_json::json!({"error": scalar, "errors": {"name": ["x"]}}).to_string();
+        let error = Error::from_response(
+            StatusCode::UNPROCESSABLE_ENTITY,
+            &HeaderMap::new(),
+            body.as_bytes(),
+        );
+        assert_eq!(
+            error.message(),
+            format!("{}...", "a".repeat(MAX_ERROR_MESSAGE_LENGTH - 4))
+        );
+        assert_eq!(error.field_errors().unwrap()["name"], vec!["x".to_string()]);
     }
 
     #[test]

--- a/rust/basecamp-sdk/src/error.rs
+++ b/rust/basecamp-sdk/src/error.rs
@@ -219,7 +219,7 @@ impl Error {
                     .as_ref()
                     .and_then(|value| value.get("message").and_then(Value::as_str))
             })
-            .map(str::to_string);
+            .map(truncate);
         let mut message = scalar
             .clone()
             .unwrap_or_else(|| format!("Request failed (HTTP {status_code})"));
@@ -252,7 +252,7 @@ impl Error {
         error.inner.request_id = headers
             .get("x-request-id")
             .and_then(|value| value.to_str().ok())
-            .map(str::to_string);
+            .map(truncate);
         error.inner.field_errors = field_errors;
         error.inner.confirmation_people = confirmation_people;
         if !body.is_empty() {
@@ -706,6 +706,20 @@ mod tests {
             assert_eq!(error.request_id(), Some("req-1"));
             assert_eq!(error.message(), format!("Request failed (HTTP {status})"));
         }
+    }
+
+    #[test]
+    fn request_id_read_off_a_response_is_bounded_like_the_setter() {
+        let long = "r".repeat(MAX_ERROR_MESSAGE_LENGTH + 1);
+        let error = Error::from_response(
+            StatusCode::BAD_GATEWAY,
+            &headers(&[("x-request-id", &long)]),
+            b"",
+        );
+        let expected = Error::usage("x").with_request_id(&long);
+        assert_eq!(error.request_id(), expected.request_id());
+        assert_eq!(error.request_id().unwrap().len(), MAX_ERROR_MESSAGE_LENGTH);
+        assert!(error.request_id().unwrap().ends_with("..."));
     }
 
     #[test]

--- a/rust/basecamp-sdk/src/operation.rs
+++ b/rust/basecamp-sdk/src/operation.rs
@@ -157,7 +157,8 @@ impl Operation {
     }
 
     /// One file under a multipart form field. The field, filename and content type are
-    /// part headers, so a line break in any of them is dropped rather than written.
+    /// part headers, so a line break in any of them is dropped rather than written, and a
+    /// quote or backslash in a quoted parameter is percent-encoded rather than escaped.
     pub fn multipart(
         &mut self,
         field: &str,
@@ -207,7 +208,7 @@ impl Operation {
 }
 
 fn escape_quotes(value: &str) -> String {
-    without_line_breaks(&value.replace('"', "%22"))
+    without_line_breaks(&value.replace('\\', "%5C").replace('"', "%22"))
 }
 
 fn without_line_breaks(value: &str) -> String {
@@ -280,12 +281,12 @@ mod tests {
             Operation::for_route(&crate::generated::routes::UPDATE_ACCOUNT_LOGO, &[]);
         operation.multipart(
             "logo",
-            "a\r\nb\"c.png",
+            "a\r\nb\"c\\d.png",
             "image/png\r\n\r\nprefix",
             b"pixels",
         );
         let body = String::from_utf8(operation.body_bytes().unwrap().to_vec()).unwrap();
-        assert!(body.contains("filename=\"ab%22c.png\""), "{body}");
+        assert!(body.contains("filename=\"ab%22c%5Cd.png\""), "{body}");
         assert!(
             body.contains("Content-Type: image/pngprefix\r\n\r\npixels"),
             "{body}"

--- a/rust/basecamp-sdk/src/security.rs
+++ b/rust/basecamp-sdk/src/security.rs
@@ -61,7 +61,8 @@ pub fn redact_headers(headers: &HeaderMap) -> HeaderMap {
 /// A URL projected to its origin and path — no userinfo, query or fragment — which is all
 /// an error or a hook needs from a request that may carry a signature in its query.
 pub fn redact_url(url: &Url) -> String {
-    match (url.host_str(), url.scheme()) {
+    // `Url::host` renders an IPv6 literal with its brackets; `host_str` drops them.
+    match (url.host(), url.scheme()) {
         (Some(host), scheme) if !scheme.is_empty() => {
             let port = url
                 .port()
@@ -76,17 +77,16 @@ pub fn redact_url(url: &Url) -> String {
 /// The origin alone — `https://host:port` — or the fixed token `unparsable`.
 pub fn origin_of(raw: &str) -> String {
     match Url::parse(raw) {
-        Ok(url) if url.host_str().is_some() => {
-            let port = url
-                .port()
-                .map(|port| format!(":{port}"))
-                .unwrap_or_default();
-            format!(
-                "{}://{}{port}",
-                url.scheme(),
-                url.host_str().unwrap_or_default()
-            )
-        }
+        Ok(url) => match url.host() {
+            Some(host) => {
+                let port = url
+                    .port()
+                    .map(|port| format!(":{port}"))
+                    .unwrap_or_default();
+                format!("{}://{host}{port}", url.scheme())
+            }
+            None => "unparsable".to_string(),
+        },
         _ => "unparsable".to_string(),
     }
 }
@@ -145,5 +145,12 @@ mod tests {
             "https://storage.example.com:8443"
         );
         assert_eq!(origin_of("not a url"), "unparsable");
+    }
+
+    #[test]
+    fn ipv6_hosts_keep_their_brackets() {
+        let url = Url::parse("https://[::1]:8443/x?s=1").unwrap();
+        assert_eq!(redact_url(&url), "https://[::1]:8443/x");
+        assert_eq!(origin_of("https://[::1]:8443/x"), "https://[::1]:8443");
     }
 }


### PR DESCRIPTION
Four fixes ported back from the seed-template review of the Rust scaffold that was extracted from this repo at 9159204 ([basecamp/sdk#15](https://github.com/basecamp/sdk/pull/15), head dc5e2bc). Each was found by review there, fixed in the seed, and flagged as also present in this exemplar; this PR carries them here, one commit per fix, with the seed's regression tests where it added them and one more for the request id. A fifth commit fixes a pre-existing composition bug review found on this PR.

| Fix | Failure it prevents |
|---|---|
| **Request id read off a failure response is bounded** (`error.rs`) | `with_request_id` cuts the id to `MAX_ERROR_MESSAGE_LENGTH` (SPEC §9: the header is the server's to fill), but `from_response` stored the raw `X-Request-Id`, so an oversized header stayed attached to every error it produced. Now both paths truncate; the new test asserts the response path matches the setter and fails on the old code. |
| **Backslash in a quoted multipart parameter is percent-encoded** (`operation.rs`) | `escape_quotes` handled `"` but let `\` through, so a filename such as `C:\temp\a.txt` reached `Content-Disposition` as quoted-pair escapes: the receiver unescapes them (changing the filename), and a trailing backslash could swallow the closing quote and malform the part header. `\` is now `%5C` the way `"` is `%22`; the existing test covers `a\d.png`. |
| **IPv6 hosts keep their brackets** (`security.rs`) | `redact_url` and `origin_of` formatted `Url::host_str`, which renders an IPv6 literal without brackets, so `https://[::1]:8443/x` was projected as the invalid and ambiguous `https://::1:8443/x` in errors and hooks. Both format `Url::host` (whose `Display` keeps the brackets); new test. |
| **Bootstrap publish token goes in `CARGO_REGISTRY_TOKEN`** (`CONTRIBUTING.md`) | The first-publish runbook minted a token and never handed it to cargo, so a maintainer without prior crates.io credentials stopped at `cargo publish` with a missing-token error. Step 3 exports `CARGO_REGISTRY_TOKEN` (not `cargo login`, which persists to `~/.cargo/credentials.toml`), step 4 runs under it, step 6 unsets it with the revoke. |
| **Composed validation message is truncated once** (`error.rs`, found in review here) | The 400/422 scalar was cut to the cap before the flattened field errors were appended and the composed result was cut again, so a message over the cap with a multibyte character straddling the cut ended in `....` rather than one `...`; SPEC §6 step 4 puts the truncation after composition. The scalar now stays raw until then; new test reproduces the four periods on the old code. The seed composes the same way. |

Verified locally on 1.98.1: `make rs-check`, `make conformance-runner-tests-rust`, `make conformance-rust` (228/228).

hey-sdk and fizzy-sdk were checked for the same four and none applies there: their request id is stored unbounded on both paths with no documented bound, matching their Go siblings; hey-sdk's one multipart builder already escapes `\` and `"` as Go's `mime/multipart` does and fizzy-sdk has no multipart; neither projects a URL through `host_str`; both runbooks already name `CARGO_REGISTRY_TOKEN`.
