### PR TITLE
Compile the CodeQL Kotlin build with the newest Kotlin CodeQL supports

### DIFF
--- a/.github/codeql/kotlin-version.init.gradle.kts
+++ b/.github/codeql/kotlin-version.init.gradle.kts
@@ -1,0 +1,27 @@
+// Gradle init script for the CodeQL job's Kotlin build only.
+//
+// CodeQL's Kotlin extractor refuses a compiler newer than the bundle it ships
+// with ("Kotlin version 2.4.20 is too recent. CodeQL currently supports
+// versions below 2.4.20"), and dependabot moves the version catalog to each
+// Kotlin release days before a CodeQL release supports it. This overrides the
+// catalog's `kotlin` version -- which the Kotlin Gradle plugins, and with them
+// the compiler and the stdlib the plugin adds, are resolved from -- to the
+// newest version CodeQL supports, for this build alone. The repository's own
+// build, tests and releases keep the catalog's version.
+//
+// The catalog is overridden rather than the plugin requests because the root
+// project requests the plugins with `apply false` and the modules request them
+// again through the same aliases; Gradle insists both requests carry the same
+// version, so the version has to change where both read it.
+//
+// Bump the pin when CodeQL supports a newer Kotlin and the sources need it;
+// until then a lower compiler analysing the same sources is the point.
+val codeqlKotlinVersion = "2.4.10"
+
+// By the time settings are evaluated Gradle has already imported the
+// conventional gradle/libs.versions.toml as `libs`, so the catalog is looked up
+// rather than created (a second `from` is an error) and one version replaced.
+settingsEvaluated {
+    dependencyResolutionManagement.versionCatalogs.maybeCreate("libs")
+        .version("kotlin", codeqlKotlinVersion)
+}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -167,10 +167,14 @@ jobs:
       # restores it, and an UP-TO-DATE compile emits nothing (empty database).
       # Scoped to :basecamp-sdk — :generator is in neither codeql-config.yml's
       # paths-ignore nor the SARIF filter, so building it would leak alerts.
+      # The init script compiles with the newest Kotlin CodeQL supports rather
+      # than the catalog's: the extractor refuses a newer compiler outright
+      # ("Kotlin version 2.4.20 is too recent"), and dependabot reaches each
+      # Kotlin release before CodeQL does.
       - name: Build (Kotlin)
         if: matrix.language == 'java-kotlin'
         working-directory: kotlin
-        run: ./gradlew --no-build-cache clean :basecamp-sdk:compileKotlinJvm
+        run: ./gradlew --init-script ../.github/codeql/kotlin-version.init.gradle.kts --no-build-cache clean :basecamp-sdk:compileKotlinJvm
 
       # --- Analysis (fails build on real errors) ---
 


### PR DESCRIPTION
## Problem

`Analyze (java-kotlin)` in `codeql.yml` has failed on every push to `main` since #866 landed (13:08Z) and on every open PR since. Last green run: 34478917881 on `9159204` (12:49Z). The failing step is Build (Kotlin), e.g. run 34534026664 / job 103061351467:

```
> Task :basecamp-sdk:compileKotlinJvm FAILED
* What went wrong:
   > Kotlin version 2.4.20 is too recent. CodeQL currently supports versions below 2.4.20
BUILD FAILED in 39s
```

(the later `Path does not exist: sarif-results` is just the upload step running after the build died.)

#866 moved the version catalog to Kotlin 2.4.20, released 2026-09-07. CodeQL CLI 2.27.0, released 2026-09-09 and the bundle the runner used, still caps below it; codeql-action v4.38.0 only moves its default to that same CLI. The check is in the closed-source Java extractor with no override. Upstream `java/kotlin-extractor/versions.bzl` on CodeQL `main` already lists 2.4.20, so the next CLI release will accept it. The Test workflow's Kotlin job passes on the same commits because it has no extractor in the loop: it is CodeQL's compiler cap, not a JDK or `clean` problem.

## Fix

Rather than revert a dependency bump to wait on CodeQL's release lag, the CodeQL job's build alone compiles with the newest Kotlin CodeQL supports:

- `.github/codeql/kotlin-version.init.gradle.kts` — a Gradle init script that resolves the `org.jetbrains.kotlin.*` plugins (and so the compiler and the stdlib the plugin adds) at 2.4.10, the compiler that built `main` until yesterday.
- `codeql.yml` Build (Kotlin) passes it with `--init-script`.

The repository's own build, tests and releases keep the catalog's version; the same sources are extracted with a compiler the extractor accepts. When a CodeQL bundle with 2.4.20 support ships, the pin is unnecessary but harmless; bump it when the sources need a newer compiler.

fizzy-sdk's new CodeQL workflow is on Kotlin 2.4.10 and its latest `main` run is green; it will hit the same wall when dependabot bumps it, unless CodeQL ships first.

## Verification

- actionlint, zizmor 1.30.0 (`--persona regular`) and pre-commit hooks clean on the workflow.
- The pinned build run on a Temurin 17 host (see comment below) and the `Analyze (java-kotlin)` job on this PR.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the CodeQL job's Kotlin build, which fails because the version catalog moved to Kotlin 2.4.20 while CodeQL's extractor only supports versions below 2.4.20.

- Adds a Gradle init script that resolves the `org.jetbrains.kotlin.*` plugins at 2.4.10, the newest Kotlin CodeQL supports, for the CodeQL job's build only.
- Passes the init script to the Build (Kotlin) step; the repository's own build, tests, and releases keep the catalog's 2.4.20.
- The same sources are analyzed with a compiler the extractor accepts; once a CodeQL release supports 2.4.20, the pin is unnecessary but harmless.

<sup>Written for commit ee82466eb2233b5024f80b2ae120d8a4a34c3c7f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-sdk/pull/875?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

