### PR TITLE
Strip the request URL from a reqwest error before it becomes the SDK's

### DIFF
--- a/rust/basecamp-sdk/src/http/reqwest.rs
+++ b/rust/basecamp-sdk/src/http/reqwest.rs
@@ -53,7 +53,7 @@ impl ReqwestClient {
 #[async_trait]
 impl HttpClient for ReqwestClient {
     async fn send(&self, request: Request<Bytes>) -> Result<Response<Body>, Error> {
-        let request = reqwest::Request::try_from(request).map_err(Error::network)?;
+        let request = reqwest::Request::try_from(request).map_err(classify)?;
         let answered = self.http.execute(request).await.map_err(classify)?;
 
         let status = answered.status();
@@ -79,7 +79,11 @@ fn chunks(response: reqwest::Response) -> impl stream::Stream<Item = Result<Byte
     })
 }
 
+/// A transport failure as the SDK's network error, less the URL reqwest writes into its
+/// own message: the failure ends up in hints and logs, and a signed URL carries its
+/// credential in the query (SPEC §9).
 fn classify(error: reqwest::Error) -> Error {
+    let error = error.without_url();
     if error.is_timeout() {
         Error::network_timeout(error)
     } else {

--- a/rust/basecamp-sdk/tests/reqwest_client.rs
+++ b/rust/basecamp-sdk/tests/reqwest_client.rs
@@ -1,0 +1,74 @@
+//! The shipped [`ReqwestClient`] keeps a request's URL out of the error a transport failure
+//! becomes. reqwest writes the URL into its own error text, and a signed download or upload
+//! URL carries its credential in the query (SPEC §9), so neither the hint nor the source
+//! chain may show it.
+
+#![cfg(feature = "reqwest")]
+#![allow(clippy::unwrap_used, clippy::expect_used)]
+
+use std::error::Error as _;
+use std::time::Duration;
+
+use basecamp_sdk::http::{HttpClient, Request, ReqwestClient};
+use basecamp_sdk::{Error, ErrorCode};
+use bytes::Bytes;
+use tokio::net::TcpListener;
+
+const SIGNATURE: &str = "sig-4f3c2a1b-never-logged";
+
+fn client() -> ReqwestClient {
+    ReqwestClient::with_timeout(Duration::from_secs(5)).unwrap()
+}
+
+fn signed_request(port: u16) -> Request<Bytes> {
+    Request::get(format!(
+        "http://127.0.0.1:{port}/storage/blob?signature={SIGNATURE}"
+    ))
+    .body(Bytes::new())
+    .unwrap()
+}
+
+/// Every rendering a caller or a log would see: the error itself, its hint and each link
+/// of its source chain, by `Display` and by `Debug`.
+fn renderings(error: &Error) -> Vec<String> {
+    let mut seen = vec![format!("{error}"), format!("{error:?}")];
+    seen.extend(error.hint().map(str::to_owned));
+    let mut source = error.source();
+    while let Some(cause) = source {
+        seen.push(format!("{cause}"));
+        seen.push(format!("{cause:?}"));
+        source = cause.source();
+    }
+    seen
+}
+
+fn assert_signature_withheld(error: &Error) {
+    assert_eq!(error.code(), ErrorCode::Network);
+    assert!(
+        error.source().is_some(),
+        "the transport failure is chained as the cause"
+    );
+    assert!(
+        error.hint().is_some_and(|hint| !hint.is_empty()),
+        "the failure is still described"
+    );
+    for text in renderings(error) {
+        assert!(
+            !text.contains(SIGNATURE),
+            "the signed query leaked into {text:?}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn a_refused_connection_withholds_the_signed_query() {
+    let port = TcpListener::bind("127.0.0.1:0")
+        .await
+        .unwrap()
+        .local_addr()
+        .unwrap()
+        .port();
+
+    let error = client().send(signed_request(port)).await.err().unwrap();
+    assert_signature_withheld(&error);
+}


### PR DESCRIPTION
Origin: Codex's second review round on basecamp/sdk#15, fixed in the seed at basecamp/sdk@5c45cb3. The seed's `http/reqwest.rs` was extracted from this crate, so the same shape was here.

**The leak.** `reqwest::Error` writes the request URL into its own `Display` (`error sending request for url (…)`) and `Debug`. `Error::network` copies that `Display` into the hint and chains the reqwest error as the source, so a transport failure — refused connection, timeout, TLS error, reset mid-stream — against a pre-signed storage URL put the signature from the query into the SDK error's hint, `Display`, `Debug` and source chain: everywhere the error gets logged. SPEC §9 has such an error name only the origin.

`download.rs` already projects its two-hop transport failures to the origin through `Error::network_at`, so the download flow was closed at that layer. The generic `HttpClient` path was not, and that is what every other operation goes through, and what a caller using `ReqwestClient` directly gets.

**The fix.** `classify` strips the URL with `reqwest::Error::without_url()` before the error becomes the hint and source, and the `try_from` conversion goes through `classify` as well, so every reqwest error the shipped client turns into an SDK error passes one function. Three conversion sites, all in `src/http/reqwest.rs`: the `try_from` of the request, the `execute`, and the body `chunk()` stream.

**The test.** `tests/reqwest_client.rs` sends through the shipped client to a closed port on 127.0.0.1 with `?signature=…` in the URL and asserts the error is `network`, still chains its cause and still carries a hint, and that the signature appears in none of `Display`, `Debug`, the hint, or any link of the source chain by either rendering. On `main` it fails with:

```
the signed query leaked into "Network error: error sending request for url (http://127.0.0.1:54870/storage/blob?signature=sig-4f3c2a1b-never-logged)"
```

The `chunk()` path is stripped for uniformity; reqwest 0.13.5 attaches the URL only on its whole-body readers (`bytes()`, `json()`), not on `chunk()`, so no test can currently fail there.

Gates run locally: `make rs-check`, `make conformance-runner-tests-rust`.

Watching the review loop on this one through to convergence.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops `reqwest` transport failures from leaking the request URL — including the signature from a pre-signed storage URL's query — into the SDK error's hint, `Display`, `Debug`, or source chain.

- `classify` strips the URL with `without_url()` before building the SDK error; the request conversion, `execute`, and body `chunk()` stream all route through it.
- Adds a test that sends through the shipped client to a closed port with a signed query and asserts the signature appears in no rendering of the error or its causes.

<sup>Written for commit ca08cc9717ec7b0b03e8ec77ead5eca05a81ecd2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-sdk/pull/869?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

