### PR TITLE
fix(kotlin): project the transport error before it becomes the network message

### DIFF
--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/BasecampClient.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/BasecampClient.kt
@@ -183,7 +183,12 @@ class BasecampClient internal constructor(
         config = config,
         hooks = hooks,
         json = json,
+        requestTimeoutMillis = if (externalHttpClient == null) installedTimeoutMillis else null,
     )
+
+    /** The HttpTimeout budget [configureClient] installs, if any. */
+    private val installedTimeoutMillis: Long?
+        get() = config.timeout.takeIf { it.isFinite() }?.inWholeMilliseconds
 
     private fun HttpClientConfig<*>.configureClient() {
         expectSuccess = false

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/Download.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/Download.kt
@@ -288,7 +288,7 @@ private suspend fun AccountClient.downloadHop1(
     // Hooks render this flow's URL as origin+path only (SPEC §9): the
     // caller's URL can smuggle a signed query through the rewrite into hop 1.
     // The wire request keeps the query; only the rendering is projected.
-    val hookUrl = hookDisplayUrl(url)
+    val hookUrl = displayUrl(url)
     var attempt = 1
     while (true) {
         val requestInfo = RequestInfo(method = "GET", url = hookUrl, attempt = attempt)
@@ -377,27 +377,6 @@ private suspend fun AccountClient.downloadHop1(
     }
 }
 
-/**
- * Renders a download URL for hooks: origin and path only — no userinfo (a
- * configured base URL can carry one), no query (where a signed credential
- * rides), no fragment (SPEC §9). Rebuilt from a parse; a URL with no complete
- * origin renders as the fixed token, never as any of its own text.
- */
-private fun hookDisplayUrl(url: String): String {
-    val parsed = try {
-        Url(url)
-    } catch (_: Exception) {
-        null
-    }
-    if (parsed == null || parsed.host.isEmpty()) return "unparsable"
-    val host = if (parsed.host.contains(':') && !parsed.host.startsWith("[")) "[${parsed.host}]" else parsed.host
-    val port = if (parsed.specifiedPort != 0 && parsed.specifiedPort != parsed.protocol.defaultPort) {
-        ":${parsed.specifiedPort}"
-    } else {
-        ""
-    }
-    return "${parsed.protocol.name}://$host$port${parsed.encodedPath}"
-}
 
 /**
  * Rewrites a URL's origin (scheme + host + port) to match the base URL,

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/TransportErrors.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/TransportErrors.kt
@@ -1,0 +1,81 @@
+package com.basecamp.sdk
+
+import io.ktor.client.network.sockets.ConnectTimeoutException
+import io.ktor.client.network.sockets.SocketTimeoutException
+import io.ktor.client.plugins.HttpRequestTimeoutException
+import io.ktor.http.Url
+
+/**
+ * SPEC §9 projection of a transport failure before it becomes a
+ * [BasecampException] or reaches a hook.
+ *
+ * Ktor's timeout exceptions render the request URL in their message —
+ * `Request timeout has expired [url=…, request_timeout=… ms]` — so a timeout
+ * on a request whose query is signed put the signature into the SDK error's
+ * message, `toString()`, stack trace and cause chain, and into
+ * `RequestResult.error`. Each is rebuilt from parts this SDK chooses: the same
+ * class, so a caller (and the device flow's own timeout classification) still
+ * recognises it, and the URL the SDK issued — a redirect's target is the
+ * transport's business and is not rendered — projected to origin and path
+ * when it sits on [trustedOrigin] without userinfo, and to the origin alone
+ * anywhere else, since a storage service can sign the path as readily as the
+ * query. Every other exception is the transport's own diagnostic (a JVM
+ * socket failure names host and port at most) and passes through unchanged,
+ * cause chain included.
+ */
+internal fun redactTransportError(
+    e: Throwable,
+    url: String,
+    trustedOrigin: String? = null,
+    timeoutMillis: Long? = null,
+): Throwable {
+    val shown = if (trustedOrigin != null && isSameOrigin(url, trustedOrigin) && !hasUserinfo(url)) {
+        displayUrl(url)
+    } else {
+        displayOrigin(url)
+    }
+    return when (e) {
+        is HttpRequestTimeoutException -> HttpRequestTimeoutException(shown, timeoutMillis)
+        is ConnectTimeoutException -> ConnectTimeoutException("Connect timeout has expired [url=$shown]")
+        is SocketTimeoutException -> SocketTimeoutException("Socket timeout has expired [url=$shown]")
+        else -> e
+    }
+}
+
+/**
+ * Renders a URL for hooks and errors: origin and path only — no userinfo (a
+ * configured base URL can carry one), no query (where a signed credential
+ * rides), no fragment (SPEC §9). Rebuilt from a parse; a URL with no complete
+ * origin renders as the fixed token, never as any of its own text.
+ */
+internal fun displayUrl(url: String): String {
+    val parsed = parseForDisplay(url) ?: return "unparsable"
+    return "${displayOrigin(parsed)}${parsed.encodedPath}"
+}
+
+/** Renders a URL as its origin alone: scheme, host and any non-default port (SPEC §9). */
+internal fun displayOrigin(url: String): String {
+    val parsed = parseForDisplay(url) ?: return "unparsable"
+    return displayOrigin(parsed)
+}
+
+private fun displayOrigin(parsed: Url): String {
+    val host = if (parsed.host.contains(':') && !parsed.host.startsWith("[")) "[${parsed.host}]" else parsed.host
+    val port = if (parsed.specifiedPort != 0 && parsed.specifiedPort != parsed.protocol.defaultPort) {
+        ":${parsed.specifiedPort}"
+    } else {
+        ""
+    }
+    return "${parsed.protocol.name}://$host$port"
+}
+
+private fun parseForDisplay(url: String): Url? {
+    val parsed = try {
+        Url(url)
+    } catch (_: Exception) {
+        return null
+    }
+    return parsed.takeIf { it.host.isNotEmpty() }
+}
+
+private fun hasUserinfo(url: String): Boolean = parseForDisplay(url)?.let { it.user != null || it.password != null } ?: true

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/TransportErrors.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/TransportErrors.kt
@@ -36,8 +36,10 @@ internal fun redactTransportError(
     }
     return when (e) {
         is HttpRequestTimeoutException -> HttpRequestTimeoutException(shown, timeoutMillis)
-        is ConnectTimeoutException -> ConnectTimeoutException("Connect timeout has expired [url=$shown]")
-        is SocketTimeoutException -> SocketTimeoutException("Socket timeout has expired [url=$shown]")
+        is ConnectTimeoutException ->
+            ConnectTimeoutException("Connect timeout has expired [url=$shown, connect_timeout=${timeoutMillis ?: "unknown"} ms]")
+        is SocketTimeoutException ->
+            SocketTimeoutException("Socket timeout has expired [url=$shown, socket_timeout=${timeoutMillis ?: "unknown"} ms]")
         else -> e
     }
 }

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/TransportErrors.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/TransportErrors.kt
@@ -21,13 +21,17 @@ import io.ktor.http.Url
  * anywhere else, since a storage service can sign the path as readily as the
  * query. Every other exception is the transport's own diagnostic (a JVM
  * socket failure names host and port at most) and passes through unchanged,
