### PR TITLE
ci(rust): save the cargo cache from main only

### DIFF
--- a/.github/workflows/release-rust.yml
+++ b/.github/workflows/release-rust.yml
@@ -51,6 +51,7 @@ jobs:
           workspaces: |
             rust
             conformance/runner/rust
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Format
         run: cargo fmt --all --check

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -926,6 +926,7 @@ jobs:
             rust
             conformance/runner/rust
           key: ${{ matrix.role }}
+          save-if: ${{ github.ref == 'refs/heads/main' }}
 
       # --- MSRV lane: the library on exactly rust-version, locked ---
       - name: Build and test the library on the MSRV (locked)


### PR DESCRIPTION
Every `Swatinem/rust-cache` step gets `save-if: ${{ github.ref == 'refs/heads/main' }}`, so pull requests and tag builds restore the cache but no longer save entries of their own.

**Why.** GitHub caps a repository's cache at 10 GB and evicts least-recently-used. This repo sits at the cap: 85 entries, of which 4.8 GB are PR-scoped `rust-stable` entries (10 × 478 MB) and 1.7 GB PR-scoped MSRV entries, against 1.5 GB for main's own two. A PR-scoped entry can only be restored by a re-run of that PR, yet each one saved pushes main's entries, the ones every PR restores from, towards eviction. Measured: `Rust stable` found no cache on 4 of its last 8 runs, including the push to main at 15:58Z, and took 341 s (main step 243 s) instead of 210 s (110 s) with a hit. Stopping PR-scoped saves removes that 131 s penalty from roughly half the stable jobs.

**What changes for a pull request.** Restore is unchanged: PRs already read main's entries and could never write to them. What goes is the `Post Cache cargo` step, about 8 s of cleanup and upload at the end of each Rust job. Tag builds in `release-rust.yml` keep restoring from main and stop saving tag-scoped entries that nothing re-reads; a `workflow_dispatch` rehearsal from main still saves.

**Risk.** None: this changes when entries are written, not what is restored. Rollback is reverting this commit.

Numbers and rationale: [build cache assessment](https://app.basecamp.com/2914079/buckets/46292715/messages/10292037410), §4.3 and §5 Option A.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops Rust CI jobs on pull requests and tags from saving their own cargo cache entries, so main's cache entries are less likely to be evicted.

Adds `save-if: ${{ github.ref == 'refs/heads/main' }}` to the `Swatinem/rust-cache` step in `test.yml` and `release-rust.yml`. PRs and tag builds still restore the cache; only the post-job save step is skipped. The repo sits at GitHub's 10 GB cache cap, and PR-scoped saves were evicting main's entries, which every PR restores from.

<sup>Written for commit f6458598c0173b66726c84b41527709a656cbd70. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-sdk/pull/870?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

