### PR TITLE
Fail the npm already-published check closed

### DIFF
--- a/.github/workflows/release-typescript.yml
+++ b/.github/workflows/release-typescript.yml
@@ -208,11 +208,23 @@ jobs:
         env:
           VERSION: ${{ needs.build.outputs.version }}
         run: |
-          if npm view "@37signals/basecamp@${VERSION}" version 2>/dev/null; then
-            echo "already_published=true" >> $GITHUB_OUTPUT
+          # Publish only when the registry positively says the version is absent
+          # (E404). Any other failure — network, auth, registry outage — stops the
+          # job rather than guessing; a re-run of this run is the recovery. An empty
+          # cache keeps npm from answering from a stale packument when the fetch fails.
+          set +e
+          output=$(npm view --cache "$RUNNER_TEMP/npm-view-cache" "@37signals/basecamp@${VERSION}" version 2>&1)
+          status=$?
+          set -e
+          if [ "$status" -eq 0 ] && [ -n "$output" ]; then
+            echo "already_published=true" >> "$GITHUB_OUTPUT"
             echo "::notice::Version ${VERSION} already published to npm"
+          elif echo "$output" | grep -q "E404"; then
+            echo "already_published=false" >> "$GITHUB_OUTPUT"
           else
-            echo "already_published=false" >> $GITHUB_OUTPUT
+            echo "$output"
+            echo "::error::Could not determine whether @37signals/basecamp@${VERSION} is on npm (npm view exit $status); not publishing blind"
+            exit 1
           fi
 
       - name: Publish to npm


### PR DESCRIPTION
Ports the seed template fix from basecamp/sdk#12 into this repo's own copy of `release-typescript.yml`.

The publish job decided whether to publish with `if npm view "@37signals/basecamp@${VERSION}" version 2>/dev/null`. `npm view` exits non-zero for an absent version (`E404`), but also for a DNS failure, an auth error, a registry 5xx or a timeout, so every one of those read as "not published" and the job went on to `npm publish`. npm refuses to overwrite an existing version, so the realistic damage was a confusing failure at the wrong step rather than a duplicate publish, but the shape is wrong.

Now: publish only when npm positively answers `E404`; a `0` exit with a version string is "already published" (skip); anything else prints npm's output, fails the job, and leaves a re-run of the same tag run as the recovery. An empty `--cache` keeps npm from answering from a stale packument when the fetch fails. Only the check step changes; the rest of the workflow (the split build/publish jobs, artifact hand-off, `needs.build.outputs.version`) is untouched.

## Verified

- The step body, extracted from this file and run against the live registry on npm 11.19: `0.18.0` → `already_published=true`; `99.99.99` → `E404`, `already_published=false`; registry unreachable (`ECONNREFUSED`) → `::error`, exit 1, no output written.
- `actionlint` 1.7.12, `zizmor` 1.30.0 (`--persona regular`) and `make lint-actions`: clean.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the npm already-published check in `release-typescript.yml` so the publish job only publishes when npm positively reports the version is absent (E404), instead of treating any non-zero `npm view` exit — DNS failure, auth error, registry 5xx, timeout — as "not published" and attempting a publish that then fails at the publish step.

The check now treats a 0 exit with a version string as "already published" and skips; any other error prints npm's output, fails the job, and re-running the same tag is the recovery. An empty `--cache` keeps npm from answering from a stale packument when the fetch fails. Only the check step changes; the split build/publish jobs and artifact hand-off are untouched.

<sup>Written for commit 24ea43e6f4e5935b9ba22735ac3feb439737188b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/basecamp/basecamp-sdk/pull/876?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