- * cause chain included.
+ * cause chain included. A rebuilt message carries only a budget the caller
+ * knows it installed — the request budget for the request timeout, the
+ * connect/socket budget for the other two, `unknown` otherwise — never the
+ * number in the transport's text.
  */
 internal fun redactTransportError(
     e: Throwable,
     url: String,
     trustedOrigin: String? = null,
-    timeoutMillis: Long? = null,
+    requestTimeoutMillis: Long? = null,
+    socketTimeoutMillis: Long? = null,
 ): Throwable {
     val shown = if (trustedOrigin != null && isSameOrigin(url, trustedOrigin) && !hasUserinfo(url)) {
         displayUrl(url)
@@ -35,11 +39,11 @@ internal fun redactTransportError(
         displayOrigin(url)
     }
     return when (e) {
-        is HttpRequestTimeoutException -> HttpRequestTimeoutException(shown, timeoutMillis)
+        is HttpRequestTimeoutException -> HttpRequestTimeoutException(shown, requestTimeoutMillis)
         is ConnectTimeoutException ->
-            ConnectTimeoutException("Connect timeout has expired [url=$shown, connect_timeout=${timeoutMillis ?: "unknown"} ms]")
+            ConnectTimeoutException("Connect timeout has expired [url=$shown, connect_timeout=${socketTimeoutMillis ?: "unknown"} ms]")
         is SocketTimeoutException ->
-            SocketTimeoutException("Socket timeout has expired [url=$shown, socket_timeout=${timeoutMillis ?: "unknown"} ms]")
+            SocketTimeoutException("Socket timeout has expired [url=$shown, socket_timeout=${socketTimeoutMillis ?: "unknown"} ms]")
         else -> e
     }
 }

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/http/BasecampHttpClient.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/http/BasecampHttpClient.kt
@@ -151,13 +151,16 @@ internal class BasecampHttpClient(
             ))
             throw e
         } catch (e: Exception) {
+            // SPEC §9: projected once, before the request-end hook, so hooks
+            // and the caller see the same URL-free shape.
+            val projected = redactTransportError(e, url, config.baseUrl, requestTimeoutMillis)
             val duration = currentTimeMillis() - startTime
             hooks.safeOnRequestEnd(info, RequestResult(
                 statusCode = 0,
                 duration = duration.millisToDuration(),
-                error = e,
+                error = projected,
             ))
-            AttemptOutcome.NetworkFailure(e)
+            AttemptOutcome.NetworkFailure(projected)
         }
 
         val response: HttpResponse = when (outcome) {
@@ -286,15 +289,17 @@ internal class BasecampHttpClient(
             ))
             throw e
         } catch (e: Exception) {
+            // SPEC §9: same projection as the retrying path.
+            val projected = redactTransportError(e, url, config.baseUrl, requestTimeoutMillis)
             val duration = currentTimeMillis() - startTime
             hooks.safeOnRequestEnd(info, RequestResult(
                 statusCode = 0,
                 duration = duration.millisToDuration(),
-                error = e,
+                error = projected,
             ))
             throw BasecampException.Network(
-                message = "Network error: ${e.message}",
-                cause = e,
+                message = "Network error: ${projected.message}",
+                cause = projected,
             )
         }
 
