### PR TITLE
fix(swift): project the transport error before it becomes the network cause

### DIFF
--- a/swift/Sources/Basecamp/HTTP/HTTPClient.swift
+++ b/swift/Sources/Basecamp/HTTP/HTTPClient.swift
@@ -144,7 +144,7 @@ package final class HTTPClient: Sendable {
     /// default rendering of `.network(message:cause:)` prints all of it, query
     /// included. The error is rebuilt from parts this SDK chooses: the same
     /// code, so ``isCancellation(_:)`` and a caller's own `URLError` matching
-    /// classify it as before; the localized description; and the failing URL
+    /// classify it as before, and the failing URL
     /// as origin and path — never its query, userinfo or fragment. A transport
     /// that already speaks `.network` (#567) keeps its message and has its
     /// cause projected the same way, to the same depth bound
@@ -152,9 +152,13 @@ package final class HTTPClient: Sendable {
     /// diagnostic and passes through unchanged.
     static func projectedTransportError(_ error: any Error, depth: Int = 0) -> any Error {
         if let urlError = error as? URLError {
-            var userInfo: [String: Any] = [NSLocalizedDescriptionKey: urlError.localizedDescription]
-            if let failingURL = urlError.failingURL,
-               let projected = URL(string: stripQueryAndFragment(failingURL.absoluteString)) {
+            // Nothing the transport wrote survives — not even its description,
+            // which a custom Transport can build around the URL; the code is
+            // the diagnostic, and Foundation describes it on its own.
+            var userInfo: [String: Any] = [:]
+            let failingURL = urlError.failingURL?.absoluteString
+                ?? urlError.userInfo[NSURLErrorFailingURLStringErrorKey] as? String
+            if let failingURL, let projected = URL(string: stripQueryAndFragment(failingURL)) {
                 userInfo[NSURLErrorFailingURLErrorKey] = projected
                 userInfo[NSURLErrorFailingURLStringErrorKey] = projected.absoluteString
             }

--- a/swift/Sources/Basecamp/HTTP/HTTPClient.swift
+++ b/swift/Sources/Basecamp/HTTP/HTTPClient.swift
@@ -137,6 +137,36 @@ package final class HTTPClient: Sendable {
         .network(message: message, cause: projectedDownloadCause(error))
     }
 
+    /// SPEC §9 projection of an API-request transport failure, for the cause
+    /// chain, the retry hook and cancellation alike. `URLError` carries the
+    /// failing URL in its `userInfo` — `NSURLErrorFailingURLErrorKey`, its
+    /// string twin, and the session task's own description — and Swift's
+    /// default rendering of `.network(message:cause:)` prints all of it, query
+    /// included. The error is rebuilt from parts this SDK chooses: the same
+    /// code, so ``isCancellation(_:)`` and a caller's own `URLError` matching
+    /// classify it as before; the localized description; and the failing URL
+    /// as origin and path — never its query, userinfo or fragment. A transport
+    /// that already speaks `.network` (#567) keeps its message and has its
+    /// cause projected the same way, to the same depth bound
+    /// ``isCancellation(_:)`` walks. Any other error is the transport's own
+    /// diagnostic and passes through unchanged.
+    static func projectedTransportError(_ error: any Error, depth: Int = 0) -> any Error {
+        if let urlError = error as? URLError {
+            var userInfo: [String: Any] = [NSLocalizedDescriptionKey: urlError.localizedDescription]
+            if let failingURL = urlError.failingURL,
+               let projected = URL(string: stripQueryAndFragment(failingURL.absoluteString)) {
+                userInfo[NSURLErrorFailingURLErrorKey] = projected
+                userInfo[NSURLErrorFailingURLStringErrorKey] = projected.absoluteString
+            }
+            return URLError(urlError.code, userInfo: userInfo)
+        }
+        if let basecampError = error as? BasecampError, case .network(let message, let cause) = basecampError {
+            guard let cause, depth < maxCauseChainDepth else { return BasecampError.network(message: message, cause: nil) }
+            return BasecampError.network(message: message, cause: projectedTransportError(cause, depth: depth + 1))
+        }
+        return error
+    }
+
     /// SPEC §9 projection of a credential-bearing URL for rendering: the origin
     /// from a successful parse — scheme, host and any non-default port, with
     /// an IPv6 host bracketed — or the fixed token when no complete origin
@@ -339,7 +369,11 @@ package final class HTTPClient: Sendable {
             } catch {
                 // Network-level error — a raw transport failure, or a Transport
                 // that reports connectivity failure as BasecampError.network
-                // (#567). Both mean the same thing, so both retry.
+                // (#567). Both mean the same thing, so both retry. Projected
+                // once, before anything renders it (SPEC §9): the retry hook,
+                // the cause chain and a propagated cancellation all see the
+                // same URL-free shape.
+                let error = Self.projectedTransportError(error)
                 let durationMs = Int((CFAbsoluteTimeGetCurrent() - startTime) * 1000)
                 safeInvokeHooks {
                     $0.onRequestEnd(info, result: RequestResult(statusCode: 0, durationMs: durationMs))
@@ -348,9 +382,9 @@ package final class HTTPClient: Sendable {
                 if Self.isCancellation(error) {
                     // Cooperative cancellation is terminal, not a transport
                     // blip: retrying would announce and start an attempt the
-                    // caller has already abandoned. It propagates raw rather
-                    // than wrapped, and the attempt is finalized above so
-                    // start/end stay paired.
+                    // caller has already abandoned. It propagates unwrapped,
+                    // and the attempt is finalized above so start/end stay
+                    // paired.
                     directive = .fail(error)
                 } else if attempt < maxAttempts {
                     let delaySeconds = calculateDelay(

--- a/swift/Sources/Basecamp/HTTP/HTTPClient.swift
+++ b/swift/Sources/Basecamp/HTTP/HTTPClient.swift
@@ -196,13 +196,18 @@ package final class HTTPClient: Sendable {
     /// with no complete origin renders as the fixed token, never as any of
     /// its own text.
     private static func stripQueryAndFragment(_ url: String) -> String {
-        guard let components = URLComponents(string: url),
-              let scheme = components.scheme,
+        guard var components = URLComponents(string: url),
+              components.scheme != nil,
               let host = components.host, !host.isEmpty
         else { return "unparsable" }
-        let renderedHost = host.contains(":") && !host.hasPrefix("[") ? "[\(host)]" : host
-        let port = components.port.map { ":\($0)" } ?? ""
-        return "\(scheme)://\(renderedHost)\(port)\(components.percentEncodedPath)"
+        // Cleared on the components rather than re-interpolated, so a host or
+        // path with a percent-encoded delimiter keeps its encoding instead of
+        // being reparsed as a query, fragment or userinfo boundary.
+        components.user = nil
+        components.password = nil
+        components.query = nil
+        components.fragment = nil
+        return components.string ?? "unparsable"
     }
 
     /// Converts a backoff interval to nanoseconds without trapping.
@@ -448,7 +453,15 @@ package final class HTTPClient: Sendable {
         request.setValue(config.userAgent, forHTTPHeaderField: "User-Agent")
         request.setValue("application/json", forHTTPHeaderField: "Accept")
 
-        let (data, response) = try await transport.data(for: request)
+        let data: Data
+        let response: URLResponse
+        do {
+            (data, response) = try await transport.data(for: request)
+        } catch {
+            // A follow-up page's URL carries the server's query; the failure
+            // propagates as the caller has always seen it, projected (SPEC §9).
+            throw Self.projectedTransportError(error)
+        }
 
         guard let httpResponse = response as? HTTPURLResponse else {
             // Neither of these two helpers retries, so the guard can surface

--- a/swift/Tests/BasecampTests/TransportErrorProjectionTests.swift
+++ b/swift/Tests/BasecampTests/TransportErrorProjectionTests.swift
@@ -1,0 +1,121 @@
+import XCTest
+@testable import Basecamp
+
+/// A request that fails in transport must not put its URL's query into any
+/// rendering of the error (SPEC §9). `URLError` carries the failing URL in its
+/// `userInfo`, and `String(describing:)` on `.network(message:cause:)` prints
+/// it — so a signed query on the request reached the error's description,
+/// `debugDescription`, `NSError` bridge, cause chain and the retry hook.
+final class TransportErrorProjectionTests: XCTestCase {
+    private static let secret = "SECRETVALUE"
+    private static let signedURL = "http://127.0.0.1:1/blob?signature=\(secret)"
+
+    private final class RetrySpy: BasecampHooks, @unchecked Sendable {
+        private let lock = NSLock()
+        private var _errors: [any Error] = []
+        var errors: [any Error] { lock.withLock { _errors } }
+
+        func onOperationStart(_ info: OperationInfo) {}
+        func onOperationEnd(_ info: OperationInfo, result: OperationResult) {}
+        func onRequestStart(_ info: RequestInfo) {}
+        func onRequestEnd(_ info: RequestInfo, result: RequestResult) {}
+        func onRetry(_ info: RequestInfo, attempt: Int, error: any Error, delaySeconds: TimeInterval) {
+            lock.withLock { _errors.append(error) }
+        }
+    }
+
+    /// Every way a caller or a logger can render an error, walking the
+    /// `.network` cause chain and the `NSError` underlying chain.
+    private static func renderings(of error: any Error, label: String = "error") -> [(String, String)] {
+        let nsError = error as NSError
+        var out: [(String, String)] = [
+            ("\(label) describing", String(describing: error)),
+            ("\(label) reflecting", String(reflecting: error)),
+            ("\(label) localizedDescription", error.localizedDescription),
+            ("\(label) NSError.description", nsError.description),
+            ("\(label) NSError.userInfo", String(describing: nsError.userInfo)),
+        ]
+        if let basecampError = error as? BasecampError, case .network(_, let cause) = basecampError, let cause {
+            out += renderings(of: cause, label: "\(label).cause")
+        }
+        if let underlying = nsError.userInfo[NSUnderlyingErrorKey] as? NSError {
+            out += renderings(of: underlying, label: "\(label).underlying")
+        }
+        return out
+    }
+
+    private static func assertNoSecret(_ error: any Error, _ context: String, file: StaticString = #filePath, line: UInt = #line) {
+        for (label, text) in renderings(of: error) {
+            XCTAssertFalse(text.contains(secret), "\(context): the signed query leaked into \(label): \(text)", file: file, line: line)
+        }
+    }
+
+    // Dials a closed port through the shipped URLSession transport, with a
+    // two-attempt policy so the retry hook sees the failure too.
+    func testTransportFailureRendersNoSignedQuery() async throws {
+        let spy = RetrySpy()
+        let client = BasecampClient(
+            auth: BearerAuth(tokenProvider: StaticTokenProvider("token")),
+            userAgent: "test/1.0",
+            config: BasecampConfig(baseURL: "http://127.0.0.1:1", enableRetry: true),
+            hooks: spy
+        )
+        let policy = RetryConfig(maxAttempts: 2, baseDelayMs: 1, backoff: .constant, retryOn: [])
+
+        do {
+            _ = try await client.httpClient.performRequest(method: "GET", url: Self.signedURL, retryConfig: policy)
+            XCTFail("expected the dial to a closed port to fail")
+        } catch {
+            guard let basecampError = error as? BasecampError, case .network(let message, let cause) = basecampError else {
+                return XCTFail("expected .network, got \(error)")
+            }
+            XCTAssertEqual(message, "Network error")
+            let urlError = try XCTUnwrap(cause as? URLError, "the cause still classifies as a URLError")
+            XCTAssertEqual(urlError.code, .cannotConnectToHost)
+            XCTAssertEqual(urlError.failingURL?.absoluteString, "http://127.0.0.1:1/blob", "origin and path survive the projection")
+            XCTAssertTrue(String(describing: basecampError).contains("http://127.0.0.1:1/blob"))
+            Self.assertNoSecret(basecampError, "thrown error")
+        }
+
+        XCTAssertEqual(spy.errors.count, 1, "the failed first attempt announces one retry")
+        for error in spy.errors {
+            XCTAssertEqual((error as? URLError)?.code, .cannotConnectToHost, "onRetry receives the projected transport error")
+            Self.assertNoSecret(error, "onRetry error")
+        }
+    }
+
+    // A Transport that speaks .network (#567) wraps its own URLSession error;
+    // the projection reaches through it and keeps the transport's message.
+    func testTransportSpokenNetworkErrorIsProjectedThroughItsCause() throws {
+        let raw = URLError(.timedOut, userInfo: [
+            NSURLErrorFailingURLErrorKey: URL(string: Self.signedURL)!,
+            NSURLErrorFailingURLStringErrorKey: Self.signedURL,
+        ])
+        let projected = HTTPClient.projectedTransportError(BasecampError.network(message: "custom transport", cause: raw))
+
+        guard let basecampError = projected as? BasecampError, case .network(let message, let cause) = basecampError else {
+            return XCTFail("expected .network, got \(projected)")
+        }
+        XCTAssertEqual(message, "custom transport")
+        let urlError = try XCTUnwrap(cause as? URLError)
+        XCTAssertEqual(urlError.code, .timedOut)
+        XCTAssertEqual(urlError.failingURL?.absoluteString, "http://127.0.0.1:1/blob")
+        Self.assertNoSecret(projected, "projected transport error")
+    }
+
+    // URLSession reports a cancelled task as URLError(.cancelled) carrying the
+    // failing URL; the projection keeps the meaning isCancellation reads.
+    func testCancelledURLErrorKeepsItsCodeAndDropsTheQuery() {
+        let raw = URLError(.cancelled, userInfo: [NSURLErrorFailingURLStringErrorKey: Self.signedURL])
+        let projected = HTTPClient.projectedTransportError(raw)
+        XCTAssertEqual((projected as? URLError)?.code, .cancelled)
+        Self.assertNoSecret(projected, "projected cancellation")
+    }
+
+    // An error that is not a URLError is the transport's own and passes through untouched.
+    func testForeignTransportErrorPassesThrough() {
+        struct ForeignTransportError: Error, Equatable { let id: Int }
+        let raw = ForeignTransportError(id: 7)
+        XCTAssertEqual(HTTPClient.projectedTransportError(raw) as? ForeignTransportError, raw)
+    }
+}

--- a/swift/Tests/BasecampTests/TransportErrorProjectionTests.swift
+++ b/swift/Tests/BasecampTests/TransportErrorProjectionTests.swift
@@ -112,6 +112,19 @@ final class TransportErrorProjectionTests: XCTestCase {
         Self.assertNoSecret(projected, "projected cancellation")
     }
 
+    // A custom Transport can build its URLError's own description around the
+    // URL; nothing the transport wrote survives, only the code.
+    func testTransportWrittenDescriptionIsDropped() throws {
+        let raw = URLError(.timedOut, userInfo: [
+            NSLocalizedDescriptionKey: "Timed out fetching \(Self.signedURL)",
+            NSURLErrorFailingURLStringErrorKey: Self.signedURL,
+        ])
+        let projected = try XCTUnwrap(HTTPClient.projectedTransportError(raw) as? URLError)
+        XCTAssertEqual(projected.code, .timedOut)
+        XCTAssertEqual(projected.failingURL?.absoluteString, "http://127.0.0.1:1/blob")
+        Self.assertNoSecret(projected, "projected description")
+    }
+
     // An error that is not a URLError is the transport's own and passes through untouched.
     func testForeignTransportErrorPassesThrough() {
         struct ForeignTransportError: Error, Equatable { let id: Int }

--- a/swift/Tests/BasecampTests/TransportErrorProjectionTests.swift
+++ b/swift/Tests/BasecampTests/TransportErrorProjectionTests.swift
@@ -84,6 +84,30 @@ final class TransportErrorProjectionTests: XCTestCase {
         }
     }
 
+    // A follow-up page's transport failure propagates unwrapped, projected.
+    func testPaginationTransportFailureRendersNoSignedQuery() async throws {
+        let client = BasecampClient(
+            auth: BearerAuth(tokenProvider: StaticTokenProvider("token")),
+            userAgent: "test/1.0",
+            config: BasecampConfig(baseURL: "http://127.0.0.1:1", enableRetry: false)
+        )
+        do {
+            _ = try await client.httpClient.fetchPage(url: Self.signedURL)
+            XCTFail("expected the dial to a closed port to fail")
+        } catch {
+            let urlError = try XCTUnwrap(error as? URLError, "the failure keeps its type")
+            XCTAssertEqual(urlError.failingURL?.absoluteString, "http://127.0.0.1:1/blob")
+            Self.assertNoSecret(error, "fetchPage error")
+        }
+    }
+
+    // A percent-encoded delimiter in the host stays encoded, never reparsed.
+    func testProjectionKeepsEncodedHostBoundaries() throws {
+        let raw = URLError(.timedOut, userInfo: [NSURLErrorFailingURLStringErrorKey: "https://foo%3Fbar/path?secret=SECRETVALUE"])
+        let projected = try XCTUnwrap(HTTPClient.projectedTransportError(raw) as? URLError)
+        XCTAssertEqual(projected.failingURL?.absoluteString, "https://foo%3Fbar/path")
+    }
+
     // A Transport that speaks .network (#567) wraps its own URLSession error;
     // the projection reaches through it and keeps the transport's message.
     func testTransportSpokenNetworkErrorIsProjectedThroughItsCause() throws {


### PR DESCRIPTION
The Swift side of [#869](https://github.com/basecamp/basecamp-sdk/pull/869), which strips the URL from the Rust SDK's reqwest errors; the same audit found nothing to fix in TypeScript, Ruby or Python (undici, Net::HTTP and httpx render no URL in their transport errors, and the download flow's projection from #837 already covers the one place a signed URL enters those paths).

**The leak.** `URLSession` reports every transport failure as a `URLError` whose `userInfo` carries the failing URL — `NSURLErrorFailingURLErrorKey`, its string twin, and the session task's own description, which prints the request line — and Swift's default rendering of `.network(message:cause:)` prints the whole of it, query included. So a refused connection, timeout or TLS failure on a request whose query is signed put the signature into `String(describing:)`, `String(reflecting:)`, `localizedDescription`'s `NSError` bridge and its `userInfo`, the cause chain, and the `onRetry` hook's `error` argument: everywhere the error gets logged. `performRequest` is the generic path every operation goes through; the download flow was already projected at its own layer (`projectedDownloadCause`, #837), so this closes the layer beneath it.

**The fix.** One helper, `HTTPClient.projectedTransportError`, beside the download projection. A `URLError` is rebuilt from parts this SDK chooses: the same code, so `isCancellation` and a caller's own `URLError` matching classify it as before; the localized description; and the failing URL projected through the existing `stripQueryAndFragment` to origin and path — never its query, userinfo or fragment (SPEC §9's "projection, not redaction"). A transport that already speaks `.network` (#567) keeps its message and has its cause projected the same way, to the same depth bound `isCancellation` walks. Any other error is the transport's own diagnostic and passes through unchanged. The one site projects once, at the top of the transport catch in `performRequest`, so the retry hook, the terminal `.network` cause and a propagated `URLError(.cancelled)` all see the same URL-free shape. `fetchPage` and the magic-link paths are untouched: they hand the raw transport error to the caller without constructing an SDK error, on an API-origin URL whose query is pagination.

**The test.** `TransportErrorProjectionTests` dials `127.0.0.1:1` through the shipped transport with `?signature=SECRETVALUE` under a two-attempt policy and asserts `SECRETVALUE` is absent from `String(describing:)`, `String(reflecting:)`, `localizedDescription`, the `NSError` description and `userInfo`, every link of the `.network` cause chain and the `NSUnderlyingError` chain, and the `onRetry` error; that the cause is still a `URLError(.cannotConnectToHost)` whose `failingURL` is `http://127.0.0.1:1/blob`; and that the rendering keeps the origin and path. Three unit tests cover the transport-spoken `.network` wrapper, a cancelled `URLError` keeping its code, and a foreign error passing through by identity. On `main` the end-to-end test fails with:

```
the signed query leaked into error reflecting: Basecamp.BasecampError.network(message: "Network error", cause: Optional(Error Domain=NSURLErrorDomain Code=-1004 "Could not connect to the server." UserInfo={… _NSURLErrorFailingURLSessionTaskErrorKey=LocalDataTask <…> {{ GET http://127.0.0.1:1/blob?signature=SECRETVALUE }} …
```

Gates run locally: `make -C swift check` (473 tests), `make conformance-swift`.

Watching the review loop on this one through to convergence.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops signed query strings from leaking into Swift transport error renderings. `URLError` carries the failing URL in its `userInfo`, and the default `.network(message:cause:)` rendering printed it with the query, so refused connections or timeouts on signed requests exposed the signature in logs, the retry hook's error, and the `NSError` bridge.

**Bug Fixes**
- Rebuilds transport errors from the code and the URL with the query stripped — clearing components on `URLComponents` so percent-encoded delimiters keep their encoding — dropping everything else the transport wrote, before anything renders them.
- Applies the projection in `performRequest`'s transport catch and in `fetchPage`, so retry hooks, cause chains, pagination failures, and propagated cancellations all see the same URL-free shape.
- Leaves errors that aren't `URLError` or transport-spoken `.network` unchanged.

<sup>Written for commit 6be1c50caaa2b213b8b2b53a7bd53a4dd49dc82e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-sdk/pull/871?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

