### PR TITLE
chore(rust): describe the crate as the official client for Basecamp

### DIFF
--- a/rust/basecamp-sdk/Cargo.toml
+++ b/rust/basecamp-sdk/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "basecamp-sdk"
 version = "0.18.0"
-description = "Official Basecamp API client, generated from the Smithy model in spec/"
+description = "Official client for Basecamp - https://basecamp.com"
 readme = "README.md"
 homepage = "https://github.com/basecamp/basecamp-sdk"
 documentation = "https://docs.rs/basecamp-sdk"


### PR DESCRIPTION
Stanko asked in Campfire that the next Rust release clean up each crate's description: the "generated from the Smithy model in ..." part isn't what crates.io readers need; it should just say "Official client for <product> - <product URL>".

Before: `Official Basecamp API client, generated from the Smithy model in spec/`
After: `Official client for Basecamp - https://basecamp.com`

Notes:
- The `description` field is hand-maintained in `rust/basecamp-sdk/Cargo.toml`; nothing generates it (the generator emits `src/generated` and the services, `scripts/bump-version.sh` only touches `version`), so this one-line edit is the change.
- The product URL matches the root README (`https://basecamp.com`).
- The crate README (which `lib.rs` includes as the crate doc) describes the Smithy model in its own prose rather than repeating the crates.io description verbatim, so it is left alone.
- No version bump.

Checked with `cargo metadata` (the new description round-trips) and `make -C rust publish-check` (`cargo publish --dry-run`) passes.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the `basecamp-sdk` crates.io description to identify the crate as the official client for Basecamp instead of describing it as generated from the Smithy model. The description is hand-maintained in `Cargo.toml`, so this one-line edit is the full change; no version bump or generator changes are needed.

<sup>Written for commit a895ad2aa2316cf6a2e6138037001ffc9e313dab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-sdk/pull/868?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