@@ -313,6 +318,10 @@ internal class BasecampHttpClient(
      * Localhost is carved out for dev/test. Mirrors the same-origin guard used
      * for pagination Link headers.
      */
+    /** The per-attempt budget HttpTimeout enforces, rendered into a projected timeout. */
+    private val requestTimeoutMillis: Long? =
+        config.timeout.takeIf { it.isFinite() }?.inWholeMilliseconds
+
     private fun requireSameOrigin(url: String) {
         if (!isLocalhost(url) && !isSameOrigin(url, config.baseUrl)) {
             throw BasecampException.Usage(
@@ -385,7 +394,7 @@ internal class BasecampHttpClient(
  */
 private sealed interface AttemptOutcome {
     class Completed(val response: HttpResponse) : AttemptOutcome
-    class NetworkFailure(val cause: Exception) : AttemptOutcome
+    class NetworkFailure(val cause: Throwable) : AttemptOutcome
 }
 
 /**

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/http/BasecampHttpClient.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/http/BasecampHttpClient.kt
@@ -24,6 +24,12 @@ internal class BasecampHttpClient(
     private val config: BasecampConfig,
     private val hooks: BasecampHooks,
     internal val json: Json,
+    /**
+     * The per-attempt budget the SDK's own HttpTimeout enforces, rendered
+     * beside a projected timeout; null when the caller supplied the
+     * [HttpClient], whose budget the SDK does not know.
+     */
+    private val requestTimeoutMillis: Long? = null,
 ) {
     /**
      * Executes an HTTP request with authentication, returning the raw [HttpResponse].
@@ -318,10 +324,6 @@ internal class BasecampHttpClient(
      * Localhost is carved out for dev/test. Mirrors the same-origin guard used
      * for pagination Link headers.
      */
-    /** The per-attempt budget HttpTimeout enforces, rendered into a projected timeout. */
-    private val requestTimeoutMillis: Long? =
-        config.timeout.takeIf { it.isFinite() }?.inWholeMilliseconds
-
     private fun requireSameOrigin(url: String) {
         if (!isLocalhost(url) && !isSameOrigin(url, config.baseUrl)) {
             throw BasecampException.Usage(

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/http/BasecampHttpClient.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/http/BasecampHttpClient.kt
@@ -25,9 +25,9 @@ internal class BasecampHttpClient(
     private val hooks: BasecampHooks,
     internal val json: Json,
     /**
-     * The per-attempt budget the SDK's own HttpTimeout enforces, rendered
-     * beside a projected timeout; null when the caller supplied the
-     * [HttpClient], whose budget the SDK does not know.
+     * The budget the SDK's own HttpTimeout enforces — request, connect and
+     * socket alike — rendered beside a projected timeout; null when the
+     * caller supplied the [HttpClient], whose budgets the SDK does not know.
      */
     private val requestTimeoutMillis: Long? = null,
 ) {
@@ -159,7 +159,7 @@ internal class BasecampHttpClient(
         } catch (e: Exception) {
             // SPEC §9: projected once, before the request-end hook, so hooks
             // and the caller see the same URL-free shape.
-            val projected = redactTransportError(e, url, config.baseUrl, requestTimeoutMillis)
+            val projected = redactTransportError(e, url, config.baseUrl, requestTimeoutMillis, requestTimeoutMillis)
             val duration = currentTimeMillis() - startTime
             hooks.safeOnRequestEnd(info, RequestResult(
                 statusCode = 0,
@@ -296,7 +296,7 @@ internal class BasecampHttpClient(
             throw e
         } catch (e: Exception) {
             // SPEC §9: same projection as the retrying path.
-            val projected = redactTransportError(e, url, config.baseUrl, requestTimeoutMillis)
+            val projected = redactTransportError(e, url, config.baseUrl, requestTimeoutMillis, requestTimeoutMillis)
             val duration = currentTimeMillis() - startTime
             hooks.safeOnRequestEnd(info, RequestResult(
                 statusCode = 0,

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/oauth/Device.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/oauth/Device.kt
@@ -258,7 +258,7 @@ suspend fun requestDeviceAuthorization(
     } catch (e: BasecampException) {
         throw e
     } catch (e: Throwable) {
-        val projected = redactTransportError(e, deviceAuthorizationEndpoint, timeoutMillis = DEVICE_REQUEST_TIMEOUT_MS)
+        val projected = redactTransportError(e, deviceAuthorizationEndpoint, requestTimeoutMillis = DEVICE_REQUEST_TIMEOUT_MS)
         throw BasecampException.DeviceFlow(
             BasecampException.DEVICE_TRANSPORT,
             "Device authorization request failed: ${projected.message ?: projected::class.simpleName}",
@@ -418,7 +418,7 @@ suspend fun pollDeviceToken(
                     continue
                 }
                 // Any other transport failure ends the flow.
-                val projected = redactTransportError(e, tokenEndpoint, timeoutMillis = pollTimeoutMillis)
+                val projected = redactTransportError(e, tokenEndpoint, requestTimeoutMillis = pollTimeoutMillis)
                 throw BasecampException.DeviceFlow(
                     BasecampException.DEVICE_TRANSPORT,
                     "Device token poll failed: ${projected.message ?: projected::class.simpleName}",

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/oauth/Device.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/oauth/Device.kt
@@ -258,7 +258,7 @@ suspend fun requestDeviceAuthorization(
     } catch (e: BasecampException) {
         throw e
     } catch (e: Throwable) {
-        val projected = redactTransportError(e, deviceAuthorizationEndpoint)
+        val projected = redactTransportError(e, deviceAuthorizationEndpoint, timeoutMillis = DEVICE_REQUEST_TIMEOUT_MS)
         throw BasecampException.DeviceFlow(
             BasecampException.DEVICE_TRANSPORT,
             "Device authorization request failed: ${projected.message ?: projected::class.simpleName}",
@@ -399,17 +399,13 @@ suspend fun pollDeviceToken(
                 throw BasecampException.DeviceFlow(BasecampException.DEVICE_EXPIRED)
             }
 
+            // Bound the request by the REMAINING code lifetime as well as the
+            // per-request timeout: near expiry, a stalled token POST must not
+            // hold the flow past the monotonic deadline for the full request
+            // budget.
+            val pollTimeoutMillis = minOf(DEVICE_REQUEST_TIMEOUT_MS, postRemaining.inWholeMilliseconds.coerceAtLeast(1))
             val result = try {
-                // Bound the request by the REMAINING code lifetime as well as
-                // the per-request timeout: near expiry, a stalled token POST
-                // must not hold the flow past the monotonic deadline for the
-                // full request budget.
-                postDeviceTokenPoll(
-                    httpClient,
-                    tokenEndpoint,
-                    params,
-                    minOf(DEVICE_REQUEST_TIMEOUT_MS, postRemaining.inWholeMilliseconds.coerceAtLeast(1)),
-                )
+                postDeviceTokenPoll(httpClient, tokenEndpoint, params, pollTimeoutMillis)
             } catch (e: CancellationException) {
                 // Cooperative coroutine cancellation — propagate, never wrap.
                 throw e
@@ -422,7 +418,7 @@ suspend fun pollDeviceToken(
                     continue
                 }
                 // Any other transport failure ends the flow.
-                val projected = redactTransportError(e, tokenEndpoint)
+                val projected = redactTransportError(e, tokenEndpoint, timeoutMillis = pollTimeoutMillis)
                 throw BasecampException.DeviceFlow(
                     BasecampException.DEVICE_TRANSPORT,
                     "Device token poll failed: ${projected.message ?: projected::class.simpleName}",

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/oauth/Device.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/oauth/Device.kt
@@ -3,6 +3,7 @@ package com.basecamp.sdk.oauth
 import com.basecamp.sdk.BasecampException
 import com.basecamp.sdk.http.currentTimeMillis
 import com.basecamp.sdk.requireSecureEndpoint
+import com.basecamp.sdk.redactTransportError
 import io.ktor.client.HttpClient
 import io.ktor.client.plugins.HttpTimeout
 import io.ktor.client.plugins.timeout
@@ -257,10 +258,11 @@ suspend fun requestDeviceAuthorization(
     } catch (e: BasecampException) {
         throw e
     } catch (e: Throwable) {
+        val projected = redactTransportError(e, deviceAuthorizationEndpoint)
         throw BasecampException.DeviceFlow(
             BasecampException.DEVICE_TRANSPORT,
-            "Device authorization request failed: ${e.message ?: e::class.simpleName}",
-            cause = e,
+            "Device authorization request failed: ${projected.message ?: projected::class.simpleName}",
+            cause = projected,
         )
     } finally {
         httpClient.close()
@@ -420,10 +422,11 @@ suspend fun pollDeviceToken(
                     continue
                 }
                 // Any other transport failure ends the flow.
+                val projected = redactTransportError(e, tokenEndpoint)
                 throw BasecampException.DeviceFlow(
                     BasecampException.DEVICE_TRANSPORT,
-                    "Device token poll failed: ${e.message ?: e::class.simpleName}",
-                    cause = e,
+                    "Device token poll failed: ${projected.message ?: projected::class.simpleName}",
+                    cause = projected,
                 )
             }
 

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/oauth/Discovery.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/oauth/Discovery.kt
@@ -1,6 +1,7 @@
 package com.basecamp.sdk.oauth
 
 import com.basecamp.sdk.BasecampException
+import com.basecamp.sdk.redactTransportError
 import com.basecamp.sdk.isSameOrigin
 import com.basecamp.sdk.requireOriginRoot
 import io.ktor.client.HttpClient
@@ -502,10 +503,11 @@ private suspend fun fetchDiscoveryDocument(url: String, baseClient: HttpClient?)
     } catch (e: BasecampException) {
         throw e
     } catch (e: Throwable) {
-        // Transport failure / timeout.
+        // Transport failure / timeout, projected first (SPEC §9).
+        val projected = redactTransportError(e, url, timeoutMillis = DISCOVERY_TIMEOUT_MS)
         throw BasecampException.Network(
-            "OAuth discovery failed: ${e.message ?: e::class.simpleName}",
-            cause = e,
+            "OAuth discovery failed: ${projected.message ?: projected::class.simpleName}",
+            cause = projected,
         )
     } finally {
         httpClient.close()

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/oauth/Discovery.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/oauth/Discovery.kt
@@ -504,7 +504,7 @@ private suspend fun fetchDiscoveryDocument(url: String, baseClient: HttpClient?)
         throw e
     } catch (e: Throwable) {
         // Transport failure / timeout, projected first (SPEC §9).
-        val projected = redactTransportError(e, url, timeoutMillis = DISCOVERY_TIMEOUT_MS)
+        val projected = redactTransportError(e, url, requestTimeoutMillis = DISCOVERY_TIMEOUT_MS)
         throw BasecampException.Network(
             "OAuth discovery failed: ${projected.message ?: projected::class.simpleName}",
             cause = projected,

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/oauth/Exchange.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/oauth/Exchange.kt
@@ -11,6 +11,7 @@ import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.Json
 import com.basecamp.sdk.BasecampException
 import com.basecamp.sdk.requireSecureEndpoint
+import com.basecamp.sdk.redactTransportError
 import com.basecamp.sdk.http.currentTimeMillis
 
 /**
@@ -307,7 +308,7 @@ private suspend fun postTokenRequest(
         // CancellationException, so left alone it would masquerade as a
         // cooperative cancellation — to the retryable network fault the other
         // SDKs raise here ("Token request timed out", TS/Python/Ruby).
-        throw BasecampException.Network("Token request timed out", cause = e)
+        throw BasecampException.Network("Token request timed out", cause = redactTransportError(e, endpoint, timeoutMillis = TOKEN_REQUEST_TIMEOUT_MS))
     } finally {
         // Always ours: hardenedTokenClient built it, an injected client only
         // lent its engine (which close() leaves running).

--- a/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/oauth/Exchange.kt
+++ b/kotlin/sdk/src/commonMain/kotlin/com/basecamp/sdk/oauth/Exchange.kt
@@ -308,7 +308,7 @@ private suspend fun postTokenRequest(
         // CancellationException, so left alone it would masquerade as a
         // cooperative cancellation — to the retryable network fault the other
         // SDKs raise here ("Token request timed out", TS/Python/Ruby).
-        throw BasecampException.Network("Token request timed out", cause = redactTransportError(e, endpoint, timeoutMillis = TOKEN_REQUEST_TIMEOUT_MS))
+        throw BasecampException.Network("Token request timed out", cause = redactTransportError(e, endpoint, requestTimeoutMillis = TOKEN_REQUEST_TIMEOUT_MS))
     } finally {
         // Always ours: hardenedTokenClient built it, an injected client only
         // lent its engine (which close() leaves running).

--- a/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/TransportErrorProjectionTest.kt
+++ b/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/TransportErrorProjectionTest.kt
@@ -1,0 +1,134 @@
+package com.basecamp.sdk
+
+import io.ktor.client.engine.mock.*
+import io.ktor.client.network.sockets.ConnectTimeoutException
+import io.ktor.client.network.sockets.SocketTimeoutException
+import io.ktor.client.plugins.HttpRequestTimeoutException
+import io.ktor.http.*
+import kotlinx.coroutines.test.runTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+/**
+ * A request that fails in transport must not put its URL's query into any
+ * rendering of the error (SPEC §9). Ktor's timeout exceptions render the
+ * request URL in their message, so a signed query on the request reached the
+ * SDK error's message, `toString()`, stack trace, cause chain and the
+ * request-end hook's `RequestResult.error`.
+ */
+class TransportErrorProjectionTest {
+    private val secret = "SECRETVALUE"
+    private val signed = "http://localhost:3000/12345/blob?signature=$secret"
+
+    private class EndSpy : BasecampHooks {
+        val errors = mutableListOf<Throwable?>()
+        override fun onRequestEnd(info: RequestInfo, result: RequestResult) { errors += result.error }
+    }
+
+    private fun renderings(e: Throwable?, label: String = "error", depth: Int = 0): List<Pair<String, String>> {
+        if (e == null || depth > 8) return emptyList()
+        val own = listOf(
+            "$label.message" to (e.message ?: ""),
+            "$label.toString" to e.toString(),
+            "$label.stackTrace" to e.stackTraceToString(),
+            "$label.hint" to ((e as? BasecampException)?.hint ?: ""),
+        )
+        return own + renderings(e.cause, "$label.cause", depth + 1)
+    }
+
+    private fun assertNoSecret(e: Throwable?, context: String) {
+        for ((label, text) in renderings(e)) {
+            assertFalse(text.contains(secret), "$context: the signed query leaked into $label: $text")
+        }
+    }
+
+    private fun clientThrowing(spy: EndSpy, failure: (MockRequestHandleScope, io.ktor.client.request.HttpRequestData) -> Throwable) =
+        testBasecampClient {
+            accessToken("test-token")
+            baseUrl = "http://localhost:3000"
+            enableRetry = false
+            hooks = spy
+            engine = MockEngine { request -> throw failure(this, request) }
+        }
+
+    @Test
+    fun requestTimeoutRendersNoSignedQuery() = runTest {
+        val spy = EndSpy()
+        // The exception the HttpTimeout plugin throws, built from the request it timed out.
+        val client = clientThrowing(spy) { _, request -> HttpRequestTimeoutException(request) }
+
+        val e = assertFailsWith<BasecampException.Network> {
+            client.forAccount("12345").httpClient.requestWithRetry(HttpMethod.Get, signed)
+        }
+
+        assertIs<HttpRequestTimeoutException>(e.cause, "the cause still classifies as the timeout")
+        assertTrue(e.message!!.startsWith("Network error: Request timeout has expired [url=http://localhost:3000/12345/blob,"), e.message)
+        assertNoSecret(e, "thrown error")
+        assertEquals(1, spy.errors.size)
+        assertIs<HttpRequestTimeoutException>(spy.errors.single(), "the request-end hook sees the projected error")
+        assertNoSecret(spy.errors.single(), "RequestResult.error")
+        client.close()
+    }
+
+    @Test
+    fun connectAndSocketTimeoutsRenderNoSignedQuery() = runTest {
+        val failures: List<(String) -> Throwable> = listOf(
+            { url -> ConnectTimeoutException("Connect timeout has expired [url=$url, connect_timeout=1 ms]") },
+            { url -> SocketTimeoutException("Socket timeout has expired [url=$url, socket_timeout=1 ms]") },
+        )
+        for (failure in failures) {
+            val spy = EndSpy()
+            val client = clientThrowing(spy) { _, request -> failure(request.url.toString()) }
+            val e = assertFailsWith<BasecampException.Network> {
+                client.forAccount("12345").httpClient.requestWithRetry(HttpMethod.Get, signed)
+            }
+            assertTrue(e.message!!.contains("[url=http://localhost:3000/12345/blob]"), e.message)
+            assertNoSecret(e, "thrown error")
+            assertNoSecret(spy.errors.single(), "RequestResult.error")
+            client.close()
+        }
+    }
+
+    @Test
+    fun otherTransportFailuresPassThroughUnchanged() = runTest {
+        val spy = EndSpy()
+        val refused = java.io.IOException("Connection refused")
+        val client = clientThrowing(spy) { _, _ -> refused }
+
+        val e = assertFailsWith<BasecampException.Network> {
+            client.forAccount("12345").httpClient.requestWithRetry(HttpMethod.Get, signed)
+        }
+
+        assertEquals("Network error: Connection refused", e.message)
+        // Compared by class and message: the coroutine test dispatcher's
+        // stack-trace recovery hands the handler a copy of the thrown instance.
+        val cause = assertIs<java.io.IOException>(e.cause, "a transport diagnostic that renders no URL keeps its class")
+        assertEquals("Connection refused", cause.message)
+        assertSame(cause, spy.errors.single(), "the request-end hook sees the same error the caller does")
+        client.close()
+    }
+
+    @Test
+    fun projectionKeepsPathOnTheTrustedOriginAndOriginOnlyElsewhere() {
+        val onApi = redactTransportError(HttpRequestTimeoutException(signed, 5), signed, "http://localhost:3000", 5)
+        assertEquals("Request timeout has expired [url=http://localhost:3000/12345/blob, request_timeout=5 ms]", onApi.message)
+
+        val elsewhere = redactTransportError(HttpRequestTimeoutException(signed, 5), signed, "https://3.basecampapi.com", 5)
+        assertEquals("Request timeout has expired [url=http://localhost:3000, request_timeout=5 ms]", elsewhere.message)
+
+        val withUserinfo = "http://user:pass@localhost:3000/12345/blob?signature=$secret"
+        val userinfo = redactTransportError(HttpRequestTimeoutException(withUserinfo, null), withUserinfo, "http://localhost:3000")
+        assertEquals("Request timeout has expired [url=http://localhost:3000, request_timeout=unknown ms]", userinfo.message)
+
+        val untrusted = redactTransportError(HttpRequestTimeoutException(signed, null), signed)
+        assertEquals("Request timeout has expired [url=http://localhost:3000, request_timeout=unknown ms]", untrusted.message)
+
+        val unparsable = redactTransportError(HttpRequestTimeoutException("://nope", null), "://nope")
+        assertEquals("Request timeout has expired [url=unparsable, request_timeout=unknown ms]", unparsable.message)
+    }
+}

--- a/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/TransportErrorProjectionTest.kt
+++ b/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/TransportErrorProjectionTest.kt
@@ -87,11 +87,27 @@ class TransportErrorProjectionTest {
             val e = assertFailsWith<BasecampException.Network> {
                 client.forAccount("12345").httpClient.requestWithRetry(HttpMethod.Get, signed)
             }
-            assertTrue(e.message!!.contains("[url=http://localhost:3000/12345/blob]"), e.message)
+            assertTrue(e.message!!.contains("[url=http://localhost:3000/12345/blob, "), e.message)
             assertNoSecret(e, "thrown error")
             assertNoSecret(spy.errors.single(), "RequestResult.error")
             client.close()
         }
+    }
+
+    @Test
+    fun binaryRequestTimeoutRendersNoSignedQuery() = runTest {
+        val spy = EndSpy()
+        val client = clientThrowing(spy) { _, request -> HttpRequestTimeoutException(request) }
+
+        val e = assertFailsWith<BasecampException.Network> {
+            client.forAccount("12345").httpClient.requestBinaryWithRetry(HttpMethod.Put, signed, byteArrayOf(1, 2, 3), "application/octet-stream")
+        }
+
+        assertIs<HttpRequestTimeoutException>(e.cause)
+        assertTrue(e.message!!.startsWith("Network error: Request timeout has expired [url=http://localhost:3000/12345/blob,"), e.message)
+        assertNoSecret(e, "thrown error")
+        assertNoSecret(spy.errors.single(), "RequestResult.error")
+        client.close()
     }
 
     @Test

--- a/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/TransportErrorProjectionTest.kt
+++ b/kotlin/sdk/src/commonTest/kotlin/com/basecamp/sdk/TransportErrorProjectionTest.kt
@@ -144,6 +144,12 @@ class TransportErrorProjectionTest {
         val untrusted = redactTransportError(HttpRequestTimeoutException(signed, null), signed)
         assertEquals("Request timeout has expired [url=http://localhost:3000, request_timeout=unknown ms]", untrusted.message)
 
+        // A connect or socket budget is rendered only when the caller installed one.
+        val connect = redactTransportError(ConnectTimeoutException("x"), signed, "http://localhost:3000", requestTimeoutMillis = 5)
+        assertEquals("Connect timeout has expired [url=http://localhost:3000/12345/blob, connect_timeout=unknown ms]", connect.message)
+        val socket = redactTransportError(SocketTimeoutException("x"), signed, "http://localhost:3000", 5, 7)
+        assertEquals("Socket timeout has expired [url=http://localhost:3000/12345/blob, socket_timeout=7 ms]", socket.message)
+
         val unparsable = redactTransportError(HttpRequestTimeoutException("://nope", null), "://nope")
         assertEquals("Request timeout has expired [url=unparsable, request_timeout=unknown ms]", unparsable.message)
     }

--- a/kotlin/sdk/src/jvmTest/kotlin/com/basecamp/sdk/TransportErrorProjectionJvmTest.kt
+++ b/kotlin/sdk/src/jvmTest/kotlin/com/basecamp/sdk/TransportErrorProjectionJvmTest.kt
@@ -1,0 +1,67 @@
+package com.basecamp.sdk
+
+import io.ktor.client.plugins.HttpRequestTimeoutException
+import io.ktor.http.*
+import kotlinx.coroutines.runBlocking
+import java.net.InetAddress
+import java.net.ServerSocket
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertIs
+import kotlin.test.assertTrue
+import kotlin.time.Duration.Companion.milliseconds
+
+/**
+ * The shipped engine's own timeout, not a mock's: a listener that accepts and
+ * never answers drives the HttpTimeout plugin to throw the exception whose
+ * message renders the request URL. On `main` this fails with the signed query
+ * in the SDK error's message.
+ */
+class TransportErrorProjectionJvmTest {
+    private val secret = "SECRETVALUE"
+
+    private class EndSpy : BasecampHooks {
+        val errors = mutableListOf<Throwable?>()
+        override fun onRequestEnd(info: RequestInfo, result: RequestResult) { errors += result.error }
+    }
+
+    private fun renderings(e: Throwable?, label: String = "error", depth: Int = 0): List<Pair<String, String>> {
+        if (e == null || depth > 8) return emptyList()
+        val own = listOf(
+            "$label.message" to (e.message ?: ""),
+            "$label.toString" to e.toString(),
+            "$label.stackTrace" to e.stackTraceToString(),
+            "$label.hint" to ((e as? BasecampException)?.hint ?: ""),
+        )
+        return own + renderings(e.cause, "$label.cause", depth + 1)
+    }
+
+    @Test
+    fun requestTimeoutThroughTheShippedEngineRendersNoSignedQuery() = runBlocking {
+        ServerSocket(0, 1, InetAddress.getByName("127.0.0.1")).use { silent ->
+            val base = "http://127.0.0.1:${silent.localPort}"
+            val spy = EndSpy()
+            val client = BasecampClient {
+                accessToken("test-token")
+                baseUrl = base
+                timeout = 300.milliseconds
+                enableRetry = false
+                hooks = spy
+            }
+
+            val e = assertFailsWith<BasecampException.Network> {
+                client.forAccount("12345").httpClient.requestWithRetry(HttpMethod.Get, "$base/12345/blob?signature=$secret")
+            }
+            client.close()
+
+            assertIs<HttpRequestTimeoutException>(e.cause)
+            assertEquals("Network error: Request timeout has expired [url=$base/12345/blob, request_timeout=300 ms]", e.message)
+            for ((label, text) in renderings(e) + renderings(spy.errors.single(), "RequestResult.error")) {
+                assertFalse(text.contains(secret), "the signed query leaked into $label: $text")
+            }
+            assertTrue(spy.errors.single() is HttpRequestTimeoutException)
+        }
+    }
+}


### PR DESCRIPTION
The Kotlin side of [#869](https://github.com/basecamp/basecamp-sdk/pull/869) (Rust) and [#871](https://github.com/basecamp/basecamp-sdk/pull/871) (Swift).

**The leak.** Ktor's timeout exceptions render the request URL in their message — `HttpRequestTimeoutException`: `Request timeout has expired [url=…, request_timeout=… ms]`, and the engine-built `ConnectTimeoutException` and `SocketTimeoutException` likewise. `BasecampHttpClient` built its `Network` error as `"Network error: ${e.message}"` with the raw exception chained, and handed the raw exception to `RequestResult.error`, so a timeout on a request whose query is signed put the signature into the SDK error's `message`, `toString()`, `stackTraceToString()`, cause chain and the request-end hook: everywhere the error gets logged. The download flow's hop 1 was already projected (#837); the generic request path beneath it, and the OAuth discovery, device and token-exchange paths, were not.

**The fix.** One helper, `redactTransportError` in `TransportErrors.kt`, with `displayUrl` (moved there from `Download.kt`, where hop 1's hooks already used it) and `displayOrigin` beside it. A Ktor timeout exception is rebuilt from parts this SDK chooses: the same class, so a caller — and the device flow's own `isConnectionTimeout` — classifies it as before, and the URL the SDK issued (a redirect's target is the transport's business and is not rendered) projected to origin and path when it sits on the configured base URL without userinfo, and to the origin alone anywhere else, because a storage service can sign the path as readily as the query (SPEC §9's "projection, not redaction"; the same trusted-origin rule the Go SDKs use). Every other exception is the transport's own diagnostic — a JVM socket failure names host and port at most — and passes through unchanged, cause chain included. The budget rendered beside the projected URL is the one the SDK itself installed (`configureClient`, or the OAuth clients' own constants); for a caller-supplied `HttpClient` none is claimed, since the number in the transport's own message is text it wrote and is not read. Sites: both transport catches in `BasecampHttpClient` (`requestWithRetry`, `requestBinaryWithRetry`), projected once before the request-end hook so hooks and the caller see the same shape; and the OAuth transport catches in `Discovery.kt`, `Device.kt` (authorization request and token poll) and `Exchange.kt`, whose endpoints are a discovered issuer's and render as origin only.

**The test.** `TransportErrorProjectionJvmTest` drives the shipped CIO engine's own `HttpTimeout` against a listener that accepts and never answers, with `?signature=SECRETVALUE` on the request, and asserts `SECRETVALUE` is absent from `message`, `toString()`, `stackTraceToString()`, `hint`, every link of the cause chain and `RequestResult.error`; that the cause is still an `HttpRequestTimeoutException`; and that the message keeps `http://127.0.0.1:<port>/12345/blob` and the configured budget. `TransportErrorProjectionTest` covers the same site, and the binary request path, through `MockEngine` for all three Ktor timeout shapes, a `Connection refused` passing through by class and message, and the trusted-origin, foreign-origin, userinfo and unparsable projections. On `main` the engine test fails with:

```
expected: <Network error: Request timeout has expired [url=http://127.0.0.1:60465/12345/blob, request_timeout=300 ms]> but was: <Network error: Request timeout has expired [url=http://127.0.0.1:60465/12345/blob?signature=SECRETVALUE, request_timeout=300 ms]>
```

Gates run locally: `./gradlew :basecamp-sdk:check`, `./gradlew :conformance:run`.

**Review rounds.** Copilot and Codex found the budget rendered for a caller-supplied `HttpClient` (now omitted), the device flow's dropped budgets (now passed), and the request budget rendered on a connect/socket timeout by the OAuth wrappers, which install only a request timeout (the helper now takes the two budgets separately); all fixed and tested.

Watching the review loop on this one through to convergence.
